### PR TITLE
P/santoch/cr/exceptions

### DIFF
--- a/src/main/java/com/adobe/epubcheck/api/EpubCheck.java
+++ b/src/main/java/com/adobe/epubcheck/api/EpubCheck.java
@@ -149,7 +149,7 @@ public class EpubCheck implements DocumentValidator
         {
           inputStream.close();
         }
-        catch (IOException ignore)
+        catch (IOException ignored)
         {
         }
       }
@@ -160,7 +160,7 @@ public class EpubCheck implements DocumentValidator
           out.flush();
           out.close();
         }
-        catch (IOException ignore)
+        catch (IOException ignored)
         {
         }
       }

--- a/src/main/java/com/adobe/epubcheck/bitmap/BitmapChecker.java
+++ b/src/main/java/com/adobe/epubcheck/bitmap/BitmapChecker.java
@@ -36,7 +36,10 @@ import javax.imageio.ImageReader;
 import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.stream.FileImageInputStream;
 import javax.imageio.stream.ImageInputStream;
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Iterator;
 
 public class BitmapChecker implements ContentChecker
@@ -134,12 +137,12 @@ public class BitmapChecker implements ContentChecker
       }
       catch (IOException e)
       {
-        report.message(MessageId.PKG_021, new MessageLocation(ocf.getName(), -1, -1, imgFileName));
+        report.message(MessageId.PKG_021, new MessageLocation(imgFileName, -1, -1, imgFileName));
         return null;
       }
       catch (IllegalArgumentException argex)
       {
-        report.message(MessageId.PKG_021, new MessageLocation(ocf.getName(), -1, -1, imgFileName));
+        report.message(MessageId.PKG_021, new MessageLocation(imgFileName, -1, -1, imgFileName));
         return null;
       }
       finally
@@ -248,7 +251,7 @@ public class BitmapChecker implements ContentChecker
     }
     catch (IOException ex)
     {
-      report.message(MessageId.PKG_008, new MessageLocation(imageFileName, -1, -1, imageFileName), imageFileName);
+      report.message(MessageId.PKG_021, new MessageLocation(imageFileName, -1, -1, imageFileName) );
     }
   }
 
@@ -286,7 +289,7 @@ public class BitmapChecker implements ContentChecker
       }
       catch (IOException e)
       {
-        report.message(MessageId.RSC_005, new MessageLocation(this.ocf.getName(), 0, 0), path);
+        report.message(MessageId.PKG_021, new MessageLocation(path, 0, 0, path));
       }
       finally
       {

--- a/src/main/java/com/adobe/epubcheck/ctc/DictionarySearch.java
+++ b/src/main/java/com/adobe/epubcheck/ctc/DictionarySearch.java
@@ -8,6 +8,7 @@ import com.adobe.epubcheck.util.SearchDictionary;
 import com.adobe.epubcheck.util.TextSearchDictionaryEntry;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Hashtable;
@@ -90,11 +91,15 @@ class DictionarySearch
         lineCounter++;
       }
     }
-
-    catch (IOException e1)
+    catch (FileNotFoundException e1)
     {
       String fileName = new File(zip.getName()).getName();
       report.message(MessageId.RSC_001, new MessageLocation(fileName, -1, -1), entry);
+    }
+    catch (IOException e1)
+    {
+      String fileName = new File(zip.getName()).getName();
+      report.message(MessageId.PKG_008, new MessageLocation(fileName, -1, -1), entry);
     }
     catch (Exception e)
     {
@@ -109,7 +114,7 @@ class DictionarySearch
         {
           is.close();
         }
-        catch (Exception ignore)
+        catch (Exception ignored)
         {
         }
       }

--- a/src/main/java/com/adobe/epubcheck/ctc/EpubHTML5StructureCheck.java
+++ b/src/main/java/com/adobe/epubcheck/ctc/EpubHTML5StructureCheck.java
@@ -259,10 +259,6 @@ public class EpubHTML5StructureCheck implements DocumentValidator
       matchingPatterns |= checkPattern(line, patternW3CElement, hasW3C);
       matchingPatterns |= checkPattern(line, patternXhtmlElement, hasXhtml);
     }
-    catch (IOException e1)
-    {
-      report.message(MessageId.RSC_005, new MessageLocation(entry, -1, -1), e1.getMessage());
-    }
     catch (Exception e)
     {
       e.printStackTrace();

--- a/src/main/java/com/adobe/epubcheck/ctc/EpubScriptCheck.java
+++ b/src/main/java/com/adobe/epubcheck/ctc/EpubScriptCheck.java
@@ -13,10 +13,7 @@ import com.adobe.epubcheck.util.FeatureEnum;
 import com.adobe.epubcheck.util.SearchDictionary;
 import com.adobe.epubcheck.util.SearchDictionary.DictionaryType;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.util.regex.Matcher;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -93,7 +90,7 @@ public class EpubScriptCheck implements DocumentValidator
       ZipEntry entry = this.zip.getEntry(fileToParse);
       if (entry == null)
       {
-        report.message(MessageId.RSC_001, new MessageLocation(fileToParse, -1, -1));
+        report.message(MessageId.RSC_001, new MessageLocation(fileToParse, -1, -1), fileToParse);
         return;
       }
       report.info(fileToParse, FeatureEnum.SCRIPT, "javascript");
@@ -122,9 +119,13 @@ public class EpubScriptCheck implements DocumentValidator
         reader.close();
         is.close();
       }
+      catch (FileNotFoundException ex)
+      {
+        report.message(MessageId.RSC_001, new MessageLocation(fileToParse, -1, -1), fileToParse);
+      }
       catch (IOException ex)
       {
-        report.message(MessageId.RSC_001, new MessageLocation(fileToParse, -1, -1));
+        report.message(MessageId.PKG_008, new MessageLocation(fileToParse, -1, -1), fileToParse);
       }
       finally
       {
@@ -134,7 +135,7 @@ public class EpubScriptCheck implements DocumentValidator
           {
             reader.close();
           }
-          catch (IOException e)
+          catch (IOException ignored)
           {
           }
         }
@@ -144,7 +145,7 @@ public class EpubScriptCheck implements DocumentValidator
           {
             is.close();
           }
-          catch (IOException e)
+          catch (IOException ignored)
           {
           }
         }

--- a/src/main/java/com/adobe/epubcheck/ctc/XmlDocParser.java
+++ b/src/main/java/com/adobe/epubcheck/ctc/XmlDocParser.java
@@ -56,7 +56,7 @@ class XmlDocParser
     }
     catch (IOException e)
     {
-      report.message(MessageId.PKG_008, new MessageLocation(fileEntry, -1, -1), e.getMessage());
+      report.message(MessageId.PKG_008, new MessageLocation(fileEntry, -1, -1), fileEntry);
     }
     catch (SAXException e)
     {

--- a/src/main/java/com/adobe/epubcheck/ctc/xml/XMLContentDocParser.java
+++ b/src/main/java/com/adobe/epubcheck/ctc/xml/XMLContentDocParser.java
@@ -68,7 +68,7 @@ public class XMLContentDocParser
     }
     catch (IOException e)
     {
-      report.message(MessageId.RSC_005, new MessageLocation(fileEntry, -1, -1), e.getMessage());
+      report.message(MessageId.PKG_008, new MessageLocation(fileEntry, -1, -1), fileEntry);
     }
     catch (SAXException e)
     {

--- a/src/main/java/com/adobe/epubcheck/nav/NavChecker.java
+++ b/src/main/java/com/adobe/epubcheck/nav/NavChecker.java
@@ -109,6 +109,7 @@ public class NavChecker implements ContentChecker, DocumentValidator
 
   public boolean validate()
   {
+    int fatalErrors = report.getFatalErrorCount();
     int errors = report.getErrorCount();
     int warnings = report.getWarningCount();
     InputStream in = null;
@@ -128,7 +129,7 @@ public class NavChecker implements ContentChecker, DocumentValidator
     }
     catch (IOException e)
     {
-      report.message(MessageId.RSC_005, new MessageLocation(path, -1, -1), e.getMessage());
+      report.message(MessageId.PKG_008, new MessageLocation(path, -1, -1), path);
     }
     finally
     {
@@ -139,12 +140,12 @@ public class NavChecker implements ContentChecker, DocumentValidator
           in.close();
         }
       }
-      catch (IOException e)
+      catch (IOException ignored)
       {
         // eat it
       }
     }
 
-    return ((errors == report.getErrorCount()) && (warnings == report.getWarningCount()));
+    return ((fatalErrors == report.getFatalErrorCount()) && (errors == report.getErrorCount()) && (warnings == report.getWarningCount()));
   }
 }

--- a/src/main/java/com/adobe/epubcheck/ncx/NCXChecker.java
+++ b/src/main/java/com/adobe/epubcheck/ncx/NCXChecker.java
@@ -116,7 +116,7 @@ public class NCXChecker implements ContentChecker
         {
           in.close();
         }
-        catch (IOException e)
+        catch (IOException ignored)
         {
           // eat it
         }

--- a/src/main/java/com/adobe/epubcheck/ocf/OCFChecker.java
+++ b/src/main/java/com/adobe/epubcheck/ocf/OCFChecker.java
@@ -154,7 +154,7 @@ public class OCFChecker
       getReport().message(MessageId.OPF_001, new MessageLocation(opfPaths.get(0), -1, -1), e.getMessage());
       return;
     }
-    catch (IOException e1)
+    catch (IOException ignored)
     {
       // missing file will be reported later
     }
@@ -195,7 +195,7 @@ public class OCFChecker
         getReport().info(null, FeatureEnum.FORMAT_NAME, sb.toString().trim());
       }
     }
-    catch (IOException e)
+    catch (IOException ignored)
     {
       // missing file will be reported later
     }
@@ -208,7 +208,7 @@ public class OCFChecker
           mimetype.close();
         }
       }
-      catch (IOException e)
+      catch (IOException ignored)
       {
         // eat it
       }
@@ -321,7 +321,7 @@ public class OCFChecker
           in = null;
         }
       }
-      catch (IOException e)
+      catch (IOException ignored)
       {
         // eat it
       }
@@ -343,7 +343,7 @@ public class OCFChecker
             in = null;
           }
         }
-        catch (IOException e)
+        catch (IOException ignored)
         {
           // eat it
         }

--- a/src/main/java/com/adobe/epubcheck/ocf/OCFZipPackage.java
+++ b/src/main/java/com/adobe/epubcheck/ocf/OCFZipPackage.java
@@ -189,7 +189,7 @@ public class OCFZipPackage extends OCFPackage
       }
       catch (IOException e)
       {
-        report.message(MessageId.PKG_008, new MessageLocation(fileName, -1, -1), e.getMessage());
+        report.message(MessageId.PKG_008, new MessageLocation(fileName, -1, -1), fileName);
       }
       finally
       {

--- a/src/main/java/com/adobe/epubcheck/opf/OPFChecker.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFChecker.java
@@ -196,6 +196,7 @@ public class OPFChecker implements DocumentValidator
   @Override
   public boolean validate()
   {
+    int fatalErrorsSoFar = report.getFatalErrorCount();
     int errorsSoFar = report.getErrorCount();
     int warningsSoFar = report.getWarningCount();
 
@@ -216,7 +217,7 @@ public class OPFChecker implements DocumentValidator
     }
     catch (IOException e)
     {
-      report.message(MessageId.PKG_008, new MessageLocation(path, 0, 0), e.getMessage());
+      report.message(MessageId.PKG_008, new MessageLocation(path, 0, 0), path);
     }
     finally
     {
@@ -289,7 +290,8 @@ public class OPFChecker implements DocumentValidator
       }
     }
 
-    return errorsSoFar == report.getErrorCount()
+    return fatalErrorsSoFar == report.getFatalErrorCount()
+        && errorsSoFar == report.getErrorCount()
         && warningsSoFar == report.getWarningCount();
   }
 

--- a/src/main/java/com/adobe/epubcheck/opf/VersionRetriever.java
+++ b/src/main/java/com/adobe/epubcheck/opf/VersionRetriever.java
@@ -110,7 +110,7 @@ public class VersionRetriever implements EntityResolver, ErrorHandler
     }
     catch (IOException e)
     {
-      report.message(MessageId.PKG_008, new MessageLocation(path, -1, -1), e.getMessage());
+      report.message(MessageId.PKG_008, new MessageLocation(path, -1, -1), path);
     }
     throw new InvalidVersionException(InvalidVersionException.VERSION_NOT_FOUND);
   }

--- a/src/main/java/com/adobe/epubcheck/ops/OPSChecker.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSChecker.java
@@ -157,6 +157,7 @@ public class OPSChecker implements ContentChecker, DocumentValidator
   {
     XMLValidator rngValidator = null;
     XMLValidator schValidator = null;
+    int fatalErrorsSoFar = report.getFatalErrorCount();
     int errorsSoFar = report.getErrorCount();
     int warningsSoFar = report.getWarningCount();
     OPSType type = new OPSType(mimeType, version);
@@ -173,9 +174,10 @@ public class OPSChecker implements ContentChecker, DocumentValidator
     }
     catch (IOException e)
     {
-      report.message(MessageId.PKG_008, new MessageLocation(path, 0, 0), e.getMessage());
+      report.message(MessageId.PKG_008, new MessageLocation(path, 0, 0), path);
     }
-    return errorsSoFar == report.getErrorCount()
+    return fatalErrorsSoFar == report.getFatalErrorCount()
+        && errorsSoFar == report.getErrorCount()
         && warningsSoFar == report.getWarningCount();
   }
 

--- a/src/main/java/com/adobe/epubcheck/overlay/OverlayChecker.java
+++ b/src/main/java/com/adobe/epubcheck/overlay/OverlayChecker.java
@@ -96,6 +96,7 @@ public class OverlayChecker implements ContentChecker, DocumentValidator
 
   public boolean validate()
   {
+    int fatalErrorsSoFar = report.getFatalErrorCount();
     int errorsSoFar = report.getErrorCount();
     int warningsSoFar = report.getWarningCount();
     InputStream in = null;
@@ -126,13 +127,13 @@ public class OverlayChecker implements ContentChecker, DocumentValidator
           in.close();
         }
       }
-      catch (Exception ignore)
+      catch (Exception ignored)
       {
-
       }
     }
 
-    return errorsSoFar == report.getErrorCount()
+    return fatalErrorsSoFar == report.getFatalErrorCount()
+        && errorsSoFar == report.getErrorCount()
         && warningsSoFar == report.getWarningCount();
   }
 }

--- a/src/main/java/com/adobe/epubcheck/util/Archive.java
+++ b/src/main/java/com/adobe/epubcheck/util/Archive.java
@@ -157,7 +157,7 @@ public class Archive
     {
       return f.getCanonicalFile();
     }
-    catch (IOException e)
+    catch (IOException ignored)
     {
       return f.getAbsoluteFile();
     }

--- a/src/test/java/com/adobe/epubcheck/test/single_file_Test.java
+++ b/src/test/java/com/adobe/epubcheck/test/single_file_Test.java
@@ -44,7 +44,7 @@ public class single_file_Test
     //This is why we are examining the command line rather than comparing json files.
     String actualErr = errContent.toString();
     Assert.assertTrue("Missing errors message", actualErr.contains(Messages.THERE_WERE_ERRORS));
-    Assert.assertTrue("Missing message", actualErr.contains("Error while parsing file"));
+    Assert.assertTrue("Missing message", actualErr.contains("PKG-008"));
     System.setOut(originalOut);
     System.setErr(originalErr);
     outContent.close();

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/listSeverities_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/listSeverities_expected_results.txt
@@ -170,7 +170,7 @@ PKG-016	WARNING	Use only lowercase characters for the ePub file extension for ma
 PKG-017	WARNING	Uncommon ePub file extension.	For maximum compatibility, use '.epub'.
 PKG-018	FATAL	The ePub file is not found.	
 PKG-020	ERROR	OPF file '%1$s' is not found.	
-PKG-021	ERROR	Corrupted image file encountered.	
+PKG-021	ERROR	Corrupted image file encountered.
 RSC-001	ERROR	File '%1$s' is not found.	
 RSC-002	FATAL	Required META-INF/container.xml resource is not found.	
 RSC-003	ERROR	No rootfile tag with media type 'application/oebps-package+xml' was found in the container.	

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Mismatched_mimetypes_epub2_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Mismatched_mimetypes_epub2_expected_results.json
@@ -3,11 +3,11 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/opf/Mismatched_mimetypes_epub2.epub",
     "filename" : "Mismatched_mimetypes_epub2.epub",
-    "checkerVersion" : "3.0.37-SNAPSHOT",
-    "checkDate" : "01-09-2014 11:46:58",
-    "elapsedTime" : 0,
-    "nFatal" : 1,
-    "nError" : 4,
+    "checkerVersion" : "${pom.version}",
+    "checkDate" : "06-02-2014 14:58:13",
+    "elapsedTime" : 71,
+    "nFatal" : 0,
+    "nError" : 5,
     "nWarning" : 2,
     "nUsage" : 1
   },
@@ -350,9 +350,9 @@
     } ],
     "suggestion" : "Every spine item in the manifest should be referenced by at least one NAV entry."
   }, {
-    "ID" : "PKG-008",
-    "severity" : "FATAL",
-    "message" : "Unable to read file 'OPS/blank'.",
+    "ID" : "PKG-021",
+    "severity" : "ERROR",
+    "message" : "Corrupted image file encountered.",
     "additionalLocations" : 0,
     "locations" : [ {
       "fileName" : "OPS/blank",

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Mismatched_mimetypes_epub3_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Mismatched_mimetypes_epub3_expected_results.json
@@ -3,11 +3,11 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/opf/Mismatched_mimetypes_epub3.epub",
     "filename" : "Mismatched_mimetypes_epub3.epub",
-    "checkerVersion" : "3.0.37-SNAPSHOT",
-    "checkDate" : "01-09-2014 11:46:58",
-    "elapsedTime" : 0,
-    "nFatal" : 1,
-    "nError" : 5,
+    "checkerVersion" : "${pom.version}",
+    "checkDate" : "06-02-2014 14:58:10",
+    "elapsedTime" : 2567,
+    "nFatal" : 0,
+    "nError" : 6,
     "nWarning" : 2,
     "nUsage" : 3
   },
@@ -374,9 +374,9 @@
     } ],
     "suggestion" : "Every spine item in the manifest should be referenced by at least one TOC entry."
   }, {
-    "ID" : "PKG-008",
-    "severity" : "FATAL",
-    "message" : "Unable to read file 'OPS/blank'.",
+    "ID" : "PKG-021",
+    "severity" : "ERROR",
+    "message" : "Corrupted image file encountered.",
     "additionalLocations" : 0,
     "locations" : [ {
       "fileName" : "OPS/blank",

--- a/src/test/resources/com/adobe/epubcheck/test/package/image_types_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/package/image_types_expected_results.json
@@ -3,9 +3,9 @@
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/package/image_types.epub",
     "filename" : "image_types.epub",
-    "checkerVersion" : "3.0.37-SNAPSHOT",
-    "checkDate" : "01-09-2014 11:47:00",
-    "elapsedTime" : 0,
+    "checkerVersion" : "4.0.0-alpha5-SNAPSHOT",
+    "checkDate" : "06-02-2014 15:02:30",
+    "elapsedTime" : 333,
     "nFatal" : 0,
     "nError" : 1,
     "nWarning" : 2,
@@ -336,7 +336,7 @@
     "message" : "Corrupted image file encountered.",
     "additionalLocations" : 0,
     "locations" : [ {
-      "fileName" : "image_types.epub",
+      "fileName" : "OPS/images/PlaceHolder.png",
       "line" : -1,
       "column" : -1,
       "context" : "OPS/images/PlaceHolder.png"


### PR DESCRIPTION
@apond 
Make IOException handling more uniform. Throw PKG_008 when the file can't be opened and PKG_021 if an image fails to open.  Also, throw RSC_001 on file not found exceptions.
Finally, make all ignored exception catch blocks use the identifier "ignored" uniformly.
