### PR TITLE
Use the request body instead of the header to pass the updated check mes...

### DIFF
--- a/node_server/checkserver.js
+++ b/node_server/checkserver.js
@@ -274,10 +274,13 @@ var configure_app = function(app, opt_root)
   });
 
   app.post('/set_messages', function (req, res) {
-    var newCheckMessages = req.headers.checkmessages;
-    if (newCheckMessages)
-    {
-      var newMessages = JSON.parse(newCheckMessages);
+    req.rawBody = '';
+    req.on('data', function(chunk) {
+      req.rawBody += chunk;
+    });
+
+    req.on('end', function() {
+      var newMessages = JSON.parse(req.rawBody);
       if (newMessages instanceof Array)
       {
         //TODO: Verify valid
@@ -289,11 +292,7 @@ var configure_app = function(app, opt_root)
       {
         error_response(res, "The check messages were not in the expected format.")
       }
-    }
-    else
-    {
-      error_response(res, "The 'checkMessages' parameter is required.");
-    }
+    });
   });
 
   app.get('/get_comparison', function (req, res) {

--- a/node_server/clientUI.js
+++ b/node_server/clientUI.js
@@ -292,9 +292,8 @@ var setContent = function () {
                 break;
               }
             }
-            var map = new goog.structs.Map;
-            map.set("checkMessages", JSON.stringify(checkMessages));
-            goog.net.XhrIo.send('/set_messages', null, "POST", null, map);
+
+            goog.net.XhrIo.send('/set_messages', null, "POST", JSON.stringify(checkMessages), null);
           });
         }
       };

--- a/node_server/test/checkserver_test.js
+++ b/node_server/test/checkserver_test.js
@@ -73,12 +73,7 @@ describe('checkserver tests', function () {
         .get('/')
         .expect(200)
         .end(function (err, res) {
-          if (err)
-          {
-            console.log(res.text);
-            console.log(err);
-            debug_dump(err, 'error');
-          }
+          log_err(err, res);
           assert.equal(err, null);
           done();
         })
@@ -92,12 +87,7 @@ describe('checkserver tests', function () {
         .get('/reset_default_messages')
         .expect(200)
         .end(function (err, res) {
-          if (err)
-          {
-            console.log(res.text);
-            console.log(err);
-            debug_dump(err, 'error');
-          }
+          log_err(err, res);
           assert.equal(err, null);
           messages = JSON.parse(res.text);
           assert.equal(messages.length, expectedMessageCount);
@@ -112,18 +102,15 @@ describe('checkserver tests', function () {
   describe('set messages', function () {
     it('POST /set_messages should update the messages', function (done) {
       messages[0].severity = "USAGE";
+      messages[0].message = "持";
       request(app)
         .post('/set_messages')
-        .set('checkmessages', JSON.stringify(messages))
+        .send(JSON.stringify(messages))
+        .set('content-type', 'application/json; charset=UTF-8')
         .expect(200)
         .end(function (err, res)
         {
-          if (err)
-          {
-            console.log(res.text);
-            console.log(err);
-            debug_dump(err, 'error');
-          }
+          log_err(err, res);
           assert.equal(err, null);
           done();
         });
@@ -136,17 +123,13 @@ describe('checkserver tests', function () {
         .get('/get_messages')
         .expect(200)
         .end(function (err, res) {
-          if (err)
-          {
-            console.log(res.text);
-            console.log(err);
-            debug_dump(err, 'error');
-          }
+          log_err(err, res);
           assert.equal(err, null);
           messages = JSON.parse(res.text);
           assert.equal(messages.length, expectedMessageCount);
           var firstMessage = messages[0];
           assert.equal(firstMessage.severity, 'USAGE');
+          assert.equal(firstMessage.message, '持');
           done();
         });
     });
@@ -158,12 +141,7 @@ describe('checkserver tests', function () {
         .get('/reset_default_messages')
         .expect(200)
         .end(function (err, res) {
-          if (err)
-          {
-            console.log(res.text);
-            console.log(err);
-            debug_dump(err, 'error');
-          }
+          log_err(err, res);
           assert.equal(err, null);
           messages = JSON.parse(res.text);
           assert.equal(messages.length, expectedMessageCount);
@@ -185,12 +163,7 @@ describe('checkserver tests', function () {
         .attach('Toy_modified.epub', 'node_server/test/Toy_modified.epub')
         .expect(200)
         .end(function (err, res) {
-          if (err)
-          {
-            console.log(res.text);
-            console.log(err);
-            debug_dump(err, 'error');
-          }
+          log_err(err, res);
           assert.equal(err, null);
           var results = JSON.parse(res.text);
           assert.equal(results.length, 2);
@@ -223,12 +196,7 @@ describe('checkserver tests', function () {
         .set('timestamp', timestamp)
         .expect(200)
         .end(function (err, res) {
-          if (err)
-          {
-            console.log(res.text);
-            console.log(err);
-            debug_dump(err, 'error');
-          }
+          log_err(err, res);
           assert.equal(err, null);
           var results = JSON.parse(res.text);
           assert.equal(results.items.length, 7);
@@ -249,12 +217,7 @@ describe('checkserver tests', function () {
         .set('timestampB', timestamp)
         .expect(200)
         .end(function (err, res) {
-          if (err)
-          {
-            console.log(res.text);
-            console.log(err);
-            debug_dump(err, 'error');
-          }
+          log_err(err, res);
           assert.equal(err, null);
           var results = JSON.parse(res.text);
           assert.equal(results.summary.itemChanges, 3);
@@ -276,3 +239,14 @@ var debug_dump = function (o, name) {
   }
 };
 
+var log_err = function(err, res) {
+  if (err)
+  {
+    if (res)
+    {
+      console.log(res.text);
+    }
+    console.log(err);
+    debug_dump(err, 'error');
+  }
+};


### PR DESCRIPTION
...sages to the server
@santoch 

I ran into a couple of issues passing the data in the header.  First the data could get bigger than the limit for header size and second there were issues passing utf-8 encoded information in the header.  This change puts the data in the body where both issues seem to be fixed.
