### PR TITLE
Corrections on XML output, addition of XMP output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.12.4</version>
                 <configuration>
-                    <argLine>-Xmx2g -Duser.language=en</argLine>
+                    <argLine>-Xmx1g -Duser.language=en</argLine>
                     <workingDirectory>${project.build.directory}/test-classes</workingDirectory>
                     <!-- manifestFile>${project.build.directory}/classes/META-INF/MANIFEST.MF</manifestFile -->
                 </configuration>

--- a/src/main/java/com/adobe/epubcheck/reporting/CheckMessage.java
+++ b/src/main/java/com/adobe/epubcheck/reporting/CheckMessage.java
@@ -182,4 +182,24 @@ public class CheckMessage implements Comparable<CheckMessage>
   {
     Collections.sort(locations);
   }
+
+public String getID() {
+	return ID;
+}
+
+public String getMessage() {
+	return message;
+}
+
+public int getAdditionalLocations() {
+	return additionalLocations;
+}
+
+public List<MessageLocation> getLocations() {
+	return locations;
+}
+
+public String getSuggestion() {
+	return suggestion;
+}
 }

--- a/src/main/java/com/adobe/epubcheck/tool/EpubChecker.java
+++ b/src/main/java/com/adobe/epubcheck/tool/EpubChecker.java
@@ -52,6 +52,7 @@ public class EpubChecker
   boolean keep = false;
   boolean jsonOutput = false;
   boolean xmlOutput = false;
+  boolean xmpOutput = false;
   File fileOut;
   File listChecksOut;
   File customMessageFile;
@@ -308,6 +309,10 @@ public class EpubChecker
     {
       report = new XmlReportImpl(fileOut, path, EpubCheck.version());
     }
+    else if (xmpOutput)
+    {
+      report = new XmpReportImpl(fileOut, path, EpubCheck.version());
+    }
     else
     {
       report = new DefaultReportImpl(path);
@@ -363,6 +368,7 @@ public class EpubChecker
   {
     report.info(null, FeatureEnum.TOOL_NAME, "epubcheck");
     report.info(null, FeatureEnum.TOOL_VERSION, EpubCheck.version());
+    report.info(null, FeatureEnum.TOOL_DATE, EpubCheck.buildDate());
     int result;
 
     try
@@ -398,6 +404,7 @@ public class EpubChecker
   {
     report.info(null, FeatureEnum.TOOL_NAME, "epubcheck");
     report.info(null, FeatureEnum.TOOL_VERSION, EpubCheck.version());
+    report.info(null, FeatureEnum.TOOL_DATE, EpubCheck.buildDate());
     int result = 0;
 
     try
@@ -579,6 +586,26 @@ public class EpubChecker
         }
         jsonOutput = true;
       }
+      else if (args[i].equals("--xmp") || args[i].equals("-xmp") || args[i].equals("-x"))
+      {
+        if ((args.length > (i + 1)) && !(args[i+1].startsWith("-")))
+        {
+          fileOut = new File(args[++i]);
+        }
+        else
+        {
+          File pathFile = new File(path);
+          if (pathFile.isDirectory())
+          {
+            fileOut = new File(pathFile.getAbsoluteFile().getParentFile(), pathFile.getName() + "check.xmp");
+          }
+          else
+          {
+            fileOut = new File(path + "check.xmp");
+          }
+        }
+        xmpOutput = true;
+      }
       else if (args[i].equals("--info") || args[i].equals("-i"))
       {
         reportingLevel = ReportingLevel.Info;
@@ -674,7 +701,7 @@ public class EpubChecker
       }
     }
 
-    if (xmlOutput && jsonOutput)
+    if ((xmlOutput && xmpOutput) || (xmlOutput && jsonOutput) || (xmpOutput && jsonOutput))
     {
       System.err.println(Messages.get("output_type_conflict"));
       return false;

--- a/src/main/java/com/adobe/epubcheck/util/FeatureEnum.java
+++ b/src/main/java/com/adobe/epubcheck/util/FeatureEnum.java
@@ -26,7 +26,7 @@ public enum FeatureEnum
 {
   TOOL_NAME("tool name"),
   TOOL_VERSION("tool version"),
-    TOOL_DATE("tool date"),
+  TOOL_DATE("tool date"),
   EXEC_MODE("execution mode"),
   FORMAT_NAME("format name"),
   FORMAT_VERSION("format version"),

--- a/src/main/java/com/adobe/epubcheck/util/XmlReportAbstract.java
+++ b/src/main/java/com/adobe/epubcheck/util/XmlReportAbstract.java
@@ -1,0 +1,319 @@
+package com.adobe.epubcheck.util;
+
+import com.adobe.epubcheck.api.MasterReport;
+import com.adobe.epubcheck.messages.Message;
+import com.adobe.epubcheck.messages.MessageLocation;
+import com.adobe.epubcheck.messages.Severity;
+import com.adobe.epubcheck.reporting.CheckMessage;
+
+import java.io.*;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+import org.javatuples.KeyValue;
+
+
+public abstract class XmlReportAbstract extends MasterReport
+{
+  protected final File outputFile;
+  protected PrintWriter out;
+
+  protected String epubCheckName = "epubcheck";
+  protected String epubCheckVersion;
+  protected String epubCheckDate = "2012-10-31"; // default date to be overiden by the property
+  protected String generationDate;
+
+  protected String creationDate;
+  protected String lastModifiedDate;
+  protected String identifier;
+  protected Set<String> titles = new LinkedHashSet<String>();
+  protected final Set<String> creators = new LinkedHashSet<String>();
+  protected final Set<String> contributors = new LinkedHashSet<String>();
+  protected final Set<String> subjects = new LinkedHashSet<String>();
+  protected String publisher;
+  protected final Set<String> rights = new LinkedHashSet<String>();
+  protected String date;
+
+  protected String formatName;
+  protected String formatVersion;
+  protected long pagesCount;
+  protected long charsCount;
+  protected String language;
+  protected final Set<String> embeddedFonts = new LinkedHashSet<String>();
+  protected final Set<String> refFonts = new LinkedHashSet<String>();
+  protected final Set<String> references = new LinkedHashSet<String>();
+  protected boolean hasEncryption;
+  protected boolean hasSignatures;
+  protected boolean hasAudio;
+  protected boolean hasVideo;
+  protected boolean hasFixedLayout;
+  protected boolean hasScripts;
+
+  protected final List<CheckMessage> warns = new ArrayList<CheckMessage>();
+  protected final List<CheckMessage> errors = new ArrayList<CheckMessage>();
+  protected final List<CheckMessage> fatalErrors = new ArrayList<CheckMessage>();
+  protected final List<CheckMessage> hints = new ArrayList<CheckMessage>();
+
+  public XmlReportAbstract(File out, String ePubName, String versionEpubCheck)
+  {
+    this.outputFile = out;
+    this.setEpubFileName(PathUtil.removeWorkingDirectory(ePubName));
+    this.epubCheckVersion = versionEpubCheck;
+  }
+
+  public void initialize()
+  {
+  }
+
+  @Override
+  public void close()
+  {
+  }
+
+  @Override
+  public void message(Message message, MessageLocation location, Object... args)
+  {
+	Severity s = message.getSeverity();
+	switch (s) {
+	case FATAL:
+        CheckMessage.addCheckMessage(fatalErrors, message, location, args);
+        break;
+	case ERROR:
+        CheckMessage.addCheckMessage(errors, message, location, args);
+        break;
+	case WARNING:
+        CheckMessage.addCheckMessage(warns, message, location, args);
+        break;
+	case USAGE:
+        CheckMessage.addCheckMessage(hints, message, location, args);
+        break;
+	}
+  }
+
+  @Override
+  public void info(String resource, FeatureEnum feature, String value)
+  {
+    switch (feature)
+    {
+      case TOOL_DATE:
+    	if (value != null && !value.startsWith("$")) {
+    		this.epubCheckDate = value;
+    	}
+    	break;
+      case TOOL_NAME:
+        this.epubCheckName = value;
+        break;
+      case TOOL_VERSION:
+        this.epubCheckVersion = value;
+        break;
+      case FORMAT_NAME:
+        this.formatName = value;
+        break;
+      case FORMAT_VERSION:
+        this.formatVersion = value;
+        break;
+      case CREATION_DATE:
+        this.creationDate = value;
+        break;
+      case MODIFIED_DATE:
+        this.lastModifiedDate = value;
+        break;
+      case PAGES_COUNT:
+        this.pagesCount = Long.parseLong(value);
+        break;
+      case CHARS_COUNT:
+        this.charsCount += Long.parseLong(value);
+        break;
+      case DECLARED_MIMETYPE:
+        if (value != null && value.startsWith("audio/")) {
+          this.hasAudio = true;
+        } else if (value != null && value.startsWith("video/")) {
+          this.hasVideo = true;
+        }
+        break;
+      case FONT_EMBEDDED:
+        this.embeddedFonts.add(value);
+        break;
+      case FONT_REFERENCE:
+        this.refFonts.add(value);
+        break;
+      case REFERENCE:
+        this.references.add(value);
+        break;
+      case DC_LANGUAGE:
+        this.language = value;
+        break;
+      case DC_TITLE:
+        this.titles.add(value);
+        break;
+      case DC_CREATOR:
+        this.creators.add(value);
+        break;
+      case DC_CONTRIBUTOR:
+        this.contributors.add(value);
+        break;
+      case DC_PUBLISHER:
+        this.publisher = value;
+        break;
+      case DC_SUBJECT:
+          this.subjects.add(value);
+          break;
+      case DC_RIGHTS:
+        this.rights.add(value);
+        break;
+      case DC_DATE:
+        this.date = value;
+        break;
+      case UNIQUE_IDENT:
+        if (resource == null) {
+    	  this.identifier = value;
+    	}
+        break;
+      case HAS_SIGNATURES:
+        this.hasSignatures = true;
+        break;
+      case HAS_ENCRYPTION:
+        this.hasEncryption = true;
+        break;
+      case HAS_FIXED_LAYOUT:
+        this.hasFixedLayout = true;
+        break;
+      case HAS_SCRIPTS:
+        this.hasScripts = true;
+        break;
+    }
+  }
+
+  protected String getNameFromPath(String path)
+  {
+    if (path == null || path.length() == 0)
+    {
+      return null;
+    }
+    int lastSlash = path.lastIndexOf('/');
+    if (lastSlash == -1)
+    {
+      return path;
+    }
+    else
+    {
+      return path.substring(lastSlash + 1);
+    }
+  }
+
+  public abstract int generate();
+
+  protected void output(int ident, String value)
+  {
+	if (ident != 0) {
+	    char[] spaces = new char[ident];
+	    Arrays.fill(spaces, ' ');
+	    out.print(spaces);
+    }
+    out.println(value);
+  }
+
+  protected String capitalize(String in) {
+	  StringBuilder sb = new StringBuilder();
+	  for (int i = 0; i < in.length(); i++) {
+		  char c = in.charAt(i);
+		  if (i == 0) sb.append(Character.toUpperCase(c));
+		  else sb.append(c);
+	  }
+	  return sb.toString();
+  }
+  
+  protected void startElement(int ident, String name, List<KeyValue<String, String>> attrs) {
+	    if (name == null || name.trim().length() == 0)
+	    {
+	      return;
+	    }
+	    StringBuilder sb = new StringBuilder();
+	    sb.append('<').append(name);
+	    if (attrs != null && attrs.size() != 0) {
+	    	for (KeyValue<String,String> attr : attrs) {
+		    	sb.append(' ').append(attr.getKey()).append("=\"");
+	    		sb.append(encodeContent(attr.getValue())).append('"');
+		    }
+	    }
+	    sb.append('>');
+	    output(ident, sb.toString());
+}
+  protected void startElement(int ident, String name, KeyValue<String, String> ... attrs) {
+	  startElement(ident, name, Arrays.asList(attrs));
+  }
+  protected void startElement(int ident, String name) {
+	  startElement(ident, name, (List<KeyValue<String, String>>)null);
+  }
+  
+  protected void endElement(int ident, String name) {
+	    if (name == null || name.trim().length() == 0)
+	    {
+	      return;
+	    }
+	    StringBuilder sb = new StringBuilder();
+	    sb.append("</").append(name).append('>');
+	    output(ident, sb.toString());
+}
+  
+  protected void generateElement(int ident, String name, String value)
+  {
+    if (value == null || value.trim().length() == 0)
+    {
+      return;
+    }
+    StringBuilder sb = new StringBuilder();
+    sb.append('<').append(name).append('>');
+    sb.append(encodeContent(value.trim()));
+    sb.append("</").append(name).append('>');
+    output(ident, sb.toString());
+  }
+
+  /**
+   * Encodes a content String in XML-clean form, converting characters
+   * to entities as necessary.  The null string will be
+   * converted to an empty string.
+   */
+  protected static String encodeContent(String content)
+  {
+    if (content == null)
+    {
+      content = "";
+    }
+    StringBuilder buffer = new StringBuilder(content);
+
+    int n = 0;
+    while ((n = buffer.indexOf("&", n)) > -1)
+    {
+      buffer.insert(n + 1, "amp;");
+      n += 5;
+    }
+    n = 0;
+    while ((n = buffer.indexOf("<", n)) > -1)
+    {
+      buffer.replace(n, n + 1, "&lt;");
+      n += 4;
+    }
+    n = 0;
+    while ((n = buffer.indexOf(">", n)) > -1)
+    {
+      buffer.replace(n, n + 1, "&gt;");
+      n += 4;
+    }
+
+    return buffer.toString();
+  }
+
+  /**
+   * Transform time into ISO 8601 string.
+   */
+  protected static String fromTime(final long time)
+  {
+    Date date = new Date(time);
+        // Waiting for Java 7: SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+    String formatted = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
+        .format(date);
+    return formatted.substring(0, 22) + ":" + formatted.substring(22);
+  }
+
+}

--- a/src/main/java/com/adobe/epubcheck/util/XmlReportImpl.java
+++ b/src/main/java/com/adobe/epubcheck/util/XmlReportImpl.java
@@ -1,249 +1,55 @@
 package com.adobe.epubcheck.util;
 
-import com.adobe.epubcheck.api.MasterReport;
-import com.adobe.epubcheck.messages.Message;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.javatuples.KeyValue;
+
 import com.adobe.epubcheck.messages.MessageLocation;
-import com.adobe.epubcheck.messages.Severity;
-
-import java.io.*;
-import java.text.SimpleDateFormat;
-import java.util.*;
+import com.adobe.epubcheck.reporting.CheckMessage;
 
 
-public class XmlReportImpl extends MasterReport
+public class XmlReportImpl extends XmlReportAbstract
 {
-  private final File outputFile;
-  private PrintWriter out;
-
-  private String epubCheckDate;
-  private String epubCheckName = "epubcheck";
-  private String epubCheckVersion;
-
-  private String creationDate;
-  private String lastModifiedDate;
-  private String identifier;
-  private String title;
-  private Set<String> titles = new LinkedHashSet<String>();
-  private final Set<String> creators = new LinkedHashSet<String>();
-  private final Set<String> contributors = new LinkedHashSet<String>();
-  private String publisher;
-  private final Set<String> rights = new LinkedHashSet<String>();
-  private String date;
-
-  private String formatName;
-  private String formatVersion;
-  private long pagesCount;
-  private long charsCount;
-  private String language;
-  private final Set<String> embeddedFonts = new LinkedHashSet<String>();
-  private final Set<String> refFonts = new LinkedHashSet<String>();
-  private final Set<String> references = new LinkedHashSet<String>();
-  private boolean hasEncryption;
-  private boolean hasSignatures;
-  private boolean hasAudio;
-  private boolean hasVideo;
-  private boolean hasFixedLayout;
-  private boolean hasScripts;
-
-  private final List<String> warns = new ArrayList<String>();
-  private final List<String> errors = new ArrayList<String>();
-  private final List<String> fatalErrors = new ArrayList<String>();
-  private final List<String> hints = new ArrayList<String>();
 
   public XmlReportImpl(File out, String ePubName, String versionEpubCheck)
   {
-    this.outputFile = out;
-    this.setEpubFileName(PathUtil.removeWorkingDirectory(ePubName));
-    this.epubCheckVersion = versionEpubCheck;
+	  super(out, ePubName, versionEpubCheck);
   }
 
-  public void initialize()
-  {
-  }
 
-  @Override
-  public void close()
-  {
-  }
-
-  @Override
-  public void message(Message message, MessageLocation location, Object... args)
-  {
-    if (message.getSeverity().equals(Severity.ERROR))
-    {
-      error(PathUtil.removeWorkingDirectory(location.getFileName()), location.getLine(), location.getColumn(), message.getMessage(args));
-    }
-    else if (message.getSeverity().equals(Severity.WARNING))
-    {
-      warning(PathUtil.removeWorkingDirectory(location.getFileName()), location.getLine(), location.getColumn(), message.getMessage(args));
-    }
-    else if (message.getSeverity().equals(Severity.FATAL))
-    {
-      fatalError(PathUtil.removeWorkingDirectory(location.getFileName()), location.getLine(), location.getColumn(), message.getMessage(args));
-    }
-  }
-
-  void error(String resource, int line, int column, String message)
-  {
-    errors.add((resource == null ? "" : "/" + resource) +
-        (line <= 0 ? "" : "(" + line + ")") + ": " + message);
-    	
-  }
-
-  public void hint(String resource, int line, int column, String message)
-  {
-    hints.add((resource == null ? "" : "/" + resource) +
-              (line <= 0 ? "" : "(" + line + ")") + ": " + message );
-
-  }
-
-  void fatalError(String resource, int line, int column, String message)
-  {
-    fatalErrors.add((resource == null ? "" : "/" + resource) +
-        (line <= 0 ? "" : "(" + line + ")") + ": " + message);
-  }
-
-  void warning(String resource, int line, int column, String message)
-  {
-    warns.add((resource == null ? "" : "/" + resource) +
-        (line <= 0 ? "" : "(" + line + ")") + ": " + message);
-  }
-
-  @Override
-  public void info(String resource, FeatureEnum feature, String value)
-  {
-    switch (feature)
-    {
-      case TOOL_DATE:
-        this.epubCheckDate = value;
-        break;
-      case TOOL_NAME:
-        this.epubCheckName = value;
-        break;
-      case TOOL_VERSION:
-        this.epubCheckVersion = value;
-        break;
-      case FORMAT_NAME:
-        this.formatName = value;
-        break;
-      case FORMAT_VERSION:
-        this.formatVersion = value;
-        break;
-      case CREATION_DATE:
-        this.creationDate = value;
-        break;
-      case MODIFIED_DATE:
-        this.lastModifiedDate = value;
-        break;
-      case PAGES_COUNT:
-        this.pagesCount = Long.parseLong(value);
-        break;
-      case CHARS_COUNT:
-        this.charsCount += Long.parseLong(value);
-        break;
-      case DECLARED_MIMETYPE:
-        if (value != null && value.startsWith("audio/"))
-        {
-          this.hasAudio = true;
-        }
-        else if (value != null && value.startsWith("video/"))
-        {
-          this.hasVideo = true;
-        }
-        break;
-      case FONT_EMBEDDED:
-        this.embeddedFonts.add(value);
-        break;
-      case FONT_REFERENCE:
-        this.refFonts.add(value);
-        break;
-      case REFERENCE:
-        this.references.add(value);
-        break;
-      case DC_LANGUAGE:
-        this.language = value;
-        break;
-      case DC_TITLE:
-        this.titles.add(value);
-        break;
-      case DC_CREATOR:
-        this.creators.add(value);
-        break;
-      case DC_CONTRIBUTOR:
-        this.contributors.add(value);
-        break;
-      case DC_PUBLISHER:
-        this.publisher = value;
-        break;
-      case DC_RIGHTS:
-        this.rights.add(value);
-        break;
-      case DC_DATE:
-        this.date = value;
-        break;
-      case UNIQUE_IDENT:
-        this.identifier = value;
-        break;
-
-      case HAS_SIGNATURES:
-        this.hasSignatures = true;
-        break;
-      case HAS_ENCRYPTION:
-        this.hasEncryption = true;
-        break;
-      case HAS_FIXED_LAYOUT:
-        this.hasFixedLayout = true;
-        break;
-      case HAS_SCRIPTS:
-        this.hasScripts = true;
-        break;
-    }
-  }
-
-  private String getNameFromPath(String path)
-  {
-    if (path == null || path.length() == 0)
-    {
-      return null;
-    }
-    int lastSlash = path.lastIndexOf('/');
-    if (lastSlash == -1)
-    {
-      return path;
-    }
-    else
-    {
-      return path.substring(lastSlash + 1);
-    }
-  }
-
+  @SuppressWarnings("unchecked")
   public int generate()
   {
-    // Quick and dirty XML generation...
     int returnCode = 1;
     out = null;
     int ident = 0;
-
+    
+    generationDate = fromTime(System.currentTimeMillis());
     try
     {
       out = new PrintWriter(outputFile, "UTF-8");
-      out.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-      String epubCheckDate = "2012-10-31";
-      output(ident++,
-          "<jhove xmlns=\"http://hul.harvard.edu/ois/xml/ns/jhove\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
-              // " xsi:schemaLocation=\"http://hul.harvard.edu/ois/xml/ns/jhove jhove.xsd\"" + 
-              " name=\"" + epubCheckName + "\" release=\"" + epubCheckVersion +
-              "\" date=\"" + epubCheckDate + "\">");
-      generateElement(ident, "date", fromTime(System.currentTimeMillis()));
-            output(ident++, "<repInfo uri=\"" + encodeContent(getNameFromPath(getEpubFileName())) + "\">");
+      output(ident, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+	  List<KeyValue<String, String>> attrs = new ArrayList<KeyValue<String, String>>();
+	  attrs.add(KeyValue.with("xmlns", "http://hul.harvard.edu/ois/xml/ns/jhove"));
+	  attrs.add(KeyValue.with("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance"));
+	  // attrs.add(KeyValue.with("xsi:schemaLocation", "http://hul.harvard.edu/ois/xml/ns/jhove jhove.xsd"));
+	  attrs.add(KeyValue.with("name", epubCheckName));
+	  attrs.add(KeyValue.with("release", epubCheckVersion)); 
+	  attrs.add(KeyValue.with("date", epubCheckDate));
+	  startElement(ident++, "jhove", attrs);
+
+	  generateElement(ident, "date", generationDate);
+	  startElement(ident++, "repInfo", KeyValue.with("uri", getNameFromPath(getEpubFileName())));
       generateElement(ident, "created", creationDate);
       generateElement(ident, "lastModified", lastModifiedDate);
-      if (formatName == null)
-      {
+      if (formatName == null) {
         generateElement(ident, "format", "application/octet-stream");
-      }
-      else
-      {
+      } else {
         generateElement(ident, "format", formatName); //application/epub+zip
       }
       generateElement(ident, "version", formatVersion);
@@ -262,36 +68,60 @@ public class XmlReportImpl extends MasterReport
       }
       if (!warns.isEmpty() || !fatalErrors.isEmpty() || !errors.isEmpty() || !hints.isEmpty())
       {
-        output(ident++, "<messages>");
-        for (String f : fatalErrors)
-        {
-          generateElement(ident, "message", "FATAL: " + encodeContent(f));
+        startElement(ident++, "messages");
+        for (CheckMessage c : fatalErrors) {
+        	String m = c.getID() + ", FATAL, [" + encodeContent(c.getMessage()) + "], ";
+        	for (MessageLocation ml : c.getLocations()) {
+			  String loc = "";
+			  if (ml.getLine() > 0 || ml.getColumn() > 0) {
+				loc = " (" + ml.getLine() + "-" + ml.getColumn() + ")";
+			  }
+              generateElement(ident, "message", m + PathUtil.removeWorkingDirectory(ml.getFileName()) + loc);
+        	}
         }
-
-        for (String w : warns)
-        {
-          generateElement(ident, "message", "WARN: " + encodeContent(w));
+        for (CheckMessage c : errors) {
+        	String m = c.getID() + ", ERROR, [" + encodeContent(c.getMessage()) + "], ";
+        	for (MessageLocation ml : c.getLocations()) {
+			  String loc = "";
+			  if (ml.getLine() > 0 || ml.getColumn() > 0) {
+				loc = " (" + ml.getLine() + "-" + ml.getColumn() + ")";
+			  }
+              generateElement(ident, "message", m + PathUtil.removeWorkingDirectory(ml.getFileName()) + loc);
+        	}
         }
-
-        for (String e : errors)
-        {
-          generateElement(ident, "message", "ERROR: " + encodeContent(e));
+        for (CheckMessage c : warns) {
+        	String m = c.getID() + ", WARN, [" + encodeContent(c.getMessage()) + "], ";
+        	for (MessageLocation ml : c.getLocations()) {
+			  String loc = "";
+			  if (ml.getLine() > 0 || ml.getColumn() > 0) {
+				loc = " (" + ml.getLine() + "-" + ml.getColumn() + ")";
+			  }
+              generateElement(ident, "message", m + PathUtil.removeWorkingDirectory(ml.getFileName()) + loc);
+        	}
         }
-
-        for (String e : hints)
-        {
-            generateElement(ident, "message", "HINT: " + encodeContent(e));
+        for (CheckMessage c : hints) {
+        	String m = c.getID() + ", HINT, [" + encodeContent(c.getMessage()) + "], ";
+        	for (MessageLocation ml : c.getLocations()) {
+			  String loc = "";
+			  if (ml.getLine() > 0 || ml.getColumn() > 0) {
+				loc = " (" + ml.getLine() + "-" + ml.getColumn() + ")";
+			  }
+              generateElement(ident, "message", m + PathUtil.removeWorkingDirectory(ml.getFileName()) + loc);
+        	}
         }
-        output(--ident, "</messages>");
+        endElement(--ident, "messages");
       }
       generateElement(ident, "mimeType", formatName);
-      output(ident++, "<properties>");
+      startElement(ident++, "properties");
 
       generateProperty(ident, "PageCount", pagesCount);
       generateProperty(ident, "CharacterCount", charsCount);
       generateProperty(ident, "Language", language, "String");
 
-      output(ident++, "<property><name>Info</name><values arity=\"List\" type=\"Property\">");
+  	  startElement(ident++, "property");
+      generateElement(ident, "name", "Info");
+      startElement(ident++, "values", KeyValue.with("arity", "List"), KeyValue.with("type", "Property"));
+
       generateProperty(ident, "Identifier", identifier, "String");
       generateProperty(ident, "CreationDate", creationDate, "Date");
       generateProperty(ident, "ModDate", lastModifiedDate, "Date");
@@ -303,52 +133,71 @@ public class XmlReportImpl extends MasterReport
       }
       if (!creators.isEmpty())
       {
-        String[] cs = new String[0];
+        String[] cs = creators.toArray(new String[creators.size()]);
         generateProperty(ident, "Creator", cs, "String");
       }
       if (!contributors.isEmpty())
       {
-        String[] cs = new String[0];
+        String[] cs = contributors.toArray(new String[contributors.size()]);
         generateProperty(ident, "Contributor", cs, "String");
       }
       generateProperty(ident, "Date", date, "String");
       generateProperty(ident, "Publisher", publisher, "String");
+      if (!subjects.isEmpty())
+      {
+        String[] cs = subjects.toArray(new String[subjects.size()]);
+        generateProperty(ident, "Subject", cs, "String");
+      }
       if (!rights.isEmpty())
       {
-        String[] cs = new String[0];
+        String[] cs = rights.toArray(new String[rights.size()]);
         generateProperty(ident, "Rights", cs, "String");
       }
-      output(--ident, "</values></property>");
+      endElement(--ident, "values");
+      endElement(--ident, "property");
 
       if (!embeddedFonts.isEmpty() || !refFonts.isEmpty())
       {
-        output(ident++, "<property><name>Fonts</name><values arity=\"List\" type=\"Property\">");
+ 	    startElement(ident++, "property");
+        generateElement(ident, "name", "Fonts");
+        startElement(ident++, "values", KeyValue.with("arity", "List"), KeyValue.with("type", "Property"));
 
         for (String f : embeddedFonts)
         {
-          output(ident++, "<property><name>Font</name><values arity=\"List\" type=\"Property\">");
+      	  startElement(ident++, "property");
+          generateElement(ident, "name", "Font");
+          startElement(ident++, "values", KeyValue.with("arity", "List"), KeyValue.with("type", "Property"));
           generateProperty(ident, "FontName", encodeContent(getNameFromPath(f)), "String");
-          generateProperty(ident, "FontFile", true);
-          output(--ident, "</values></property>");
+          generateProperty(ident, "FontFile", false);
+          endElement(--ident, "values");
+          endElement(--ident, "property");
         }
         for (String f : refFonts)
         {
-          output(ident++, "<property><name>Font</name><values arity=\"List\" type=\"Property\">");
+          startElement(ident++, "property");
+          generateElement(ident, "name", "Font");
+          startElement(ident++, "values", KeyValue.with("arity", "List"), KeyValue.with("type", "Property"));
           generateProperty(ident, "FontName", encodeContent(getNameFromPath(f)), "String");
           generateProperty(ident, "FontFile", false);
-          output(--ident, "</values></property>");
+          endElement(--ident, "values");
+          endElement(--ident, "property");
         }
-        output(--ident, "</values></property>");
+        
+        endElement(--ident, "values");
+        endElement(--ident, "property");
       }
 
       if (!references.isEmpty())
       {
-        output(ident++, "<property><name>References</name><values arity=\"List\" type=\"Property\">");
+    	startElement(ident++, "property");
+    	generateElement(ident++, "name", "References");
+    	startElement(ident++, "values", KeyValue.with("arity", "List"), KeyValue.with("type", "Property"));
         for (String r : references)
         {
           generateProperty(ident, "Reference", encodeContent(r), "String");
         }
-        output(--ident, "</values></property>");
+        endElement(--ident, "values");
+        endElement(--ident, "property");
       }
 
       if (hasEncryption)
@@ -376,16 +225,9 @@ public class XmlReportImpl extends MasterReport
         generateProperty(ident, "hasScripts", hasScripts);
       }
 
-      boolean withDocumentMD = false;
-      if (withDocumentMD)
-      {
-        output(ident++, "<property><name>DocumentMDMetadata</name><values arity=\"Scalar\" type=\"Object\"><value>");
-        generateDocumentMD(ident);
-        output(--ident, "</value></values></property>");
-      }
-      output(--ident, "</properties>");
-      output(--ident, "</repInfo>");
-      output(--ident, "</jhove>");
+      endElement(--ident, "properties");
+      endElement(--ident, "repInfo");
+      endElement(--ident, "jhove");
       returnCode = 0;
     }
     catch (FileNotFoundException e)
@@ -396,11 +238,6 @@ public class XmlReportImpl extends MasterReport
     catch (UnsupportedEncodingException e)
     {
       System.err.println("FileNotFound error: " + e.getMessage());
-      returnCode = 1;
-    }
-    catch (IOException e)
-    {
-      System.err.println("IOException error: " + e.getMessage());
       returnCode = 1;
     }
     catch (Exception e)
@@ -418,105 +255,37 @@ public class XmlReportImpl extends MasterReport
     return returnCode;
   }
 
-  private void generateDocumentMD(int ident)
-  {
-    output(ident++, "<docmd:document xmlns:docmd=\"http://www.fcla.edu/docmd\">");
-
-    generateElement(ident, "docmd:PageCount", pagesCount);
-    generateElement(ident, "docmd:CharacterCount", charsCount);
-    generateElement(ident, "docmd:Language", language);
-    for (String f : embeddedFonts)
-    {
-      output(ident, "<docmd:Font FontName=\"" + encodeContent(getNameFromPath(f)) + "\" isEmbedded=\"true\" />");
-    }
-    for (String f : refFonts)
-    {
-      output(ident, "<docmd:Font FontName=\"" + encodeContent(getNameFromPath(f)) + "\" isEmbedded=\"false\" />");
-    }
-    for (String r : references)
-    {
-      generateElement(ident, "docmd:Reference", encodeContent(r));
-    }
-    //if (hasEncryption) generateElement(ident, "docmd:Features", "hasEncryption");
-    //if (hasSignatures) generateElement(ident, "docmd:Features", "hasSignatures");
-    if (hasAudio)
-    {
-      generateElement(ident, "docmd:Features", "hasAudio");
-    }
-    if (hasVideo)
-    {
-      generateElement(ident, "docmd:Features", "hasVideo");
-    }
-    if (hasFixedLayout)
-    {
-      generateElement(ident, "docmd:Features", "hasFixedLayout");
-    }
-    if (hasScripts)
-    {
-      generateElement(ident, "docmd:Features", "hasScripts");
-    }
-
-    output(--ident, "</docmd:document>");
-  }
-
-  private void output(int ident, String value)
-  {
-    char[] spaces = new char[ident];
-    Arrays.fill(spaces, ' ');
-    out.print(spaces);
-    out.println(value);
-  }
-
-  private void generateElement(int ident, String name, String value)
-  {
-    if (value == null || value.trim().length() == 0)
-    {
-      return;
-    }
-    StringBuilder sb = new StringBuilder();
-    sb.append('<').append(name).append('>');
-    sb.append(encodeContent(value.trim()));
-    sb.append("</").append(name).append('>');
-    output(ident, sb.toString());
-  }
-
-  private void generateElement(int ident, String name, long value)
-  {
-    if (value == 0)
-    {
-      return;
-    }
-    generateElement(ident, name, Long.toString(value));
-  }
-
+  @SuppressWarnings("unchecked")
   private void generateProperty(int ident, String name, String[] value, String type)
   {
     if (value == null || value.length == 0)
     {
       return;
     }
-    StringBuilder sb = new StringBuilder();
-    sb.append("<property><name>").append(name).append("</name>");
-    sb.append("<values arity=\"").append(value.length == 1 ? "Scalar" : "Array").append("\" type=\"").append(type).append("\">");
+	startElement(ident++, "property");
+    generateElement(ident, "name", name);
+    startElement(ident++, "values", KeyValue.with("arity", value.length == 1 ? "Scalar" : "Array"), KeyValue.with("type", type));
     for (String v : value)
     {
-      sb.append("<value>").append(encodeContent(v)).append("</value>");
+      generateElement(ident, "value", v);
     }
-    sb.append("</values></property>");
-    output(ident, sb.toString());
+    endElement(--ident, "values");
+    endElement(--ident, "property");
   }
 
+  @SuppressWarnings("unchecked")
   private void generateProperty(int ident, String name, String value, String type)
   {
     if (value == null || value.trim().length() == 0)
     {
       return;
     }
-    StringBuilder sb = new StringBuilder();
-    sb.append("<property><name>").append(name).append("</name><values arity=\"Scalar\" type=\"").append(type).append("\">");
-    sb.append("<value>").append(encodeContent(value)).append("</value>");
-    sb.append("</values></property>");
-    output(ident, sb.toString());
+	startElement(ident++, "property");
+    generateElement(ident, "name", name);
+    startElement(ident++, "values", KeyValue.with("arity", "Scalar"), KeyValue.with("type", type));
+    generateElement(ident, "value", value);
+    endElement(--ident, "values");
+    endElement(--ident, "property");
   }
 
   private void generateProperty(int ident, String name, long value)
@@ -533,50 +302,4 @@ public class XmlReportImpl extends MasterReport
     generateProperty(ident, name, value ? "true" : "false", "Boolean");
   }
 
-  /**
-   * Encodes a content String in XML-clean form, converting characters
-   * to entities as necessary.  The null string will be
-   * converted to an empty string.
-   */
-  private static String encodeContent(String content)
-  {
-    if (content == null)
-    {
-      content = "";
-    }
-    StringBuilder buffer = new StringBuilder(content);
-
-    int n = 0;
-    while ((n = buffer.indexOf("&", n)) > -1)
-    {
-      buffer.insert(n + 1, "amp;");
-      n += 5;
-    }
-    n = 0;
-    while ((n = buffer.indexOf("<", n)) > -1)
-    {
-      buffer.replace(n, n + 1, "&lt;");
-      n += 4;
-    }
-    n = 0;
-    while ((n = buffer.indexOf(">", n)) > -1)
-    {
-      buffer.replace(n, n + 1, "&gt;");
-      n += 4;
-    }
-
-    return buffer.toString();
-  }
-
-  /**
-   * Transform time into ISO 8601 string.
-   */
-  private static String fromTime(final long time)
-  {
-    Date date = new Date(time);
-        // Waiting for Java 7: SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
-    String formatted = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
-        .format(date);
-    return formatted.substring(0, 22) + ":" + formatted.substring(22);
-  }
 }

--- a/src/main/java/com/adobe/epubcheck/util/XmpReportImpl.java
+++ b/src/main/java/com/adobe/epubcheck/util/XmpReportImpl.java
@@ -1,0 +1,247 @@
+package com.adobe.epubcheck.util;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.javatuples.KeyValue;
+
+import com.adobe.epubcheck.messages.MessageLocation;
+import com.adobe.epubcheck.reporting.CheckMessage;
+
+
+public class XmpReportImpl extends XmlReportAbstract
+{
+
+  public XmpReportImpl(File out, String ePubName, String versionEpubCheck)
+  {
+	  super(out, ePubName, versionEpubCheck);
+  }
+
+
+  @SuppressWarnings("unchecked")
+  public int generate()
+  {
+    int returnCode = 1;
+    out = null;
+    int ident = 0;
+    
+    generationDate = fromTime(System.currentTimeMillis());
+    try
+    {
+      out = new PrintWriter(outputFile, "UTF-8");
+      output(ident, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+	  startElement(ident++, "x:xmpmeta", 
+			  KeyValue.with("xmlns:x", "adobe:ns:meta/"), 
+			  KeyValue.with("x:xmptk", "Adobe XMP Core 5.1.0-jc003") 
+	  );
+	  startElement(ident++, "rdf:RDF", 
+			  KeyValue.with("xmlns:rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+	  );
+	  List<KeyValue<String, String>> attrs = new ArrayList<KeyValue<String, String>>();
+	  attrs.add(KeyValue.with("rdf:about", ""));
+	  attrs.add(KeyValue.with("xmlns:dc", "http://purl.org/dc/elements/1.1/"));
+	  attrs.add(KeyValue.with("xmlns:xmp", "http://ns.adobe.com/xap/1.0/"));
+	  attrs.add(KeyValue.with("xmlns:xmpTPg", "http://ns.adobe.com/xap/1.0/t/pg/"));
+	  attrs.add(KeyValue.with("stFnt", "http:ns.adobe.com/xap/1.0/sType/Font#")); 
+	  attrs.add(KeyValue.with("xmlns:cp", "http://schemas.openxmlformats.org/package/2006/metadata/core-properties/"));
+	  attrs.add(KeyValue.with("xmlns:extended-properties", "http://schemas.openxmlformats.org/officeDocument/2006/extended-properties/"));
+	  attrs.add(KeyValue.with("xmlns:premis", "http://www.loc.gov/premis/rdf/v1"));
+      if (formatName == null) {
+    	  attrs.add(KeyValue.with("dc:format", "application/octet-stream"));
+      } else {
+    	  if (formatVersion == null) {
+    		  attrs.add(KeyValue.with("dc:format", formatName));
+    	  } else {
+    		  attrs.add(KeyValue.with("dc:format", formatName + ";version=" + formatVersion));
+    	  }
+      }
+	  if (creationDate != null) {
+		  attrs.add(KeyValue.with("xmp:CreateDate", creationDate));
+	  }
+	  if (charsCount != 0) {
+		  attrs.add(KeyValue.with("extended-properties:Characters", Long.toString(charsCount)));
+	  }
+	  if (pagesCount != 0) {
+		  attrs.add(KeyValue.with("xmpTPg:NPage", Long.toString(pagesCount)));
+	  }
+	  if (publisher != null) {
+		  attrs.add(KeyValue.with("dc:publisher", publisher));
+	  }
+	  attrs.add(KeyValue.with("dc:identifier", identifier));
+	  if (language != null) {
+		  attrs.add(KeyValue.with("dc:language", language));
+	  }
+	  
+	  startElement(ident++, "rdf:Description", attrs);
+	  
+	  // DC
+	  if (!creators.isEmpty()) {
+		  startElement(ident++, "dc:creator");
+		  startElement(ident++, "rdf:Seq");
+		  for (String creator : creators) {
+			  generateElement(ident,  "rdf:li", creator);
+		  }
+		  endElement(--ident, "rdf:Seq");
+		  endElement(--ident, "dc:creator");
+	  }
+	  if (!titles.isEmpty()) {
+		  startElement(ident++, "dc:title");
+		  startElement(ident++, "rdf:Alt");
+		  boolean first = true;
+		  for (String title : titles) {
+			  if (first) { 
+				  output(ident, "<rdf:li xml:lang=\"x-default\">" + title + "</rdf:li>");
+				  first =false;
+			  } else {
+				  generateElement(ident,  "rdf:li", title);
+			  }
+		  }
+		  endElement(--ident, "rdf:Alt");
+		  endElement(--ident, "dc:title");
+	  }
+	  if (!subjects.isEmpty()) {
+		  startElement(ident++, "dc:subject");
+		  startElement(ident++, "rdf:Bag");
+		  for (String subject : subjects) {
+			  generateElement(ident,  "rdf:li", subject);
+		  }
+		  endElement(--ident, "rdf:Bag");
+		  endElement(--ident, "dc:subject");
+	  }
+	  
+	  // Fonts
+	  if (!embeddedFonts.isEmpty() || !refFonts.isEmpty()) {
+		  startElement(ident++, "xmpTPg:Font");
+		  startElement(ident++, "rdf:Bag"); 
+		  for (String font : embeddedFonts) {
+			  generateFont(ident, font);
+		  }
+		  for (String font : refFonts) {
+			  generateFont(ident, font);
+		  }
+		  endElement(--ident, "rdf:Bag");
+		  
+		  endElement(ident++, "xmpTPg:Font");
+	  }	  
+	  
+	  // Premis:event
+	  startElement(ident++, "premis:hasEvent");
+	  generateElement(ident, "premis:hasEventDateTime", generationDate);
+      output(ident, "<premis:hasEventType rdf:resource=\"http://id.loc.gov/vocabulary/preservation/eventType/val\" />");
+      if (fatalErrors.isEmpty() && errors.isEmpty()) {
+        generateElement(ident, "premis:hasEventDetail", "Well-formed");
+      } else {
+        generateElement(ident, "premis:hasEventDetail", "Not well-formed");
+      }
+      generateEventOutcome(ident, fatalErrors, "FATAL");
+      generateEventOutcome(ident, errors, "ERROR");
+      generateEventOutcome(ident, warns, "WARN");
+      generateEventOutcome(ident, hints, "HINT");
+
+	  startElement(ident++, "premis:hasEventRelatedAgent");
+      output(ident, "<premis:hasAgentType rdf:resource=\"http://id.loc.gov/vocabulary/preservation/agentType/sof\" />");
+      if (epubCheckVersion == null) {
+    	  generateElement(ident, "premis:hasAgentName", epubCheckName);
+      } else {
+    	  generateElement(ident, "premis:hasAgentName", epubCheckName + " " + epubCheckVersion);
+      }
+	  endElement(--ident, "premis:hasEventRelatedAgent");
+
+	  endElement(--ident, "premis:hasEvent");
+
+	  // Significant properties
+	  generateSignificantProperty(ident, "renditionLayout", hasFixedLayout?"fixed-layout":"reflowable");
+	  generateSignificantProperty(ident, "isScripted", Boolean.toString(hasScripts));
+	  generateSignificantProperty(ident, "hasEncryption", Boolean.toString(hasEncryption));
+	  generateSignificantProperty(ident, "hasAudio", Boolean.toString(hasAudio));
+	  generateSignificantProperty(ident, "hasVideo", Boolean.toString(hasVideo));
+	  generateSignificantProperty(ident, "hasSignatures", Boolean.toString(hasSignatures));
+	  int nRefs = 0;
+	  for (String ref : references) {
+		  nRefs++;
+		  if (nRefs > 50) {
+			  generateSignificantProperty(ident, "reference", "" + (references.size() - 50) + " more references");
+			  break;
+		  }
+		  generateSignificantProperty(ident, "reference", ref);
+	  }
+	  
+	  endElement(--ident, "rdf:Description");
+	  endElement(--ident, "rdf:RDF");
+	  endElement(--ident, "x:xmpmeta");
+
+	  returnCode = 0;
+    }
+    catch (FileNotFoundException e)
+    {
+      System.err.println("FileNotFound error: " + e.getMessage());
+      returnCode = 1;
+    }
+    catch (UnsupportedEncodingException e)
+    {
+      System.err.println("FileNotFound error: " + e.getMessage());
+      returnCode = 1;
+    }
+    catch (Exception e)
+    {
+      System.err.println("Exception encountered: " + e.getMessage());
+      returnCode = 1;
+    }
+    finally
+    {
+      if (out != null)
+      {
+        out.close();
+      }
+    }
+    return returnCode;
+  }
+
+  protected void generateFont(int ident, String font) {
+	String[] elFont = font.split(",");
+	  startElement(ident++,  "rdf:li");
+	  // stFnt:fontName, stFnt:fontType, stFnt:versionString, stFnt:composite, stFnt:fontFileName
+	  generateElement(ident, "stFnt:fontFamily", capitalize(elFont[0]));
+	  String fontFace = "";
+	  for (int i = 1; i < elFont.length; i++) {
+		  fontFace += capitalize(elFont[i]) + " ";
+	  }
+	  fontFace = fontFace.trim();
+	  if (fontFace.length() == 0) {
+		  generateElement(ident, "stFnt:fontFace", "Regular");
+	  } else {
+		  generateElement(ident, "stFnt:fontFace", fontFace);
+	  }
+	  endElement(--ident,  "rdf:li");
+  }
+
+  private void generateEventOutcome(int ident, List<CheckMessage> messages, String sev) {
+	  	for (CheckMessage c : messages) {
+			startElement(ident++, "premis:hasEventOutcomeInformation");
+			generateElement(ident, "premis:hasEventOutcome", c.getID() + ", " + sev + ", " + encodeContent(c.getMessage()));
+			for (MessageLocation ml : c.getLocations()) {
+				String loc = "";
+				if (ml.getLine() > 0 || ml.getColumn() > 0) {
+					loc = " (" + ml.getLine() + "-" + ml.getColumn() + ")";
+				}
+				startElement(ident++, "premis:hasEventOutcomeDetail");
+				generateElement(ident, "premis:hasEventOutcomeDetailNote", PathUtil.removeWorkingDirectory(ml.getFileName()) + loc);
+				endElement(--ident, "premis:hasEventOutcomeDetail");
+		    }
+			endElement(--ident, "premis:hasEventOutcomeInformation");
+		}
+  }
+  
+  private void generateSignificantProperty(int ident, String property, String value) {
+	  // Significant properties
+	  startElement(ident++, "premis:hasSignificantProperties");
+	  generateElement(ident, "premis:hasSignificantPropertiesType", property);
+	  generateElement(ident, "premis:hasSignificantPropertiesValue", value);
+	  endElement(--ident, "premis:hasSignificantProperties");
+
+  }
+}

--- a/src/main/resources/com/adobe/epubcheck/util/messages.properties
+++ b/src/main/resources/com/adobe/epubcheck/util/messages.properties
@@ -45,15 +45,18 @@ help_text = \
           --mode exp  // For expanded EPUB archives\n\
           \n\
           This tool also accepts the following options:\n\
-          --save 	         = saves the epub created from the expanded epub\n\
+          --save 	       = saves the epub created from the expanded epub\n\
           --out <file>     = output an assessment XML document file.\n\
+          --xmp <file>     = output an assessment XMP document file.\n\
           --json <file>    = output an assessment JSON document file\n\
           -m <file>        = same as --mode\n\
           -o <file>        = same as --out\n\
+          -x <file>        = same as --xmp\n\
           -j <file>        = same as --json\n\
           --failonwarnings[+|-] = By default, the tool returns a 1 if errors are found in the file or 0 if no errors\n\
           \                        are found.  Using --failonwarnings will cause the process to exit with a status of\n\
           \                        1 if either warnings or errors are present and 0 only when there are no errors or warnings.\n\
+          -q, --quiet      = no message on console, except errors, only in the output\n\
           -f, --fatal      = include only fatal errors in the output\n\
           -e, --error      = include only error and fatal severity messages in ouput\n\
           -w, --warn       = include fatal, error, and warn severity messages in output\n\

--- a/src/test/java/com/adobe/epubcheck/test/common.java
+++ b/src/test/java/com/adobe/epubcheck/test/common.java
@@ -155,7 +155,7 @@ public class common
     {
       System.err.println(Messages.get("there_were_errors"));
       ex.printStackTrace();
-      Assert.assertTrue("Error performing the json comparison: ", false);
+      Assert.assertTrue("Error performing the xml comparison: ", false);
       return;
     }
     OutputDifferenceListener listener = new OutputDifferenceListener();

--- a/src/test/resources/com/adobe/epubcheck/test/DTBook/Basic_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/DTBook/Basic_expected_results.xml
@@ -7,17 +7,46 @@
   <version>2.0</version>
   <status>Well-formed</status>
   <messages>
-   <message>WARN: /OPS/AreYouReadyV3.xml(25): Use of non-registered URI scheme type in href: 'waka://barnesandnoble.com'.</message>
+   <message>OPF-021, WARN, [Use of non-registered URI scheme type in href: 'waka://barnesandnoble.com'.], OPS/AreYouReadyV3.xml (25-69)</message>
+   <message>HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>
-   <property><name>CharacterCount</name><values arity="Scalar" type="Long"><value>99</value></values></property>
-   <property><name>Language</name><values arity="Scalar" type="String"><value>en</value></values></property>
-   <property><name>Info</name><values arity="List" type="Property">
-    <property><name>Identifier</name><values arity="Scalar" type="String"><value>opf-70</value></values></property>
-    <property><name>CreationDate</name><values arity="Scalar" type="Date"><value>2014-07-14T16:31:12Z</value></values></property>
-    <property><name>Title</name><values arity="Scalar" type="String"><value>Epub2 marked as version 3</value></values></property>
-   </values></property>
+   <property>
+    <name>CharacterCount</name>
+    <values arity="Scalar" type="Long">
+     <value>99</value>
+    </values>
+   </property>
+   <property>
+    <name>Language</name>
+    <values arity="Scalar" type="String">
+     <value>en</value>
+    </values>
+   </property>
+   <property>
+    <name>Info</name>
+    <values arity="List" type="Property">
+     <property>
+      <name>Identifier</name>
+      <values arity="Scalar" type="String">
+       <value>000000000000000000</value>
+      </values>
+     </property>
+     <property>
+      <name>CreationDate</name>
+      <values arity="Scalar" type="Date">
+       <value>2014-07-14T16:31:12Z</value>
+      </values>
+     </property>
+     <property>
+      <name>Title</name>
+      <values arity="Scalar" type="String">
+       <value>Epub2 marked as version 3</value>
+      </values>
+     </property>
+    </values>
+   </property>
   </properties>
  </repInfo>
 </jhove>

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/xmlfile_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/xmlfile_expected_results.xml
@@ -8,21 +8,66 @@
   <version>3.0</version>
   <status>Well-formed</status>
   <messages>
-   <message>WARN: /OPS/inline_css.xhtml(14): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /OPS/inline_css.xhtml(10): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /OPS/inline_css.xhtml(15): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /OPS/inline_css.xhtml(11): Content file contains at least one inline style declaration.</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (14-116)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (10-119)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (15-114)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (11-115)</message>
+   <message>HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
+   <message>OPF-059, HINT, [Spine item has no NAV entry reference.], OPS/toc.ncx</message>
+   <message>OPF-059, HINT, [Spine item has no NAV entry reference.], OPS/toc.ncx</message>
+   <message>ACC-008, HINT, [Epub should have 1 landmarks nav element.], xmlfile.epub</message>
+   <message>CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style.css (3-23)</message>
+   <message>CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style.css (8-23)</message>
+   <message>CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style_tag_css.xhtml (8-31)</message>
+   <message>CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style_tag_css.xhtml (13-31)</message>
+   <message>CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style_tag_css.xhtml (5-28)</message>
+   <message>ACC-007, HINT, [Epub should use epub:type attributes.], OPS/external_css.xhtml</message>
+   <message>ACC-007, HINT, [Epub should use epub:type attributes.], OPS/style_tag_css.xhtml</message>
+   <message>ACC-007, HINT, [Epub should use epub:type attributes.], OPS/inline_css.xhtml</message>
   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>
-   <property><name>CharacterCount</name><values arity="Scalar" type="Long"><value>648</value></values></property>
-   <property><name>Language</name><values arity="Scalar" type="String"><value>en</value></values></property>
-   <property><name>Info</name><values arity="List" type="Property">
-    <property><name>Identifier</name><values arity="Scalar" type="String"><value>style</value></values></property>
-    <property><name>CreationDate</name><values arity="Scalar" type="Date"><value>2014-02-19T11:35:56Z</value></values></property>
-    <property><name>ModDate</name><values arity="Scalar" type="Date"><value>2012-10-10T12:00:00Z</value></values></property>
-    <property><name>Title</name><values arity="Scalar" type="String"><value>Transform Sample Book</value></values></property>
-   </values></property>
+   <property>
+    <name>CharacterCount</name>
+    <values arity="Scalar" type="Long">
+     <value>648</value>
+    </values>
+   </property>
+   <property>
+    <name>Language</name>
+    <values arity="Scalar" type="String">
+     <value>en</value>
+    </values>
+   </property>
+   <property>
+    <name>Info</name>
+    <values arity="List" type="Property">
+     <property>
+      <name>Identifier</name>
+      <values arity="Scalar" type="String">
+       <value>000000000000000000</value>
+      </values>
+     </property>
+     <property>
+      <name>CreationDate</name>
+      <values arity="Scalar" type="Date">
+       <value>2014-02-19T11:35:56Z</value>
+      </values>
+     </property>
+     <property>
+      <name>ModDate</name>
+      <values arity="Scalar" type="Date">
+       <value>2012-10-10T12:00:00Z</value>
+      </values>
+     </property>
+     <property>
+      <name>Title</name>
+      <values arity="Scalar" type="String">
+       <value>Transform Sample Book</value>
+      </values>
+     </property>
+    </values>
+   </property>
   </properties>
  </repInfo>
 </jhove>

--- a/src/test/resources/com/adobe/epubcheck/test/css/discouraged_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/css/discouraged_expected_results.xml
@@ -8,55 +8,124 @@
   <version>3.0</version>
   <status>Not well-formed</status>
   <messages>
-   <message>WARN: /OPS/style.css(2): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/style.css(7): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/style.css(7): CSS Selector font line-height attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/style.css(11): CSS Selector font shorthand specifies an invalid System Font.</message>
-   <message>WARN: /OPS/style.css(15): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/style.css(19): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/style.css(27): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/style.css(27): CSS Selector font line-height attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/style.css(35): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/style.css(39): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/style.css(70): CSS Selector specifies absolute position.</message>
-   <message>WARN: /OPS/style.css(90): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/style.css(99): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/unused.css(8): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/unused.css(14): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/unused.css(23): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/unused.css(32): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/unused.css(38): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/unused.css(51): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/unused.css(58): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/cssStyles.css(2): CSS Selector specifies absolute position.</message>
-   <message>WARN: /OPS/cssStyles.css(10): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/cssStyles.css(10): CSS Selector font line-height attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/cssStyles.css(27): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/cssStyles.css(35): CSS Selector font-size attribute value does not use a relative size.</message>
-   <message>WARN: /OPS/style_tag_css.xhtml(17): CSS Selector specifies absolute position.</message>
-   <message>WARN: /OPS/inline_css.xhtml(10): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /OPS/inline_css.xhtml(11): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /OPS/inline_css.xhtml(14): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /OPS/inline_css.xhtml(15): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /OPS/style_tag_css.xhtml(38): CSS position:fixed property is not allowed in ePub documents.</message>
-   <message>WARN: /OPS/inline_css.xhtml(15): CSS position:fixed property is not allowed in ePub documents.</message>
-   <message>WARN: /OPS/style.css(66): CSS position:fixed property is not allowed in ePub documents.</message>
-   <message>ERROR: /OPS/style_tag_css.xhtml(27): The 'unicode-bidi' property must not be included in an ePub Style Sheet.</message>
-   <message>ERROR: /OPS/inline_css.xhtml(14): The 'unicode-bidi' property must not be included in an ePub Style Sheet.</message>
-   <message>ERROR: /OPS/inline_css.xhtml(14): The 'direction' property must not be included in an ePub Style Sheet.</message>
-   <message>ERROR: /OPS/style.css(55): The 'unicode-bidi' property must not be included in an ePub Style Sheet.</message>
-   <message>ERROR: /OPS/style.css(56): The 'direction' property must not be included in an ePub Style Sheet.</message>
+   <message>CSS-001, ERROR, [The 'unicode-bidi' property must not be included in an ePub Style Sheet.], OPS/style_tag_css.xhtml (27-13)</message>
+   <message>CSS-001, ERROR, [The 'unicode-bidi' property must not be included in an ePub Style Sheet.], OPS/inline_css.xhtml (14-1)</message>
+   <message>CSS-001, ERROR, [The 'unicode-bidi' property must not be included in an ePub Style Sheet.], OPS/style.css (55-5)</message>
+   <message>CSS-001, ERROR, [The 'direction' property must not be included in an ePub Style Sheet.], OPS/inline_css.xhtml (14-22)</message>
+   <message>CSS-001, ERROR, [The 'direction' property must not be included in an ePub Style Sheet.], OPS/style.css (56-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/style.css (2-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/style.css (7-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/style.css (15-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/style.css (19-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/style.css (27-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/style.css (35-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/style.css (39-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/style.css (90-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/style.css (99-9)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/unused.css (8-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/unused.css (14-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/unused.css (23-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/unused.css (32-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/unused.css (38-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/unused.css (51-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/unused.css (58-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/cssStyles.css (10-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/cssStyles.css (27-5)</message>
+   <message>ACC-014, WARN, [CSS Selector font-size attribute value does not use a relative size.], OPS/cssStyles.css (35-9)</message>
+   <message>ACC-015, WARN, [CSS Selector font line-height attribute value does not use a relative size.], OPS/style.css (7-5)</message>
+   <message>ACC-015, WARN, [CSS Selector font line-height attribute value does not use a relative size.], OPS/style.css (27-5)</message>
+   <message>ACC-015, WARN, [CSS Selector font line-height attribute value does not use a relative size.], OPS/cssStyles.css (10-5)</message>
+   <message>CSS-021, WARN, [CSS Selector font shorthand specifies an invalid System Font.], OPS/style.css (11-5)</message>
+   <message>CSS-017, WARN, [CSS Selector specifies absolute position.], OPS/style.css (70-5)</message>
+   <message>CSS-017, WARN, [CSS Selector specifies absolute position.], OPS/cssStyles.css (2-5)</message>
+   <message>CSS-017, WARN, [CSS Selector specifies absolute position.], OPS/style_tag_css.xhtml (17-13)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (10-54)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (11-97)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (14-50)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (15-41)</message>
+   <message>CSS-006, WARN, [CSS position:fixed property is not allowed in ePub documents.], OPS/style_tag_css.xhtml (38-13)</message>
+   <message>CSS-006, WARN, [CSS position:fixed property is not allowed in ePub documents.], OPS/inline_css.xhtml (15-1)</message>
+   <message>CSS-006, WARN, [CSS position:fixed property is not allowed in ePub documents.], OPS/style.css (66-5)</message>
+   <message>HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
+   <message>OPF-059, HINT, [Spine item has no NAV entry reference.], OPS/toc.ncx</message>
+   <message>OPF-059, HINT, [Spine item has no NAV entry reference.], OPS/toc.ncx</message>
+   <message>CSS-012, HINT, [Document links to multiple CSS files.], OPS/external_css.xhtml (6-62)</message>
+   <message>CSS-012, HINT, [Document links to multiple CSS files.], OPS/external_css.xhtml (7-66)</message>
+   <message>ACC-008, HINT, [Epub should have 1 landmarks nav element.], discouraged.epub</message>
+   <message>CSS-013, HINT, [CSS Selector attribute is declared !Important.], OPS/style.css (79-5)</message>
+   <message>CSS-013, HINT, [CSS Selector attribute is declared !Important.], OPS/cssStyles.css (15-5)</message>
+   <message>CSS-013, HINT, [CSS Selector attribute is declared !Important.], OPS/style_tag_css.xhtml (9-13)</message>
+   <message>CSS-023, HINT, [CSS Selector specifies media query.], OPS/style.css (97-1)</message>
+   <message>CSS-023, HINT, [CSS Selector specifies media query.], OPS/cssStyles.css (33-1)</message>
+   <message>CSS-023, HINT, [CSS Selector specifies media query.], OPS/style_tag_css.xhtml (20-9)</message>
+   <message>CSS-025, HINT, [CSS class Selector is not found.], OPS/style_tag_css.xhtml (54-24)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/style_tag_css.xhtml (14-9)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (1-1)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (22-1)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (14-1)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (10-1)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (18-1)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (34-1)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (38-1)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (42-1)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (46-1)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (30-1)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (6-1)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (30-1)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (56-1)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (82-1)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (49-1)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (36-1)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (98-5)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (62-1)</message>
+   <message>CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (66-3)</message>
+   <message>ACC-007, HINT, [Epub should use epub:type attributes.], OPS/external_css.xhtml</message>
+   <message>ACC-007, HINT, [Epub should use epub:type attributes.], OPS/style_tag_css.xhtml</message>
+   <message>ACC-007, HINT, [Epub should use epub:type attributes.], OPS/inline_css.xhtml</message>
   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>
-   <property><name>CharacterCount</name><values arity="Scalar" type="Long"><value>4782</value></values></property>
-   <property><name>Language</name><values arity="Scalar" type="String"><value>en</value></values></property>
-   <property><name>Info</name><values arity="List" type="Property">
-    <property><name>Identifier</name><values arity="Scalar" type="String"><value>style3</value></values></property>
-    <property><name>CreationDate</name><values arity="Scalar" type="Date"><value>2014-07-14T16:31:12Z</value></values></property>
-    <property><name>ModDate</name><values arity="Scalar" type="Date"><value>2012-10-10T12:00:00Z</value></values></property>
-    <property><name>Title</name><values arity="Scalar" type="String"><value>Hyperlink Sample Book</value></values></property>
-   </values></property>
+   <property>
+    <name>CharacterCount</name>
+    <values arity="Scalar" type="Long">
+     <value>4782</value>
+    </values>
+   </property>
+   <property>
+    <name>Language</name>
+    <values arity="Scalar" type="String">
+     <value>en</value>
+    </values>
+   </property>
+   <property>
+    <name>Info</name>
+    <values arity="List" type="Property">
+     <property>
+      <name>Identifier</name>
+      <values arity="Scalar" type="String">
+       <value>000000000000000000</value>
+      </values>
+     </property>
+     <property>
+      <name>CreationDate</name>
+      <values arity="Scalar" type="Date">
+       <value>2014-07-14T16:31:12Z</value>
+      </values>
+     </property>
+     <property>
+      <name>ModDate</name>
+      <values arity="Scalar" type="Date">
+       <value>2012-10-10T12:00:00Z</value>
+      </values>
+     </property>
+     <property>
+      <name>Title</name>
+      <values arity="Scalar" type="String">
+       <value>Hyperlink Sample Book</value>
+      </values>
+     </property>
+    </values>
+   </property>
   </properties>
  </repInfo>
 </jhove>

--- a/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.xml
@@ -8,84 +8,324 @@
   <version>3.0</version>
   <status>Well-formed</status>
   <messages>
-   <message>WARN: /Css-fontface/pages/pg1.xhtml(23): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /Css-fontface/pages/pg1.xhtml(33): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /Css-fontface/pages/pg1.xhtml(11): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /Css-fontface/pages/pg1.xhtml(19): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /Css-fontface/pages/pg1.xhtml(15): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /Css-fontface/pages/pg2.xhtml(11): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /Css-fontface/pages/pg2.xhtml(35): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /Css-fontface/pages/pg2.xhtml(15): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /Css-fontface/pages/pg2.xhtml(19): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /Css-fontface/pages/pg2.xhtml(23): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /Css-fontface/pages/pg3.xhtml(11): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /Css-fontface/pages/pg3.xhtml(35): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /Css-fontface/pages/pg3.xhtml(15): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /Css-fontface/pages/pg3.xhtml(23): Content file contains at least one inline style declaration.</message>
-   <message>WARN: /Css-fontface/pages/pg3.xhtml(19): Content file contains at least one inline style declaration.</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (23-56)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (33-44)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (11-51)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (19-55)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (15-52)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (11-68)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (35-61)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (15-69)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (19-72)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (23-73)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (11-69)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (35-62)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (15-70)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (23-74)</message>
+   <message>ACC-013, WARN, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (19-73)</message>
+   <message>OPF-058, HINT, [Spine item has no TOC entry reference.], Css-fontface/pages/toc.xhtml</message>
+   <message>ACC-008, HINT, [Epub should have 1 landmarks nav element.], font_encryption_idpf.epub</message>
+   <message>ACC-007, HINT, [Epub should use epub:type attributes.], Css-fontface/pages/cover.xhtml</message>
+   <message>ACC-007, HINT, [Epub should use epub:type attributes.], Css-fontface/pages/pg1.xhtml</message>
+   <message>ACC-007, HINT, [Epub should use epub:type attributes.], Css-fontface/pages/pg2.xhtml</message>
+   <message>ACC-007, HINT, [Epub should use epub:type attributes.], Css-fontface/pages/pg3.xhtml</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (2-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (3-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (4-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (5-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (9-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (10-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (11-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (12-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (16-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (17-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (18-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (19-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (23-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (24-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (25-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (26-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (30-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (31-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (32-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (33-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (37-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (38-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (39-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (40-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (43-5)</message>
+   <message>CSS-028, HINT, [Use of Font-face declaration.], There are 23 additional locations for this message.</message>
   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>
-   <property><name>CharacterCount</name><values arity="Scalar" type="Long"><value>2904</value></values></property>
-   <property><name>Language</name><values arity="Scalar" type="String"><value>en-US</value></values></property>
-   <property><name>Info</name><values arity="List" type="Property">
-    <property><name>Identifier</name><values arity="Scalar" type="String"><value>encryption</value></values></property>
-    <property><name>CreationDate</name><values arity="Scalar" type="Date"><value>2014-07-14T16:31:12Z</value></values></property>
-    <property><name>ModDate</name><values arity="Scalar" type="Date"><value>2012-01-20T12:47:00Z</value></values></property>
-    <property><name>Title</name><values arity="Scalar" type="String"><value>External CSS @fontface Test</value></values></property>
-    <property><name>Publisher</name><values arity="Scalar" type="String"><value>Epub3 Team</value></values></property>
-   </values></property>
-   <property><name>Fonts</name><values arity="List" type="Property">
-    <property><name>Font</name><values arity="List" type="Property">
-     <property><name>FontName</name><values arity="Scalar" type="String"><value>OS-obf-otf</value></values></property>
-     <property><name>FontFile</name><values arity="Scalar" type="Boolean"><value>true</value></values></property>
-    </values></property>
-    <property><name>Font</name><values arity="List" type="Property">
-     <property><name>FontName</name><values arity="Scalar" type="String"><value>OS-obf-otf,bold</value></values></property>
-     <property><name>FontFile</name><values arity="Scalar" type="Boolean"><value>true</value></values></property>
-    </values></property>
-    <property><name>Font</name><values arity="List" type="Property">
-     <property><name>FontName</name><values arity="Scalar" type="String"><value>OS-obf-otf,italic</value></values></property>
-     <property><name>FontFile</name><values arity="Scalar" type="Boolean"><value>true</value></values></property>
-    </values></property>
-    <property><name>Font</name><values arity="List" type="Property">
-     <property><name>FontName</name><values arity="Scalar" type="String"><value>OS-woff</value></values></property>
-     <property><name>FontFile</name><values arity="Scalar" type="Boolean"><value>true</value></values></property>
-    </values></property>
-    <property><name>Font</name><values arity="List" type="Property">
-     <property><name>FontName</name><values arity="Scalar" type="String"><value>OS-woff,bold</value></values></property>
-     <property><name>FontFile</name><values arity="Scalar" type="Boolean"><value>true</value></values></property>
-    </values></property>
-    <property><name>Font</name><values arity="List" type="Property">
-     <property><name>FontName</name><values arity="Scalar" type="String"><value>OS-woff,italic</value></values></property>
-     <property><name>FontFile</name><values arity="Scalar" type="Boolean"><value>true</value></values></property>
-    </values></property>
-    <property><name>Font</name><values arity="List" type="Property">
-     <property><name>FontName</name><values arity="Scalar" type="String"><value>OS-obf-woff</value></values></property>
-     <property><name>FontFile</name><values arity="Scalar" type="Boolean"><value>true</value></values></property>
-    </values></property>
-    <property><name>Font</name><values arity="List" type="Property">
-     <property><name>FontName</name><values arity="Scalar" type="String"><value>OS-obf-woff,bold</value></values></property>
-     <property><name>FontFile</name><values arity="Scalar" type="Boolean"><value>true</value></values></property>
-    </values></property>
-    <property><name>Font</name><values arity="List" type="Property">
-     <property><name>FontName</name><values arity="Scalar" type="String"><value>OS-obf-woff,italic</value></values></property>
-     <property><name>FontFile</name><values arity="Scalar" type="Boolean"><value>true</value></values></property>
-    </values></property>
-    <property><name>Font</name><values arity="List" type="Property">
-     <property><name>FontName</name><values arity="Scalar" type="String"><value>OS-otf</value></values></property>
-     <property><name>FontFile</name><values arity="Scalar" type="Boolean"><value>true</value></values></property>
-    </values></property>
-    <property><name>Font</name><values arity="List" type="Property">
-     <property><name>FontName</name><values arity="Scalar" type="String"><value>OS-otf,bold</value></values></property>
-     <property><name>FontFile</name><values arity="Scalar" type="Boolean"><value>true</value></values></property>
-    </values></property>
-    <property><name>Font</name><values arity="List" type="Property">
-     <property><name>FontName</name><values arity="Scalar" type="String"><value>OS-otf,italic</value></values></property>
-     <property><name>FontFile</name><values arity="Scalar" type="Boolean"><value>true</value></values></property>
-    </values></property>
-   </values></property>
-   <property><name>hasEncryption</name><values arity="Scalar" type="Boolean"><value>true</value></values></property>
+   <property>
+    <name>CharacterCount</name>
+    <values arity="Scalar" type="Long">
+     <value>2904</value>
+    </values>
+   </property>
+   <property>
+    <name>Language</name>
+    <values arity="Scalar" type="String">
+     <value>en-US</value>
+    </values>
+   </property>
+   <property>
+    <name>Info</name>
+    <values arity="List" type="Property">
+     <property>
+      <name>Identifier</name>
+      <values arity="Scalar" type="String">
+       <value>epub3.test</value>
+      </values>
+     </property>
+     <property>
+      <name>CreationDate</name>
+      <values arity="Scalar" type="Date">
+       <value>2014-07-14T16:31:12Z</value>
+      </values>
+     </property>
+     <property>
+      <name>ModDate</name>
+      <values arity="Scalar" type="Date">
+       <value>2012-01-20T12:47:00Z</value>
+      </values>
+     </property>
+     <property>
+      <name>Title</name>
+      <values arity="Scalar" type="String">
+       <value>External CSS @fontface Test</value>
+      </values>
+     </property>
+     <property>
+      <name>Creator</name>
+      <values arity="Scalar" type="String">
+       <value>David</value>
+      </values>
+     </property>
+     <property>
+      <name>Publisher</name>
+      <values arity="Scalar" type="String">
+       <value>Epub3 Team</value>
+      </values>
+     </property>
+    </values>
+   </property>
+   <property>
+    <name>Fonts</name>
+    <values arity="List" type="Property">
+     <property>
+      <name>Font</name>
+      <values arity="List" type="Property">
+       <property>
+        <name>FontName</name>
+        <values arity="Scalar" type="String">
+         <value>OS-obf-otf</value>
+        </values>
+       </property>
+       <property>
+        <name>FontFile</name>
+        <values arity="Scalar" type="Boolean">
+         <value>false</value>
+        </values>
+       </property>
+      </values>
+     </property>
+     <property>
+      <name>Font</name>
+      <values arity="List" type="Property">
+       <property>
+        <name>FontName</name>
+        <values arity="Scalar" type="String">
+         <value>OS-obf-otf,bold</value>
+        </values>
+       </property>
+       <property>
+        <name>FontFile</name>
+        <values arity="Scalar" type="Boolean">
+         <value>false</value>
+        </values>
+       </property>
+      </values>
+     </property>
+     <property>
+      <name>Font</name>
+      <values arity="List" type="Property">
+       <property>
+        <name>FontName</name>
+        <values arity="Scalar" type="String">
+         <value>OS-obf-otf,italic</value>
+        </values>
+       </property>
+       <property>
+        <name>FontFile</name>
+        <values arity="Scalar" type="Boolean">
+         <value>false</value>
+        </values>
+       </property>
+      </values>
+     </property>
+     <property>
+      <name>Font</name>
+      <values arity="List" type="Property">
+       <property>
+        <name>FontName</name>
+        <values arity="Scalar" type="String">
+         <value>OS-woff</value>
+        </values>
+       </property>
+       <property>
+        <name>FontFile</name>
+        <values arity="Scalar" type="Boolean">
+         <value>false</value>
+        </values>
+       </property>
+      </values>
+     </property>
+     <property>
+      <name>Font</name>
+      <values arity="List" type="Property">
+       <property>
+        <name>FontName</name>
+        <values arity="Scalar" type="String">
+         <value>OS-woff,bold</value>
+        </values>
+       </property>
+       <property>
+        <name>FontFile</name>
+        <values arity="Scalar" type="Boolean">
+         <value>false</value>
+        </values>
+       </property>
+      </values>
+     </property>
+     <property>
+      <name>Font</name>
+      <values arity="List" type="Property">
+       <property>
+        <name>FontName</name>
+        <values arity="Scalar" type="String">
+         <value>OS-woff,italic</value>
+        </values>
+       </property>
+       <property>
+        <name>FontFile</name>
+        <values arity="Scalar" type="Boolean">
+         <value>false</value>
+        </values>
+       </property>
+      </values>
+     </property>
+     <property>
+      <name>Font</name>
+      <values arity="List" type="Property">
+       <property>
+        <name>FontName</name>
+        <values arity="Scalar" type="String">
+         <value>OS-obf-woff</value>
+        </values>
+       </property>
+       <property>
+        <name>FontFile</name>
+        <values arity="Scalar" type="Boolean">
+         <value>false</value>
+        </values>
+       </property>
+      </values>
+     </property>
+     <property>
+      <name>Font</name>
+      <values arity="List" type="Property">
+       <property>
+        <name>FontName</name>
+        <values arity="Scalar" type="String">
+         <value>OS-obf-woff,bold</value>
+        </values>
+       </property>
+       <property>
+        <name>FontFile</name>
+        <values arity="Scalar" type="Boolean">
+         <value>false</value>
+        </values>
+       </property>
+      </values>
+     </property>
+     <property>
+      <name>Font</name>
+      <values arity="List" type="Property">
+       <property>
+        <name>FontName</name>
+        <values arity="Scalar" type="String">
+         <value>OS-obf-woff,italic</value>
+        </values>
+       </property>
+       <property>
+        <name>FontFile</name>
+        <values arity="Scalar" type="Boolean">
+         <value>false</value>
+        </values>
+       </property>
+      </values>
+     </property>
+     <property>
+      <name>Font</name>
+      <values arity="List" type="Property">
+       <property>
+        <name>FontName</name>
+        <values arity="Scalar" type="String">
+         <value>OS-otf</value>
+        </values>
+       </property>
+       <property>
+        <name>FontFile</name>
+        <values arity="Scalar" type="Boolean">
+         <value>false</value>
+        </values>
+       </property>
+      </values>
+     </property>
+     <property>
+      <name>Font</name>
+      <values arity="List" type="Property">
+       <property>
+        <name>FontName</name>
+        <values arity="Scalar" type="String">
+         <value>OS-otf,bold</value>
+        </values>
+       </property>
+       <property>
+        <name>FontFile</name>
+        <values arity="Scalar" type="Boolean">
+         <value>false</value>
+        </values>
+       </property>
+      </values>
+     </property>
+     <property>
+      <name>Font</name>
+      <values arity="List" type="Property">
+       <property>
+        <name>FontName</name>
+        <values arity="Scalar" type="String">
+         <value>OS-otf,italic</value>
+        </values>
+       </property>
+       <property>
+        <name>FontFile</name>
+        <values arity="Scalar" type="Boolean">
+         <value>false</value>
+        </values>
+       </property>
+      </values>
+     </property>
+    </values>
+   </property>
+   <property>
+    <name>hasEncryption</name>
+    <values arity="Scalar" type="Boolean">
+     <value>true</value>
+    </values>
+   </property>
   </properties>
  </repInfo>
 </jhove>

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Epub2_marked_v3_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Epub2_marked_v3_expected_results.xml
@@ -7,22 +7,53 @@
   <version>3.0</version>
   <status>Not well-formed</status>
   <messages>
-   <message>WARN: /page01.xhtml: HTML4 DOCTYPE definition within ePub v3.</message>
-   <message>ERROR: /OPS/content.opf(3): Error while parsing file 'assertion failed:
-  package dcterms:modified meta element must occur exactly once'.</message>
-   <message>ERROR: /OPS/content.opf(8): Error while parsing file 'assertion failed:
-  Exactly one manifest item must declare the 'nav' property (number of 'nav' items: 0).'.</message>
-   <message>ERROR: /OPS/page01.xhtml: Irregular DOCTYPE: found '-//W3C//DTD XHTML 1.1//EN', expected '&amp;lt;!DOCTYPE html&amp;gt;'.</message>
+   <message>RSC-005, ERROR, [Error while parsing file 'assertion failed:
+  package dcterms:modified meta element must occur exactly once'.], OPS/content.opf (3-57)</message>
+   <message>RSC-005, ERROR, [Error while parsing file 'assertion failed:
+  Exactly one manifest item must declare the 'nav' property (number of 'nav' items: 0).'.], OPS/content.opf (8-13)</message>
+   <message>HTM-004, ERROR, [Irregular DOCTYPE: found '-//W3C//DTD XHTML 1.1//EN', expected '&amp;lt;!DOCTYPE html&amp;gt;'.], OPS/page01.xhtml</message>
+   <message>HTM-015, WARN, [HTML4 DOCTYPE definition within ePub v3.], page01.xhtml</message>
+   <message>HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
+   <message>ACC-008, HINT, [Epub should have 1 landmarks nav element.], Epub2_marked_v3.epub</message>
+   <message>ACC-007, HINT, [Epub should use epub:type attributes.], OPS/page01.xhtml</message>
   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>
-   <property><name>CharacterCount</name><values arity="Scalar" type="Long"><value>73</value></values></property>
-   <property><name>Language</name><values arity="Scalar" type="String"><value>en</value></values></property>
-   <property><name>Info</name><values arity="List" type="Property">
-    <property><name>Identifier</name><values arity="Scalar" type="String"><value>page01</value></values></property>
-    <property><name>CreationDate</name><values arity="Scalar" type="Date"><value>2014-07-14T16:31:12Z</value></values></property>
-    <property><name>Title</name><values arity="Scalar" type="String"><value>Epub2 marked as version 3</value></values></property>
-   </values></property>
+   <property>
+    <name>CharacterCount</name>
+    <values arity="Scalar" type="Long">
+     <value>73</value>
+    </values>
+   </property>
+   <property>
+    <name>Language</name>
+    <values arity="Scalar" type="String">
+     <value>en</value>
+    </values>
+   </property>
+   <property>
+    <name>Info</name>
+    <values arity="List" type="Property">
+     <property>
+      <name>Identifier</name>
+      <values arity="Scalar" type="String">
+       <value>000000000000000000</value>
+      </values>
+     </property>
+     <property>
+      <name>CreationDate</name>
+      <values arity="Scalar" type="Date">
+       <value>2014-07-14T16:31:12Z</value>
+      </values>
+     </property>
+     <property>
+      <name>Title</name>
+      <values arity="Scalar" type="String">
+       <value>Epub2 marked as version 3</value>
+      </values>
+     </property>
+    </values>
+   </property>
   </properties>
  </repInfo>
 </jhove>

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Epub3_marked_v2_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Epub3_marked_v2_expected_results.xml
@@ -8,23 +8,57 @@
   <version>2.0</version>
   <status>Not well-formed</status>
   <messages>
-   <message>WARN: /toc.xhtml: HTML5 DOCTYPE definition within ePub v2.</message>
-   <message>ERROR: /OPS/content.opf(7): Error while parsing file 'attribute "property" not allowed here; expected attribute "content", "id", "name", "scheme" or "xml:lang"'.</message>
-   <message>ERROR: /OPS/content.opf(7): Error while parsing file 'element "meta" missing required attributes "content" and "name"'.</message>
-   <message>ERROR: /OPS/content.opf(7): Error while parsing file 'text not allowed here; expected the element end-tag'.</message>
-   <message>ERROR: /OPS/content.opf(12): Error while parsing file 'attribute "properties" not allowed here; expected attribute "fallback", "fallback-style", "href", "media-type", "required-modules" or "required-namespace"'.</message>
-   <message>ERROR: /OPS/toc.xhtml: The nav file is not supported for ePub v2.</message>
+   <message>RSC-005, ERROR, [Error while parsing file 'attribute "property" not allowed here; expected attribute "content", "id", "name", "scheme" or "xml:lang"'.], OPS/content.opf (7-39)</message>
+   <message>RSC-005, ERROR, [Error while parsing file 'element "meta" missing required attributes "content" and "name"'.], OPS/content.opf (7-39)</message>
+   <message>RSC-005, ERROR, [Error while parsing file 'text not allowed here; expected the element end-tag'.], OPS/content.opf (7-61)</message>
+   <message>RSC-005, ERROR, [Error while parsing file 'attribute "properties" not allowed here; expected attribute "fallback", "fallback-style", "href", "media-type", "required-modules" or "required-namespace"'.], OPS/content.opf (12-90)</message>
+   <message>NAV-001, ERROR, [The nav file is not supported for ePub v2.], OPS/toc.xhtml</message>
+   <message>HTM-016, WARN, [HTML5 DOCTYPE definition within ePub v2.], toc.xhtml</message>
+   <message>HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>
-   <property><name>CharacterCount</name><values arity="Scalar" type="Long"><value>223</value></values></property>
-   <property><name>Language</name><values arity="Scalar" type="String"><value>en</value></values></property>
-   <property><name>Info</name><values arity="List" type="Property">
-    <property><name>Identifier</name><values arity="Scalar" type="String"><value>toc</value></values></property>
-    <property><name>CreationDate</name><values arity="Scalar" type="Date"><value>2014-07-14T16:31:12Z</value></values></property>
-    <property><name>ModDate</name><values arity="Scalar" type="Date"><value>2012-10-10T12:00:00Z</value></values></property>
-    <property><name>Title</name><values arity="Scalar" type="String"><value>Missing TOC Sample Book</value></values></property>
-   </values></property>
+   <property>
+    <name>CharacterCount</name>
+    <values arity="Scalar" type="Long">
+     <value>223</value>
+    </values>
+   </property>
+   <property>
+    <name>Language</name>
+    <values arity="Scalar" type="String">
+     <value>en</value>
+    </values>
+   </property>
+   <property>
+    <name>Info</name>
+    <values arity="List" type="Property">
+     <property>
+      <name>Identifier</name>
+      <values arity="Scalar" type="String">
+       <value>000000000000000000</value>
+      </values>
+     </property>
+     <property>
+      <name>CreationDate</name>
+      <values arity="Scalar" type="Date">
+       <value>2014-07-14T16:31:12Z</value>
+      </values>
+     </property>
+     <property>
+      <name>ModDate</name>
+      <values arity="Scalar" type="Date">
+       <value>2012-10-10T12:00:00Z</value>
+      </values>
+     </property>
+     <property>
+      <name>Title</name>
+      <values arity="Scalar" type="String">
+       <value>Missing TOC Sample Book</value>
+      </values>
+     </property>
+    </values>
+   </property>
   </properties>
  </repInfo>
 </jhove>

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Missing_Spine_epub3_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Missing_Spine_epub3_expected_results.xml
@@ -8,20 +8,55 @@
   <version>3.0</version>
   <status>Not well-formed</status>
   <messages>
-   <message>FATAL: /OPS/content.opf: Spine tag was not found in the OPF file.</message>
-   <message>WARN: /OPS/toc.xhtml(11): Found a reference to a resource that is not a spine item.</message>
-   <message>ERROR: /OPS/content.opf(13): Error while parsing file 'element "package" incomplete; missing required element "spine"'.</message>
+   <message>OPF-019, FATAL, [Spine tag was not found in the OPF file.], OPS/content.opf</message>
+   <message>RSC-005, ERROR, [Error while parsing file 'element "package" incomplete; missing required element "spine"'.], OPS/content.opf (13-11)</message>
+   <message>RSC-011, WARN, [Found a reference to a resource that is not a spine item.], OPS/toc.xhtml (11-36)</message>
+   <message>ACC-008, HINT, [Epub should have 1 landmarks nav element.], Missing_Spine_epub3.epub</message>
+   <message>ACC-007, HINT, [Epub should use epub:type attributes.], OPS/page01.xhtml</message>
   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>
-   <property><name>CharacterCount</name><values arity="Scalar" type="Long"><value>175</value></values></property>
-   <property><name>Language</name><values arity="Scalar" type="String"><value>en</value></values></property>
-   <property><name>Info</name><values arity="List" type="Property">
-    <property><name>Identifier</name><values arity="Scalar" type="String"><value>toc</value></values></property>
-    <property><name>CreationDate</name><values arity="Scalar" type="Date"><value>2014-07-14T16:31:12Z</value></values></property>
-    <property><name>ModDate</name><values arity="Scalar" type="Date"><value>2012-10-10T12:00:00Z</value></values></property>
-    <property><name>Title</name><values arity="Scalar" type="String"><value>Missing Spine Sample Book</value></values></property>
-   </values></property>
+   <property>
+    <name>CharacterCount</name>
+    <values arity="Scalar" type="Long">
+     <value>175</value>
+    </values>
+   </property>
+   <property>
+    <name>Language</name>
+    <values arity="Scalar" type="String">
+     <value>en</value>
+    </values>
+   </property>
+   <property>
+    <name>Info</name>
+    <values arity="List" type="Property">
+     <property>
+      <name>Identifier</name>
+      <values arity="Scalar" type="String">
+       <value>000000000000000000</value>
+      </values>
+     </property>
+     <property>
+      <name>CreationDate</name>
+      <values arity="Scalar" type="Date">
+       <value>2014-07-14T16:31:12Z</value>
+      </values>
+     </property>
+     <property>
+      <name>ModDate</name>
+      <values arity="Scalar" type="Date">
+       <value>2012-10-10T12:00:00Z</value>
+      </values>
+     </property>
+     <property>
+      <name>Title</name>
+      <values arity="Scalar" type="String">
+       <value>Missing Spine Sample Book</value>
+      </values>
+     </property>
+    </values>
+   </property>
   </properties>
  </repInfo>
 </jhove>

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Publication_Metadata_epub3_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Publication_Metadata_epub3_expected_results.xml
@@ -7,22 +7,107 @@
   <format>application/epub+zip</format>
   <version>3.0</version>
   <status>Well-formed</status>
+  <messages>
+   <message>HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
+   <message>ACC-008, HINT, [Epub should have 1 landmarks nav element.], Publication_Metadata_epub3.epub</message>
+   <message>ACC-007, HINT, [Epub should use epub:type attributes.], OPS/page01.xhtml</message>
+  </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>
-   <property><name>CharacterCount</name><values arity="Scalar" type="Long"><value>155</value></values></property>
-   <property><name>Language</name><values arity="Scalar" type="String"><value>en</value></values></property>
-   <property><name>Info</name><values arity="List" type="Property">
-    <property><name>Identifier</name><values arity="Scalar" type="String"><value>toc</value></values></property>
-    <property><name>CreationDate</name><values arity="Scalar" type="Date"><value>2014-07-14T16:31:12Z</value></values></property>
-    <property><name>ModDate</name><values arity="Scalar" type="Date"><value>2013-01-30T12:00:00Z</value></values></property>
-    <property><name>Title</name><values arity="Scalar" type="String"><value>Publication Metadata Sample</value></values></property>
-    <property><name>Publisher</name><values arity="Scalar" type="String"><value>Barnes &amp; Noble Inc.</value></values></property>
-   </values></property>
-   <property><name>References</name><values arity="List" type="Property">
-    <property><name>Reference</name><values arity="Scalar" type="String"><value>http://example.org/xmp/#12389347</value></values></property>
-    <property><name>Reference</name><values arity="Scalar" type="String"><value>http://example.org/book-info/#12389347</value></values></property>
-    <property><name>Reference</name><values arity="Scalar" type="String"><value>wakawaka://example.org/book-info/#12389347</value></values></property>
-   </values></property>
+   <property>
+    <name>CharacterCount</name>
+    <values arity="Scalar" type="Long">
+     <value>155</value>
+    </values>
+   </property>
+   <property>
+    <name>Language</name>
+    <values arity="Scalar" type="String">
+     <value>en</value>
+    </values>
+   </property>
+   <property>
+    <name>Info</name>
+    <values arity="List" type="Property">
+     <property>
+      <name>Identifier</name>
+      <values arity="Scalar" type="String">
+       <value>urn:uuid:1234-5678</value>
+      </values>
+     </property>
+     <property>
+      <name>CreationDate</name>
+      <values arity="Scalar" type="Date">
+       <value>2014-07-14T16:31:12Z</value>
+      </values>
+     </property>
+     <property>
+      <name>ModDate</name>
+      <values arity="Scalar" type="Date">
+       <value>2013-01-30T12:00:00Z</value>
+      </values>
+     </property>
+     <property>
+      <name>Title</name>
+      <values arity="Scalar" type="String">
+       <value>Publication Metadata Sample</value>
+      </values>
+     </property>
+     <property>
+      <name>Creator</name>
+      <values arity="Array" type="String">
+       <value>John Doe</value>
+       <value>Jane Doe</value>
+      </values>
+     </property>
+     <property>
+      <name>Publisher</name>
+      <values arity="Scalar" type="String">
+       <value>Barnes &amp; Noble Inc.</value>
+      </values>
+     </property>
+     <property>
+      <name>Subject</name>
+      <values arity="Array" type="String">
+       <value>EPUB</value>
+       <value>Reading Systems</value>
+       <value>OPF</value>
+       <value>OCF</value>
+       <value>OPS</value>
+       <value>Sample eBooks</value>
+      </values>
+     </property>
+     <property>
+      <name>Rights</name>
+      <values arity="Scalar" type="String">
+       <value>Copyright 2013 Barnes &amp; Noble Inc. All rights reserved.</value>
+      </values>
+     </property>
+    </values>
+   </property>
+   <property>
+    <name>References</name>
+     <values arity="List" type="Property">
+      <property>
+       <name>Reference</name>
+       <values arity="Scalar" type="String">
+        <value>http://example.org/xmp/#12389347</value>
+       </values>
+      </property>
+      <property>
+       <name>Reference</name>
+       <values arity="Scalar" type="String">
+        <value>http://example.org/book-info/#12389347</value>
+       </values>
+      </property>
+      <property>
+       <name>Reference</name>
+       <values arity="Scalar" type="String">
+        <value>wakawaka://example.org/book-info/#12389347</value>
+       </values>
+      </property>
+     </values>
+    </property>
   </properties>
  </repInfo>
 </jhove>

--- a/src/test/resources/com/adobe/epubcheck/test/package/interesting_paths_epub2_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/package/interesting_paths_epub2_expected_results.xml
@@ -7,20 +7,49 @@
   <version>2.0</version>
   <status>Well-formed</status>
   <messages>
-   <message>WARN: /OPS Content/More XHTML Content/page01.xhtml: Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.</message>
-   <message>WARN: /OPS Content/content.opf: Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.</message>
-   <message>WARN: /XHTML Content/page02.xhtml: Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.</message>
-   <message>WARN: /OPS Content/toc.ncx: Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.</message>
+   <message>PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/More XHTML Content/page01.xhtml</message>
+   <message>PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/content.opf</message>
+   <message>PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], XHTML Content/page02.xhtml</message>
+   <message>PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/toc.ncx</message>
+   <message>HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS Content/toc.ncx (2-68)</message>
   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>
-   <property><name>CharacterCount</name><values arity="Scalar" type="Long"><value>193</value></values></property>
-   <property><name>Language</name><values arity="Scalar" type="String"><value>en</value></values></property>
-   <property><name>Info</name><values arity="List" type="Property">
-    <property><name>Identifier</name><values arity="Scalar" type="String"><value>page02</value></values></property>
-    <property><name>CreationDate</name><values arity="Scalar" type="Date"><value>2014-07-14T16:31:12Z</value></values></property>
-    <property><name>Title</name><values arity="Scalar" type="String"><value>Epub2 with interesting paths</value></values></property>
-   </values></property>
+   <property>
+    <name>CharacterCount</name>
+    <values arity="Scalar" type="Long">
+     <value>193</value>
+    </values>
+   </property>
+   <property>
+    <name>Language</name>
+    <values arity="Scalar" type="String">
+     <value>en</value>
+    </values>
+   </property>
+   <property>
+    <name>Info</name>
+    <values arity="List" type="Property">
+     <property>
+      <name>Identifier</name>
+      <values arity="Scalar" type="String">
+       <value>000000000000000000</value>
+      </values>
+     </property>
+     <property>
+      <name>CreationDate</name>
+      <values arity="Scalar" type="Date">
+       <value>2014-07-14T16:31:12Z</value>
+      </values>
+     </property>
+     <property>
+      <name>Title</name>
+      <values arity="Scalar" type="String">
+       <value>Epub2 with interesting paths</value>
+      </values>
+     </property>
+    </values>
+   </property>
   </properties>
  </repInfo>
 </jhove>

--- a/src/test/resources/com/adobe/epubcheck/test/package/interesting_paths_epub3_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/package/interesting_paths_epub3_expected_results.xml
@@ -8,39 +8,71 @@
   <version>3.0</version>
   <status>Not well-formed</status>
   <messages>
-   <message>WARN: /OPS Content/More XHTML Content/page01.xhtml: Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.</message>
-   <message>WARN: /OPS Content/toc.xhtml: Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.</message>
-   <message>WARN: /OPS Content/page{03}.xhtml: Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.</message>
-   <message>WARN: /interesting_paths_epub3.epub: Item 'OPS Content/Cyrillic_phi.xhtml' exists in the ePub, but is not declared in the OPF manifest.</message>
-   <message>WARN: /OPS Content/Cyrillic_phi.xhtml: Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.</message>
-   <message>WARN: /OPS Content/content.opf: Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.</message>
-   <message>WARN: /OPS Content/toc.ncx: Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.</message>
-   <message>WARN: /XHTML Content/page 02.xhtml: Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.</message>
-   <message>ERROR: /interesting_paths_epub3.epub: File 'OPS Content/Cyrillic_phi.html' is not found.</message>
-   <message>ERROR: /interesting_paths_epub3.epub: File 'OPS Content/Cyrillic_phi.html' is not found.</message>
-   <message>ERROR: /interesting_paths_epub3.epub: File 'OPS Content/Cyrillic_phi.html' is not found.</message>
-   <message>ERROR: /interesting_paths_epub3.epub: File 'OPS Content/Cyrillic_phi.html' is not found.</message>
-   <message>ERROR: /interesting_paths_epub3.epub: File 'OPS Content/style.' is not found.</message>
-   <message>ERROR: /interesting_paths_epub3.epub: File 'OPS Content/Cyrillic_phi.html' is not found.</message>
-   <message>ERROR: /interesting_paths_epub3.epub: File 'OPS Content/Cyrillic_phi.html' is not found.</message>
-   <message>ERROR: /interesting_paths_epub3.epub: File 'OPS Content/Cyrillic_phi.html' is not found.</message>
-   <message>ERROR: /interesting_paths_epub3.epub: File 'OPS Content/Cyrillic_phi.html' is not found.</message>
-   <message>ERROR: /interesting_paths_epub3.epub: File 'OPS Content/Cyrillic_phi.html' is not found.</message>
-   <message>ERROR: /interesting_paths_epub3.epub: File 'OPS Content/Cyrillic_phi.html' is not found.</message>
-   <message>ERROR: /interesting_paths_epub3.epub: File 'OPS Content/style.' is not found.</message>
-   <message>ERROR: /OPS Content/More XHTML Content/page01.xhtml(13): Referenced resource is not found in the ePub.</message>
-   <message>ERROR: /OPS Content/page{03}.xhtml: File name contains characters that are not allowed in OCF file names: '"{","}"'.</message>
+   <message>RSC-001, ERROR, [File 'OPS Content/Cyrillic_phi.html' is not found.], interesting_paths_epub3.epub</message>
+   <message>RSC-001, ERROR, [File 'OPS Content/style.' is not found.], interesting_paths_epub3.epub</message>
+   <message>RSC-007, ERROR, [Referenced resource is not found in the ePub.], OPS Content/More XHTML Content/page01.xhtml (13-35)</message>
+   <message>PKG-009, ERROR, [File name contains characters that are not allowed in OCF file names: '"{","}"'.], OPS Content/page{03}.xhtml</message>
+   <message>PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/More XHTML Content/page01.xhtml</message>
+   <message>PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/toc.xhtml</message>
+   <message>PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/page{03}.xhtml</message>
+   <message>PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/Cyrillic_phi.xhtml</message>
+   <message>PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/content.opf</message>
+   <message>PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], XHTML Content/page 02.xhtml</message>
+   <message>PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/toc.ncx</message>
+   <message>OPF-003, WARN, [Item 'OPS Content/Cyrillic_phi.xhtml' exists in the ePub, but is not declared in the OPF manifest.], interesting_paths_epub3.epub</message>
+   <message>OPF-058, HINT, [Spine item has no TOC entry reference.], OPS Content/toc.xhtml</message>
+   <message>OPF-058, HINT, [Spine item has no TOC entry reference.], OPS Content/toc.xhtml</message>
+   <message>HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS Content/toc.ncx (2-68)</message>
+   <message>OPF-059, HINT, [Spine item has no NAV entry reference.], OPS Content/toc.ncx</message>
+   <message>OPF-059, HINT, [Spine item has no NAV entry reference.], OPS Content/toc.ncx</message>
+   <message>ACC-008, HINT, [Epub should have 1 landmarks nav element.], interesting_paths_epub3.epub</message>
+   <message>ACC-007, HINT, [Epub should use epub:type attributes.], OPS Content/More XHTML Content/page01.xhtml</message>
+   <message>ACC-007, HINT, [Epub should use epub:type attributes.], XHTML Content/page 02.xhtml</message>
+   <message>ACC-007, HINT, [Epub should use epub:type attributes.], OPS Content/page{03}.xhtml</message>
   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>
-   <property><name>CharacterCount</name><values arity="Scalar" type="Long"><value>386</value></values></property>
-   <property><name>Language</name><values arity="Scalar" type="String"><value>en</value></values></property>
-   <property><name>Info</name><values arity="List" type="Property">
-    <property><name>Identifier</name><values arity="Scalar" type="String"><value>style</value></values></property>
-    <property><name>CreationDate</name><values arity="Scalar" type="Date"><value>2014-07-14T16:31:12Z</value></values></property>
-    <property><name>ModDate</name><values arity="Scalar" type="Date"><value>2012-10-10T12:00:00Z</value></values></property>
-    <property><name>Title</name><values arity="Scalar" type="String"><value>Interesting Paths Sample Book</value></values></property>
-   </values></property>
+   <property>
+    <name>CharacterCount</name>
+    <values arity="Scalar" type="Long">
+     <value>386</value>
+    </values>
+   </property>
+   <property>
+    <name>Language</name>
+    <values arity="Scalar" type="String">
+     <value>en</value>
+    </values>
+   </property>
+   <property>
+    <name>Info</name>
+    <values arity="List" type="Property">
+     <property>
+      <name>Identifier</name>
+      <values arity="Scalar" type="String">
+       <value>000000000000000000</value>
+      </values>
+     </property>
+     <property>
+      <name>CreationDate</name>
+      <values arity="Scalar" type="Date">
+       <value>2014-07-14T16:31:12Z</value>
+      </values>
+     </property>
+     <property>
+      <name>ModDate</name>
+      <values arity="Scalar" type="Date">
+       <value>2012-10-10T12:00:00Z</value>
+      </values>
+     </property>
+     <property>
+      <name>Title</name>
+      <values arity="Scalar" type="String">
+       <value>Interesting Paths Sample Book</value>
+      </values>
+     </property>
+    </values>
+   </property>
   </properties>
  </repInfo>
 </jhove>


### PR DESCRIPTION
Right injection of builddate in TOOL_DATE, fixes issue #397
Generation of subjects, rights and creators
Use of CheckMessage to group the errors
Add a XMP output to give a standardized output
Extracts real identifier of epub
Modified the unit tests accordingly
Limit to 1g the memory for the tests
