### PR TITLE
use ResourceBundle in com.adobe.epubcheck.util.Messages

### DIFF
--- a/src/main/java/com/adobe/epubcheck/tool/EpubChecker.java
+++ b/src/main/java/com/adobe/epubcheck/tool/EpubChecker.java
@@ -126,11 +126,11 @@ public class EpubChecker
 
     if (factory == null)
     {
-      outWriter.println(Messages.DISPLAY_HELP);
+      outWriter.println(Messages.get("display_help"));
       System.err.println(String.format(
-          Messages.MODE_VERSION_NOT_SUPPORTED, mode, version));
+          Messages.get("mode_version_not_supported"), mode, version));
 
-      throw new RuntimeException(String.format(Messages.MODE_VERSION_NOT_SUPPORTED, mode, version));
+      throw new RuntimeException(String.format(Messages.get("mode_version_not_supported"), mode, version));
     }
 
     DocumentValidator check = factory.newInstance(report, path,
@@ -141,25 +141,25 @@ public class EpubChecker
       int validationResult = ((EpubCheck)check).doValidate();
       if (validationResult == 0)
       {
-        outWriter.println(Messages.NO_ERRORS__OR_WARNINGS);
+        outWriter.println(Messages.get("no_errors__or_warnings"));
         return 0;
       }
       else if (validationResult == 1)
       {
-        System.err.println(Messages.THERE_WERE_WARNINGS);
+        System.err.println(Messages.get("there_were_warnings"));
         return failOnWarnings ? 1 : 0;
       }
-      System.err.println(Messages.THERE_WERE_ERRORS);
+      System.err.println(Messages.get("there_were_errors"));
       return 1;
     }
     else
     {
       if (check.validate())
       {
-        outWriter.println(Messages.NO_ERRORS__OR_WARNINGS);
+        outWriter.println(Messages.get("no_errors__or_warnings"));
         return 0;
       }
-      System.err.println(Messages.THERE_WERE_ERRORS);
+      System.err.println(Messages.get("there_were_errors"));
     }
     return 1;
   }
@@ -193,11 +193,11 @@ public class EpubChecker
 
     if (factory == null)
     {
-      outWriter.println(Messages.DISPLAY_HELP);
+      outWriter.println(Messages.get("display_help"));
       System.err.println(String.format(
-          Messages.MODE_VERSION_NOT_SUPPORTED, mode, version));
+          Messages.get("mode_version_not_supported"), mode, version));
 
-      throw new RuntimeException(String.format(Messages.MODE_VERSION_NOT_SUPPORTED, mode, version));
+      throw new RuntimeException(String.format(Messages.get("mode_version_not_supported"), mode, version));
     }
 
     DocumentValidator check = factory.newInstance(report, path,
@@ -206,10 +206,10 @@ public class EpubChecker
 
     if (check.validate())
     {
-      outWriter.println(Messages.NO_ERRORS__OR_WARNINGS);
+      outWriter.println(Messages.get("no_errors__or_warnings"));
       return 0;
     }
-    System.err.println(Messages.THERE_WERE_ERRORS);
+    System.err.println(Messages.get("there_were_errors"));
 
     return 1;
   }
@@ -371,13 +371,13 @@ public class EpubChecker
       {
         if (mode != null)
         {
-          report.info(null, FeatureEnum.EXEC_MODE, String.format(Messages.SINGLE_FILE, mode, version.toString()));
+          report.info(null, FeatureEnum.EXEC_MODE, String.format(Messages.get("single_file"), mode, version.toString()));
         }
         result = validateFile(path, version, report);
       }
       else
       {
-        System.err.println(Messages.ERROR_PROCESSING_UNEXPANDED_EPUB);
+        System.err.println(Messages.get("error_processing_unexpanded_epub"));
         return 1;
       }
 
@@ -412,7 +412,7 @@ public class EpubChecker
         }
         catch (RuntimeException ex)
         {
-          System.err.println(Messages.THERE_WERE_ERRORS);
+          System.err.println(Messages.get("there_were_errors"));
           return 1;
         }
 
@@ -422,17 +422,17 @@ public class EpubChecker
         int validationResult = check.doValidate();
         if (validationResult == 0)
         {
-          outWriter.println(Messages.NO_ERRORS__OR_WARNINGS);
+          outWriter.println(Messages.get("no_errors__or_warnings"));
           result = 0;
         }
         else if (validationResult == 1)
         {
-          System.err.println(Messages.THERE_WERE_WARNINGS);
+          System.err.println(Messages.get("there_were_warnings"));
           result = failOnWarnings ? 1 : 0;
         }
         else if (validationResult >= 2)
         {
-          System.err.println(Messages.THERE_WERE_ERRORS);
+          System.err.println(Messages.get("there_were_errors"));
           result = 1;
         }
 
@@ -441,7 +441,7 @@ public class EpubChecker
           if ((report.getErrorCount() > 0) || (report.getFatalErrorCount() > 0))
           {
             //keep if valid or only warnings
-            System.err.println(Messages.DELETING_ARCHIVE);
+            System.err.println(Messages.get("deleting_archive"));
             epub.deleteEpubFile();
           }
         }
@@ -454,7 +454,7 @@ public class EpubChecker
       {
         if (mode != null)
         {
-          report.info(null, FeatureEnum.EXEC_MODE, String.format(Messages.SINGLE_FILE, mode, version.toString()));
+          report.info(null, FeatureEnum.EXEC_MODE, String.format(Messages.get("single_file"), mode, version.toString()));
         }
         result = validateFile(path, version, report);
       }
@@ -489,7 +489,7 @@ public class EpubChecker
     // Exit if there are no arguments passed to main
     if (args.length < 1)
     {
-      System.err.println(Messages.ARGUMENT_NEEDED);
+      System.err.println(Messages.get("argument_needed"));
       return false;
     }
 
@@ -511,15 +511,15 @@ public class EpubChecker
           }
           else
           {
-            outWriter.println(Messages.DISPLAY_HELP);
+            outWriter.println(Messages.get("display_help"));
             throw new RuntimeException(new InvalidVersionException(
                 InvalidVersionException.UNSUPPORTED_VERSION));
           }
         }
         else
         {
-          outWriter.println(Messages.DISPLAY_HELP);
-          throw new RuntimeException(Messages.VERSION_ARGUMENT_EXPECTED);
+          outWriter.println(Messages.get("display_help"));
+          throw new RuntimeException(Messages.get("version_argument_expected"));
         }
       }
       else if (args[i].equals("--mode") || args[i].equals("-mode") || args[i].equals("-m"))
@@ -531,8 +531,8 @@ public class EpubChecker
         }
         else
         {
-          outWriter.println(Messages.DISPLAY_HELP);
-          throw new RuntimeException(Messages.MODE_ARGUMENT_EXPECTED);
+          outWriter.println(Messages.get("display_help"));
+          throw new RuntimeException(Messages.get("mode_argument_expected"));
         }
       }
       else if (args[i].equals("--save") || args[i].equals("-save") || args[i].equals("-s"))
@@ -676,7 +676,7 @@ public class EpubChecker
 
     if (xmlOutput && jsonOutput)
     {
-      System.err.println(Messages.OUTPUT_TYPE_CONFLICT);
+      System.err.println(Messages.get("output_type_conflict"));
       return false;
     }
     if (path != null)
@@ -704,7 +704,7 @@ public class EpubChecker
       }
       else
       {
-        System.err.println(Messages.NO_FILE_SPECIFIED);
+        System.err.println(Messages.get("no_file_specified"));
         return false;
       }
     }
@@ -712,13 +712,13 @@ public class EpubChecker
     {
       if (mode != null || version != EPUBVersion.VERSION_3)
       {
-        System.err.println(Messages.MODE_VERSION_IGNORED);
+        System.err.println(Messages.get("mode_version_ignored"));
         mode = null;
       }
     }
     else if (mode == null)
     {
-      outWriter.println(Messages.MODE_REQUIRED);
+      outWriter.println(Messages.get("mode_required"));
       return false;
     }
 
@@ -746,6 +746,6 @@ public class EpubChecker
    */
   private static void displayHelp()
   {
-    outWriter.println(String.format(Messages.HELP_TEXT, EpubCheck.version()));
+    outWriter.println(String.format(Messages.get("help_text"), EpubCheck.version()));
   }
 }

--- a/src/main/java/com/adobe/epubcheck/util/DefaultReportImpl.java
+++ b/src/main/java/com/adobe/epubcheck/util/DefaultReportImpl.java
@@ -111,7 +111,7 @@ public class DefaultReportImpl extends MasterReport
         case FORMAT_VERSION:
           if (!quiet)
           {
-            outWriter.println(String.format(Messages.VALIDATING_VERSION_MESSAGE, value));
+            outWriter.println(String.format(Messages.get("validating_version_message"), value));
           }
           break;
         default:

--- a/src/main/java/com/adobe/epubcheck/util/Messages.java
+++ b/src/main/java/com/adobe/epubcheck/util/Messages.java
@@ -22,87 +22,101 @@
 
 package com.adobe.epubcheck.util;
 
-import com.adobe.epubcheck.api.EpubCheck;
+import com.google.common.base.Charsets;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.text.MessageFormat;
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.PropertyResourceBundle;
+import java.util.ResourceBundle;
+import java.util.ResourceBundle.Control;
 
 public class Messages {
 
-  public static final String SINGLE_FILE = "File is validated as a single file of type %1$s and version %2$s. Only a subset of the available tests is run.";
+  private static final String BUNDLE_NAME = "com.adobe.epubcheck.util.messages"; //$NON-NLS-1$
+  private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME, Locale.getDefault(), new UTF8Control());
 
-  public static String OPV_VERSION_TEST = "*** Candidate for msg deletion *** Tests are performed only for the OPF version.";
+  private Messages()
+  {
+  }
 
-  public static final String MODE_VERSION_NOT_SUPPORTED = "The checker doesn't validate type %1$s and version %2$s.";
+  public static String get(String key)
+  {
+    try
+    {
+      return RESOURCE_BUNDLE.getString(key);
+    }
+    catch (MissingResourceException e)
+    {
+      return key;
+    }
+  }
 
-  public static final String NO_ERRORS__OR_WARNINGS = "No errors or warnings detected.";
+  public static String get(String key, Object... arguments)
+  {
+    try
+    {
+      return MessageFormat.format(RESOURCE_BUNDLE.getString(key), arguments);
+    }
+    catch (MissingResourceException e)
+    {
+      return key;
+    }
+  }
 
-  public static final String THERE_WERE_ERRORS = "\nCheck finished with errors\n";
-
-  public static final String THERE_WERE_WARNINGS = "\nCheck finished with warnings\n";
-
-  public static final String ERROR_PROCESSING_UNEXPANDED_EPUB = "\nThis check cannot process expanded epubs\n";
-
-  public static final String DELETING_ARCHIVE = "\nEpub creation cancelled due to detected errors.\n";
-
-  public static final String DISPLAY_HELP = "-help displays help";
-
-  public static final String ARGUMENT_NEEDED = "At least one argument expected";
-
-  public static final String VERSION_ARGUMENT_EXPECTED = "Version number omitted from the -version argument.";
-
-  public static final String MODE_ARGUMENT_EXPECTED = "Type omitted from the -mode argument.";
-
-  public static final String NO_FILE_SPECIFIED = "No file specified in the arguments. Exiting.";
-
-  public static final String MODE_VERSION_IGNORED = "The mode and version arguments are ignored for epubs. "
-      + "They are retrieved from the files.";
-
-  public static final String MODE_REQUIRED = "Mode required for non-epub files. Default version is 3.0.";
-
-  public static final String VALIDATING_VERSION_MESSAGE = "Validating using EPUB version %1$s rules.";
-
-  public static final String OUTPUT_TYPE_CONFLICT = "Only one output format can be specified at a time.";
-
-  public static final String HELP_TEXT =
-          "nookepubcheck v.%1$s\n" +
-          "When running this tool, the first argument should be the name (with the path)\n" +
-          " of the file to check.\n" +
-          "\n" +
-          "If checking a non-epub file, the epub version of the file must\n" +
-          " be specified using -v and the type of the file using -mode.\n" +
-          " The default version is: 3.0.\n" +
-          "\n" +
-          "Modes and versions supported: \n" +
-          "--mode opf -v 2.0\n" +
-          "--mode opf -v 3.0\n" +
-          "--mode xhtml -v 2.0\n" +
-          "--mode xhtml -v 3.0\n" +
-          "--mode svg -v 2.0\n" +
-          "--mode svg -v 3.0\n" +
-          "--mode nav -v 3.0\n" +
-          "--mode mo  -v 3.0 // For Media Overlays validation\n" +                    // \  the bar is 100
-          "--mode exp  // For expanded EPUB archives\n" +
-          "\n" +
-          "This tool also accepts the following options:\n" +
-          "--save 	         = saves the epub created from the expanded epub\n" +
-          "--out <file>     = output an assessment XML document file.\n" +
-          "--json <file>    = output an assessment JSON document file\n" +
-          "-m <file>        = same as --mode\n" +
-          "-o <file>        = same as --out\n" +
-          "-j <file>        = same as --json\n" +
-          "--failonwarnings[+|-] = By default, the tool returns a 1 if errors are found in the file or 0 if no errors\n" +
-          "                        are found.  Using --failonwarnings will cause the process to exit with a status of\n" +
-          "                        1 if either warnings or errors are present and 0 only when there are no errors or warnings.\n" +
-          "-f, --fatal      = include only fatal errors in the output\n" +
-          "-e, --error      = include only error and fatal severity messages in ouput\n" +
-          "-w, --warn       = include fatal, error, and warn severity messages in output\n" +
-          "-u, --usage      = include ePub feature usage information in output\n" +
-          "                    (default is OFF); if enabled, usage information will\n" +
-          "                    always be included in the output file\n" +
-          "\n" +
-          "-l, --listChecks [<file>] = list message ids and severity levels to the custom message file named <file>\n" +
-          "                          or the console\n" +
-          "-c, --customMessages [<file>] = override message severity levels as defined in the custom message file named <file>\n" +
-          "\n" +
-          "-h, -? or --help = displays this help message\n";
-
+  private static class UTF8Control extends Control
+  {
+    public ResourceBundle newBundle
+        (String baseName, Locale locale, String format, ClassLoader loader, boolean reload)
+        throws
+        IllegalAccessException,
+        InstantiationException,
+        IOException
+    {
+      // The below is a copy of the default implementation.
+      String bundleName = toBundleName(baseName, locale);
+      String resourceName = toResourceName(bundleName, "properties"); //$NON-NLS-1$
+      ResourceBundle bundle = null;
+      InputStream stream = null;
+      if (reload)
+      {
+        URL url = loader.getResource(resourceName);
+        if (url != null)
+        {
+          URLConnection connection = url.openConnection();
+          if (connection != null)
+          {
+            connection.setUseCaches(false);
+            stream = connection.getInputStream();
+          }
+        }
+      }
+      else
+      {
+        stream = loader.getResourceAsStream(resourceName);
+      }
+      if (stream != null)
+      {
+        try
+        {
+          // Only this line is changed to make it to read properties files as UTF-8.
+          bundle = new PropertyResourceBundle(
+              new BufferedReader(
+                  new InputStreamReader(stream, Charsets.UTF_8)));
+        }
+        finally
+        {
+          stream.close();
+        }
+      }
+      return bundle;
+    }
+  }
 
 }

--- a/src/main/java/com/adobe/epubcheck/util/WriterReportImpl.java
+++ b/src/main/java/com/adobe/epubcheck/util/WriterReportImpl.java
@@ -114,7 +114,7 @@ public class WriterReportImpl extends MasterReport
         case FORMAT_VERSION:
           if (DEBUG && !quiet)
           {
-            outWriter.println(String.format(Messages.VALIDATING_VERSION_MESSAGE, value));
+            outWriter.println(String.format(Messages.get("validating_version_message"), value));
           }
           break;
         default:

--- a/src/main/resources/com/adobe/epubcheck/util/messages.properties
+++ b/src/main/resources/com/adobe/epubcheck/util/messages.properties
@@ -1,0 +1,63 @@
+single_file=File is validated as a single file of type %1$s and version %2$s. Only a subset of the available tests is run.
+opv_version_test=*** Candidate for msg deletion *** Tests are performed only for the OPF version.
+mode_version_not_supported=The checker doesn't validate type %1$s and version %2$s.
+
+no_errors__or_warnings=No errors or warnings detected.
+there_were_errors=\nCheck finished with errors\n
+there_were_warnings=\nCheck finished with warnings\n
+
+error_processing_unexpanded_epub=\nThis check cannot process expanded epubs\n
+deleting_archive=\nEpub creation cancelled due to detected errors.\n
+display_help=-help displays help
+argument_needed=At least one argument expected
+version_argument_expected=Version number omitted from the -version argument.
+mode_argument_expected=Type omitted from the -mode argument.
+no_file_specified=No file specified in the arguments. Exiting.
+mode_version_ignored=The mode and version arguments are ignored for epubs. They are retrieved from the files.
+mode_required=Mode required for non-epub files. Default version is 3.0.
+validating_version_message=Validating using EPUB version %1$s rules.
+output_type_conflict=Only one output format can be specified at a time.
+
+help_text = \
+          nookepubcheck v.%1$s\n\
+          When running this tool, the first argument should be the name (with the path)\n\
+          of the file to check.\n\
+          \n\
+          If checking a non-epub file, the epub version of the file must\n\
+           be specified using -v and the type of the file using -mode.\n\
+           The default version is: 3.0.\n\
+          \n\
+          Modes and versions supported: \n\
+          --mode opf -v 2.0\n\
+          --mode opf -v 3.0\n\
+          --mode xhtml -v 2.0\n\
+          --mode xhtml -v 3.0\n\
+          --mode svg -v 2.0\n\
+          --mode svg -v 3.0\n\
+          --mode nav -v 3.0\n\
+          --mode mo  -v 3.0 // For Media Overlays validation\n\
+          --mode exp  // For expanded EPUB archives\n\
+          \n\
+          This tool also accepts the following options:\n\
+          --save 	         = saves the epub created from the expanded epub\n\
+          --out <file>     = output an assessment XML document file.\n\
+          --json <file>    = output an assessment JSON document file\n\
+          -m <file>        = same as --mode\n\
+          -o <file>        = same as --out\n\
+          -j <file>        = same as --json\n\
+          --failonwarnings[+|-] = By default, the tool returns a 1 if errors are found in the file or 0 if no errors\n\
+          \                        are found.  Using --failonwarnings will cause the process to exit with a status of\n\
+          \                        1 if either warnings or errors are present and 0 only when there are no errors or warnings.\n\
+          -f, --fatal      = include only fatal errors in the output\n\
+          -e, --error      = include only error and fatal severity messages in ouput\n\
+          -w, --warn       = include fatal, error, and warn severity messages in output\n\
+          -u, --usage      = include ePub feature usage information in output\n\
+          \                    (default is OFF); if enabled, usage information will\n\
+          \                    always be included in the output file\n\
+          \n\
+          -l, --listChecks [<file>] = list message ids and severity levels to the custom message file named <file>\n\
+          \                          or the console\n\
+          -c, --customMessages [<file>] = override message severity levels as defined in the custom message file named <file>\n\
+          \n\
+          -h, -? or --help = displays this help message\n
+

--- a/src/main/resources/com/adobe/epubcheck/util/messages_ja.properties
+++ b/src/main/resources/com/adobe/epubcheck/util/messages_ja.properties
@@ -1,0 +1,62 @@
+single_file = ファイルはファイル種別 %1$s、version %2$s のシングルファイルとして検証されます. 適用可能なテストのサブセットのみ実行します.
+opv_version_test = *** Candidate for msg deletion *** テストはOPF versionに対してのみ実行します.
+mode_version_not_supported = このチェッカーではファイル種別 %1$s、 version %2$s の検証はできません.
+
+no_errors__or_warnings = エラーも警告も検出されませんでした.
+there_were_errors = \nエラーが検出されました\n
+there_were_warnings = \n警告が検出されました\n
+
+error_processing_unexpanded_epub = \nこのチェックは展開されたepubでは実行できません\n
+deleting_archive = \nエラーの検出のためEPUBの生成を中止しました.\n
+display_help = -help ヘルプを表示
+argument_needed = 少なくとも1つの引数が必要です
+version_argument_expected = オプション -version で与えられるバージョン番号が省略されています
+mode_argument_expected = オプション -mode で与えられるファイル種別が省略されています
+no_file_specified = オプションでファイルが指定されていません. 終了します.
+mode_version_ignored = mode と version の引数はepubファイル指定時は無視します. ファイルより取り出します.
+mode_required = 非epubファイルには -mode オプションが必要です. デフォルトの version は 3.0 です.
+validating_version_message = EPUB version %1$s のルールを使って検証します.
+output_type_conflict = 一度に指定できる出力フォーマットは1つのみです.
+
+help_text = \
+          nookepubcheck v.%1$s\n\
+          このツールを実行するには、最初の引数をチェックしたいファイルの(パスを含んだ)\n\
+          名前にして下さい.\n\
+          \n\
+          非epubファイルを検証する際は、-v オプションでepubのバージョンを、\n\
+           -modeオプションでファイル種別を指定します.\n\
+           デフォルトのバージョン: 3.0.\n\
+          \n\
+          サポートしている mode と version: \n\
+          --mode opf -v 2.0\n\
+          --mode opf -v 3.0\n\
+          --mode xhtml -v 2.0\n\
+          --mode xhtml -v 3.0\n\
+          --mode svg -v 2.0\n\
+          --mode svg -v 3.0\n\
+          --mode nav -v 3.0 // メディアオーバーレイ検証用\n\
+          --mode mo  -v 3.0 // 展開済みEPUBアーカイブ\n\
+          --mode exp\n\
+          \n\
+          以下のオプションも受け付けます:\n\
+          --save 	         = 展開されたepubパスから生成されたepubファイルを保存します\n\
+          --out <file>     = 評価結果のXML文書ファイルを出力します\n\
+          --json <file>    = 評価結果のXJSON文書ファイルを出力します\n\
+          -m <file>        = --mode と同様\n\
+          -o <file>        = --out と同様\n\
+          -j <file>        = --json と同様\n\
+          --failonwarnings[+|-] = デフォルトでは、終了ステータスコードとして、エラーが検出されれば1を、検出されなければ\n\
+          \                        0を返します. --failonwarnings オプションを指定すると、警告かエラーがあれば1を、どちらも\n\
+          \                        ない場合のみ0を返すようになります.\n\
+          -f, --fatal      = fatal レベルの深刻度のエラーメッセージのみを出力します\n\
+          -e, --error      = fatal レベルと error レベルの深刻度のエラーメッセージのみを出力します\n\
+          -w, --warn       = fatal、error、warn レベルの深刻度のエラーメッセージを出力します\n\
+          -u, --usage      = epubの利用法情報も出力します\n\
+          \                    (デフォルトは OFF です); 指定した場合、利用法情報は\n\
+          \                    出力ファイルに常に含まれるようになります\n\
+          \n\
+          -l, --listChecks [<file>] = メッセージIDと深刻度レベルをカスタムメッセージファイル <file> または\n\
+          \                          コンソールに出力します\n\
+          -c, --customMessages [<file>] = カスタムメッセージファイル <file> でメッセージ深刻度レベルを上書きします\n\
+          \n\
+          -h, -? or --help = ヘルプメッセージを表示します\n

--- a/src/test/java/com/adobe/epubcheck/nav/NavCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/nav/NavCheckerTest.java
@@ -48,7 +48,7 @@ public class NavCheckerTest
                                    boolean verbose)
   {
     ValidationReport testReport = new ValidationReport(fileName, String.format(
-        Messages.SINGLE_FILE, "nav", "3.0"));
+        Messages.get("single_file"), "nav", "3.0"));
 
     GenericResourceProvider resourceProvider;
     if (fileName.startsWith("http://") || fileName.startsWith("https://"))

--- a/src/test/java/com/adobe/epubcheck/ocf/OCFFilenameCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/ocf/OCFFilenameCheckerTest.java
@@ -55,7 +55,7 @@ public class OCFFilenameCheckerTest
                                    EPUBVersion version)
   {
     testReport = new ValidationReport(fileName, String.format(
-        Messages.SINGLE_FILE, "opf", version.toString()));
+        Messages.get("single_file"), "opf", version.toString()));
 
 
     String result = OCFFilenameChecker.checkCompatiblyEscaped(fileName, testReport, version);

--- a/src/test/java/com/adobe/epubcheck/opf/OPFCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/opf/OPFCheckerTest.java
@@ -54,7 +54,7 @@ public class OPFCheckerTest
                                    EPUBVersion version, boolean verbose)
   {
     ValidationReport testReport = new ValidationReport(fileName, String.format(
-        Messages.SINGLE_FILE, "opf", version.toString()));
+        Messages.get("single_file"), "opf", version.toString()));
 
     GenericResourceProvider resourceProvider;
     if (fileName.startsWith("http://") || fileName.startsWith("https://"))

--- a/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
@@ -66,7 +66,7 @@ public class OPSCheckerTest
 	public void testValidateDocument(String fileName, String mimeType,
 			    List<MessageId> errors, List<MessageId> warnings, List<MessageId> fatalErrors, EPUBVersion version, boolean verbose, ExtraReportTest extraTest)
   {
-    ValidationReport testReport = new ValidationReport(fileName, String.format(Messages.SINGLE_FILE, mimeType, version));
+    ValidationReport testReport = new ValidationReport(fileName, String.format(Messages.get("single_file"), mimeType, version));
     String basepath = null;
     if (version == EPUBVersion.VERSION_2)
     {

--- a/src/test/java/com/adobe/epubcheck/overlay/OverlayCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/overlay/OverlayCheckerTest.java
@@ -51,7 +51,7 @@ public class OverlayCheckerTest
   public void testValidateDocument(String fileName, List<MessageId> errors, List<MessageId> warnings, List<MessageId> fatalErrors, boolean verbose)
   {
     ValidationReport testReport = new ValidationReport(fileName, String.format(
-        Messages.SINGLE_FILE, "media overlay", "3.0"));
+        Messages.get("single_file"), "media overlay", "3.0"));
 
     GenericResourceProvider resourceProvider;
     if (fileName.startsWith("http://") || fileName.startsWith("https://"))

--- a/src/test/java/com/adobe/epubcheck/test/command_line_Test.java
+++ b/src/test/java/com/adobe/epubcheck/test/command_line_Test.java
@@ -47,9 +47,6 @@ public class command_line_Test
     Checker checker = new Checker();
     Assert.assertTrue("Checker string isn't as expected", checker.toString().startsWith("com.adobe.epubcheck.tool.Checker"));
 
-    Messages messages = new Messages();
-    Assert.assertTrue("Messages string isn't as expected", messages.toString().startsWith("com.adobe.epubcheck.util.Messages"));
-
     EpubTypeAttributes attributes = new EpubTypeAttributes();
     Assert.assertTrue("EpubTypeAttributes string isn't as expected", attributes.toString().startsWith("com.adobe.epubcheck.util.EpubTypeAttributes"));
 
@@ -73,15 +70,15 @@ public class command_line_Test
   public void empty_Test()
   {
     common.runCustomTest("command_line", "empty", 1);
-    Assert.assertEquals("Command output not as expected", Messages.ARGUMENT_NEEDED, errContent.toString().trim());
+    Assert.assertEquals("Command output not as expected", Messages.get("argument_needed"), errContent.toString().trim());
   }
 
   @Test
   public void help_Test()
   {
     common.runCustomTest("command_line", "help", 1, true, "-?");
-    Assert.assertEquals("Command output not as expected", Messages.NO_FILE_SPECIFIED, errContent.toString().trim());
-    String expected = String.format(Messages.HELP_TEXT.replaceAll("[\\s]+", " "), EpubCheck.version());
+    Assert.assertEquals("Command output not as expected", Messages.get("no_file_specified"), errContent.toString().trim());
+    String expected = String.format(Messages.get("help_text").replaceAll("[\\s]+", " "), EpubCheck.version());
     String actual = outContent.toString();
     actual = actual.replaceAll("[\\s]+", " ");
     Assert.assertTrue("Help output isn't as expected", actual.contains(expected));
@@ -91,7 +88,7 @@ public class command_line_Test
   public void conflicting_output_Test()
   {
     common.runCustomTest("command_line", "conflicting_output", 1, "-o", "foo.xml", "-j", "bar.json");
-    Assert.assertEquals("Command output not as expected", Messages.OUTPUT_TYPE_CONFLICT, errContent.toString().trim());
+    Assert.assertEquals("Command output not as expected", Messages.get("output_type_conflict"), errContent.toString().trim());
   }
 
   @Test

--- a/src/test/java/com/adobe/epubcheck/test/common.java
+++ b/src/test/java/com/adobe/epubcheck/test/common.java
@@ -92,7 +92,7 @@ public class common
     }
     catch (Exception ex)
     {
-      System.err.println(Messages.THERE_WERE_ERRORS);
+      System.err.println(Messages.get("there_were_errors"));
       ex.printStackTrace();
       Assert.assertTrue(String.format("Error running %s test('%s')", componentName, testName), false);
     }
@@ -136,7 +136,7 @@ public class common
     }
     catch (Exception ex)
     {
-      System.err.println(Messages.THERE_WERE_ERRORS);
+      System.err.println(Messages.get("there_were_errors"));
       ex.printStackTrace();
       Assert.assertTrue("Error performing the json comparison: ", false);
     }
@@ -153,7 +153,7 @@ public class common
     }
     catch (Exception ex)
     {
-      System.err.println(Messages.THERE_WERE_ERRORS);
+      System.err.println(Messages.get("there_were_errors"));
       ex.printStackTrace();
       Assert.assertTrue("Error performing the json comparison: ", false);
       return;

--- a/src/test/java/com/adobe/epubcheck/test/debug.java
+++ b/src/test/java/com/adobe/epubcheck/test/debug.java
@@ -35,7 +35,7 @@ public class debug
     }
     catch (Exception ex)
     {
-      System.err.println(Messages.THERE_WERE_ERRORS);
+      System.err.println(Messages.get("there_were_errors"));
       ex.printStackTrace();
     }
   }

--- a/src/test/java/com/adobe/epubcheck/test/single_file_Test.java
+++ b/src/test/java/com/adobe/epubcheck/test/single_file_Test.java
@@ -43,7 +43,7 @@ public class single_file_Test
     //The exception string is different on iOS than it is on Windows.
     //This is why we are examining the command line rather than comparing json files.
     String actualErr = errContent.toString();
-    Assert.assertTrue("Missing errors message", actualErr.contains(Messages.THERE_WERE_ERRORS));
+    Assert.assertTrue("Missing errors message", actualErr.contains(Messages.get("there_were_errors")));
     Assert.assertTrue("Missing message", actualErr.contains("PKG-008"));
     System.setOut(originalOut);
     System.setErr(originalErr);

--- a/src/test/java/com/adobe/epubcheck/util/ResourceUtilTest.java
+++ b/src/test/java/com/adobe/epubcheck/util/ResourceUtilTest.java
@@ -22,6 +22,7 @@
 
 package com.adobe.epubcheck.util;
 
+import com.adobe.epubcheck.util.Messages;
 import com.adobe.epubcheck.messages.MessageId;
 import com.adobe.epubcheck.messages.MessageLocation;
 import com.adobe.epubcheck.opf.VersionRetriever;
@@ -58,7 +59,7 @@ public class ResourceUtilTest
   public void testVersion(String fileName, List<MessageId> errors, List<MessageId> warnings, List<MessageId> fatalErrors, boolean verbose)
   {
 
-    ValidationReport testReport = new ValidationReport(fileName, Messages.OPV_VERSION_TEST);
+    ValidationReport testReport = new ValidationReport(fileName, Messages.get("opv_version_test"));
 
     GenericResourceProvider resourceProvider;
     if (fileName.startsWith("http://") || fileName.startsWith("https://"))


### PR DESCRIPTION
I'd like to localize messages in `com.adobe.epubcheck.util.Messages`.
With this patch, I added `get` method, copied inner class `UTF8Control` from `org.idpf.epubcheck.util.css.Messages`, remove all constants of messages, and  added resource files `messages(_ja).properties` into src/main/resources/com/adobe/epubcheck/util/ .
