### PR TITLE
NCHK-2869 ePubCheck erroneously reports an OPF-014 error when an .svg im...

### DIFF
--- a/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
@@ -202,7 +202,7 @@ public class OPSHandler30 extends OPSHandler
     {
       propertiesSet.add("scripted");
     }
-    else if (name.equals("switch"))
+    else if (!mimeType.equals("image/svg+xml") && name.equals("switch"))
     {
       propertiesSet.add("switch");
     }
@@ -596,7 +596,7 @@ public class OPSHandler30 extends OPSHandler
 
   void checkProperties()
   {
-    Set<String> props = new HashSet<String>(Arrays.asList((properties!=null) ? properties.split("\\s+") : new String[]{})); 
+    Set<String> props = new HashSet<String>(Arrays.asList((properties!=null) ? properties.split("\\s+") : new String[]{}));
     if (props.contains("singleFileValidation"))
     {
       return;


### PR DESCRIPTION
...age file uses the svg switch construct
@brucemackenzie

'switch' is defined in both OPF and svg, so suppress that property from the check list when we are in an svg file.
