### PR TITLE
Set a tag format for maven-release-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,9 @@
                         <version>1.8.1</version>
                     </dependency>
                 </dependencies>
+                <configuration>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Tells the `maven-release-plugin` that git tags should have the form `vVersion`
