### PR TITLE
remove code fragments from constants definitions in com.adobe.epubcheck.util.Messages

### DIFF
--- a/src/main/java/com/adobe/epubcheck/tool/EpubChecker.java
+++ b/src/main/java/com/adobe/epubcheck/tool/EpubChecker.java
@@ -746,6 +746,6 @@ public class EpubChecker
    */
   private static void displayHelp()
   {
-    outWriter.println(Messages.HELP_TEXT);
+    outWriter.println(String.format(Messages.HELP_TEXT, EpubCheck.version()));
   }
 }

--- a/src/main/java/com/adobe/epubcheck/util/Messages.java
+++ b/src/main/java/com/adobe/epubcheck/util/Messages.java
@@ -62,7 +62,7 @@ public class Messages {
   public static final String OUTPUT_TYPE_CONFLICT = "Only one output format can be specified at a time.";
 
   public static final String HELP_TEXT =
-          "nookepubcheck v." + EpubCheck.version() + "\n" +
+          "nookepubcheck v.%1$s\n" +
           "When running this tool, the first argument should be the name (with the path)\n" +
           " of the file to check.\n" +
           "\n" +

--- a/src/test/java/com/adobe/epubcheck/test/command_line_Test.java
+++ b/src/test/java/com/adobe/epubcheck/test/command_line_Test.java
@@ -1,5 +1,6 @@
 package com.adobe.epubcheck.test;
 
+import com.adobe.epubcheck.api.EpubCheck;
 import com.adobe.epubcheck.tool.Checker;
 import com.adobe.epubcheck.util.*;
 import junit.framework.Assert;
@@ -80,7 +81,7 @@ public class command_line_Test
   {
     common.runCustomTest("command_line", "help", 1, true, "-?");
     Assert.assertEquals("Command output not as expected", Messages.NO_FILE_SPECIFIED, errContent.toString().trim());
-    String expected = Messages.HELP_TEXT.replaceAll("[\\s]+", " ");
+    String expected = String.format(Messages.HELP_TEXT.replaceAll("[\\s]+", " "), EpubCheck.version());
     String actual = outContent.toString();
     actual = actual.replaceAll("[\\s]+", " ");
     Assert.assertTrue("Help output isn't as expected", actual.contains(expected));


### PR DESCRIPTION
I'd like to internationalize messages in com.adobe.epubcheck.util.Messages.

First of all, I'd like to remove a code `EpubCheck.version()` and use String.format().
After this pull req. merged, I will make another pull req. to replace messages of the class using ResourceBundle.
