### PR TITLE
Re-enable OSGi metadata generation at build time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,6 +423,7 @@
                             <addClasspath>true</addClasspath>
                             <classpathPrefix>lib/</classpathPrefix>
                         </manifest>
+                        <manifestFile>${project.build.directory}/classes/META-INF/MANIFEST.MF</manifestFile>
                         <manifestEntries>
                             <project-url>${project.url}</project-url>
                             <scm-location>${project.scm.developerConnection}</scm-location>


### PR DESCRIPTION
The manifest created by the `maven-jar-plugin` uses the manifest
computed by `maven-bundle-plugin` as its baseline.

Fixes #415
