### PR TITLE
Fix for bug #381 in public epubcheck - NullPointerException on Issue95.epub

### DIFF
--- a/src/main/java/com/adobe/epubcheck/ocf/OCFChecker.java
+++ b/src/main/java/com/adobe/epubcheck/ocf/OCFChecker.java
@@ -125,7 +125,7 @@ public class OCFChecker
           ++rootfileErrorCounter;
           getReport().message(MessageId.OPF_017, new MessageLocation(OCFData.containerEntry, -1, -1));
          }
-        if (!ocf.hasEntry(opfPath))
+        else if (!ocf.hasEntry(opfPath))
         {
           getReport().message(MessageId.OPF_002, new MessageLocation(OCFData.containerEntry, -1, -1), opfPath);
           return;

--- a/src/test/java/com/adobe/epubcheck/api/Epub20CheckTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub20CheckTest.java
@@ -288,10 +288,9 @@ public class Epub20CheckTest extends AbstractEpubCheckTest
 	@Test
 	public void testMissingFullpathAttributeIssue236() {
     List<MessageId> expectedErrors = new ArrayList<MessageId>();
-    Collections.addAll(expectedErrors, MessageId.RSC_001, MessageId.OPF_017);
+    Collections.addAll(expectedErrors, MessageId.RSC_001, MessageId.OPF_017, MessageId.OPF_016);
     List<MessageId> expectedWarnings = new ArrayList<MessageId>();
     List<MessageId> fatalErrors = new ArrayList<MessageId>();
-    Collections.addAll(fatalErrors, MessageId.OPF_002);
     //container.xml missing @full-path attribute or @full-path is empty
 		// issue 95 / issue 236
 		testValidateDocument("invalid/issue236.epub", expectedErrors, expectedWarnings, fatalErrors);

--- a/src/test/java/com/adobe/epubcheck/test/message_coverage.java
+++ b/src/test/java/com/adobe/epubcheck/test/message_coverage.java
@@ -47,7 +47,6 @@ public class message_coverage
     expectedMissedCoverage.add(MessageId.PKG_005); //This is only reported in an exception that is difficult to generate in a test
     expectedMissedCoverage.add(MessageId.RSC_017); //This message may never be reported.   Sax Parser Error and message RSC_005, but this covers SAX warnings, which may never happen.
     expectedMissedCoverage.add(MessageId.PKG_015); //This is only reported in an exception that is difficult to generate in a test
-    expectedMissedCoverage.add(MessageId.OPF_016); //This is only reported in an exception that is difficult to generate in a test
     Assert.assertEquals("Messages not covered by tests", expectedMissedCoverage, allMessages);
 
   }


### PR DESCRIPTION
@apond 
null and empty opf path name were both handled above.  Throwing MessageId.OPF_002 for a null or empty path makes no sense (how can you have a file not found on a file with a null or empty name?) so turning this into an else if () is correct.
