### PR TITLE
NCHK-2897 ePubCheck is detecting invalid named entities in files other t...

### DIFF
--- a/src/main/java/com/adobe/epubcheck/ctc/EpubTextContentCheck.java
+++ b/src/main/java/com/adobe/epubcheck/ctc/EpubTextContentCheck.java
@@ -26,7 +26,7 @@ public class EpubTextContentCheck implements DocumentValidator
 
   public boolean validate()
   {
-    SearchDictionary validScriptTypes = new SearchDictionary(DictionaryType.SCRIPT_TYPES);
+    SearchDictionary validScriptTypes = new SearchDictionary(DictionaryType.VALID_TEXT_MEDIA_TYPES);
 
     for (int i = 0; i < epack.getManifest().itemsLength(); i++)
     {
@@ -41,7 +41,6 @@ public class EpubTextContentCheck implements DocumentValidator
           report.message(MessageId.RSC_001, new MessageLocation(this.epack.getFileName(), -1, -1), fileToParse);
           continue;
         }
-
         this.search.Search(fileToParse);
       }
     }

--- a/src/main/java/com/adobe/epubcheck/util/SearchDictionary.java
+++ b/src/main/java/com/adobe/epubcheck/util/SearchDictionary.java
@@ -9,7 +9,7 @@ public class SearchDictionary
 
   public enum DictionaryType
   {
-    VALID_TEXT_MEDIA_TYPES, CSS_FILES, CSS_VALUES, LINK_VALUES, SCRIPT_TYPES, SVG_MEDIA_TYPES
+    VALID_TEXT_MEDIA_TYPES, CSS_FILES, CSS_VALUES, LINK_VALUES, SVG_MEDIA_TYPES
   }
 
 
@@ -18,10 +18,6 @@ public class SearchDictionary
     if (dt.equals(DictionaryType.VALID_TEXT_MEDIA_TYPES))
     {
       buildValidTypesDictionary();
-    }
-    if (dt.equals(DictionaryType.SCRIPT_TYPES))
-    {
-      buildValidScriptTypesDictionary();
     }
     if (dt.equals(DictionaryType.CSS_VALUES))
     {
@@ -123,22 +119,6 @@ public class SearchDictionary
     value = "application/xhtml+xml";
     de = new TextSearchDictionaryEntry(description, value, null);
     v.add(de);
-  }
-
-  void buildValidScriptTypesDictionary()
-  {
-    String description;
-    String value;
-    TextSearchDictionaryEntry de;
-
-    description = "application/xhtml+xml";
-    value = "application/xhtml+xml";
-    de = new TextSearchDictionaryEntry(description, value, null);
-    v.add(de);
-
-    de = new TextSearchDictionaryEntry("text/javascript", "text/javascript", null);
-    v.add(de);
-
   }
 
   void buildLinkSearchDictionary()


### PR DESCRIPTION
...han html and xhtml, in .js files in this case
@apond 
Only run the entity check on xhtml files.  Delete unneeded code as SCRIPT_TYPES was a superset of VALID_TEXT_MEDIA_TYPES.  
