### PR TITLE
Removed dependency on proprietary GIFStreamMetadata

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/MessageId.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageId.java
@@ -227,6 +227,7 @@ public enum MessageId implements Comparable<MessageId>
   PKG_018("PKG-018"),
   PKG_020("PKG-020"),
   PKG_021("PKG-021"),
+  /*PKG_022("PKG-022"),*/
 
   // Messages relating to resources
   RSC_001("RSC-001"),

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -233,6 +233,7 @@ PKG_017_SUG=For maximum compatibility, use '.epub'.
 PKG_018=The ePub file is not found.
 PKG_020=OPF file '%1$s' is not found.
 PKG_021=Corrupted image file encountered.
+PKG_022=Wrong file extension for image. The image is a %1$-file but has the file extension %2$.
 
 #Resources
 RSC_001=File '%1$s' is not found.


### PR DESCRIPTION
When compiling and running in Java 7 (which I did just to see if it worked), a warning is shown about com.sun.imageio.plugins.gif.GIFStreamMetadata being proprietary and therefore deprecated. In a OSGi context, an external dependency was required for Suns ImageIO implementation, which I could not find in Maven Central. The changes in this commit should fix this.
