### PR TITLE
P/santoch/cr/nchk2708

### DIFF
--- a/src/main/java/com/adobe/epubcheck/opf/OPFHandler30.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFHandler30.java
@@ -37,7 +37,7 @@ import java.util.Set;
 public class OPFHandler30 extends OPFHandler
 {
   private final HashSet<String> prefixSet;
-  private boolean reportedUnsupportedXMLVersion;
+  private boolean checkedUnsupportedXmlVersion = false;
 
   private static final String[] predefinedPrefixes = {"dcterms", "marc", "media", "onix", "xsd"};
 
@@ -114,16 +114,18 @@ public class OPFHandler30 extends OPFHandler
   {
     super(path, report, xrefChecker, parser, version);
     prefixSet = new HashSet<String>();
-    reportedUnsupportedXMLVersion = false;
+    checkedUnsupportedXmlVersion = false;
     Collections.addAll(prefixSet, predefinedPrefixes);
   }
 
   public void startElement()
   {
     super.startElement();
-    if (!reportedUnsupportedXMLVersion)
+
+    if (!checkedUnsupportedXmlVersion)
     {
-      reportedUnsupportedXMLVersion = HandlerUtil.checkXMLVersion(parser);
+      HandlerUtil.checkXMLVersion(parser);
+      checkedUnsupportedXmlVersion = true;
     }
     XMLElement e = parser.getCurrentElement();
     String name = e.getName();

--- a/src/main/java/com/adobe/epubcheck/ops/OPSHandler.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSHandler.java
@@ -42,6 +42,7 @@ import java.util.Stack;
 
 public class OPSHandler implements XMLHandler
 {
+
   class ElementLocation
   {
     int lineNumber;
@@ -87,6 +88,7 @@ public class OPSHandler implements XMLHandler
   boolean hasThead = false;
   boolean hasCaption = false;
   boolean epubTypeInUse = false;
+  boolean checkedUnsupportedXMLVersion = false;
   StringBuilder textNode;
   Stack<ElementLocation> elementLocationStack = new Stack<ElementLocation>();
 
@@ -248,6 +250,12 @@ public class OPSHandler implements XMLHandler
     XMLElement e = parser.getCurrentElement();
     ElementLocation currentLocation = new ElementLocation(parser.getLineNumber(), parser.getColumnNumber());
     elementLocationStack.push(currentLocation);
+
+    if (!checkedUnsupportedXMLVersion)
+    {
+      HandlerUtil.checkXMLVersion(parser);
+      checkedUnsupportedXMLVersion = true;
+    }
 
     String id = e.getAttribute("id");
 

--- a/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
@@ -40,8 +40,6 @@ public class OPSHandler30 extends OPSHandler
 
   static final HashSet<String> linkClassSet;
 
-  boolean reportedUnsupportedXMLVersion;
-
   static
   {
     HashSet<String> set = new HashSet<String>();
@@ -121,7 +119,7 @@ public class OPSHandler30 extends OPSHandler
     this.properties = properties;
     prefixSet = new HashSet<String>();
     propertiesSet = new HashSet<String>();
-    reportedUnsupportedXMLVersion = false;
+    checkedUnsupportedXMLVersion = false;
   }
 
 
@@ -170,11 +168,6 @@ public class OPSHandler30 extends OPSHandler
   public void startElement()
   {
     super.startElement();
-
-    if (!reportedUnsupportedXMLVersion)
-    {
-      reportedUnsupportedXMLVersion = HandlerUtil.checkXMLVersion(parser);
-    }
 
     XMLElement e = parser.getCurrentElement();
     String name = e.getName();

--- a/src/main/java/com/adobe/epubcheck/overlay/OverlayHandler.java
+++ b/src/main/java/com/adobe/epubcheck/overlay/OverlayHandler.java
@@ -25,7 +25,7 @@ public class OverlayHandler implements XMLHandler
 
   private final XMLParser parser;
 
-  private boolean reportedUnsupportedXMLVersion;
+  private boolean checkedUnsupportedXMLVersion;
 
   public OverlayHandler(String path, XRefChecker xrefChecker,
       XMLParser parser, Report report)
@@ -35,14 +35,15 @@ public class OverlayHandler implements XMLHandler
     this.report = report;
     this.parser = parser;
     prefixSet = new HashSet<String>();
-    reportedUnsupportedXMLVersion = false;
+    checkedUnsupportedXMLVersion = false;
   }
 
   public void startElement()
   {
-    if (!reportedUnsupportedXMLVersion)
+    if (!checkedUnsupportedXMLVersion)
     {
-      reportedUnsupportedXMLVersion = HandlerUtil.checkXMLVersion(parser);
+      HandlerUtil.checkXMLVersion(parser);
+      checkedUnsupportedXMLVersion = true;
     }
 
     XMLElement e = parser.getCurrentElement();

--- a/src/main/java/com/adobe/epubcheck/util/HandlerUtil.java
+++ b/src/main/java/com/adobe/epubcheck/util/HandlerUtil.java
@@ -59,7 +59,7 @@ public class HandlerUtil
 
   }
 
-  public static boolean checkXMLVersion(XMLParser parser)
+  public static void checkXMLVersion(XMLParser parser)
   {
     String version = parser.getXMLVersion();
 
@@ -68,15 +68,11 @@ public class HandlerUtil
     {
       parser.getReport().message(MessageId.HTM_002, new MessageLocation(parser.getResourceName(),
           parser.getLineNumber(), parser.getColumnNumber()));
-      return true;
     }
-
-    if (!"1.0".equals(version))
+    else if (!"1.0".equals(version))
     {
       parser.getReport().message(MessageId.HTM_001, new MessageLocation(parser.getResourceName(),
           parser.getLineNumber(), parser.getColumnNumber()), version);
-      return true;
     }
-    return false;
   }
 }


### PR DESCRIPTION
@apond 
per the spec(s), the xml documents must be xml 1.0, not 1.1, for 2.0.1 and later.
moving the check into the base class allows it to be called for both 2.0 and 3.0 documents.
also, the wrapper logic was wrong.  It would only skip calling it if the version check reported back that it WAS an invalid version.  Otherwise, it called the check on every element in the document, a huge perf loss.
