### PR TITLE
messages in tests should be written in English without any settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.12.4</version>
                 <configuration>
-                    <argLine>-Xmx2g</argLine>
+                    <argLine>-Xmx2g -Duser.language=en</argLine>
                     <workingDirectory>${project.build.directory}/test-classes</workingDirectory>
                     <!-- manifestFile>${project.build.directory}/classes/META-INF/MANIFEST.MF</manifestFile -->
                 </configuration>


### PR DESCRIPTION
I'd like to add localized messages using ResourceBundle and MessageBundle_*.properties files.
I added some properties files in my local repository and confirmed to work properly.
But with localized properties file, some tests are failed bacause messages are localized even in tests.
This patch (maven's option) make langauge setting as EN in all tests.
