### PR TITLE
Add support for "staging" EDUPUB vocab

### DIFF
--- a/src/main/java/com/adobe/epubcheck/nav/NavChecker.java
+++ b/src/main/java/com/adobe/epubcheck/nav/NavChecker.java
@@ -24,6 +24,7 @@ package com.adobe.epubcheck.nav;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Set;
 
 import com.adobe.epubcheck.api.Report;
 import com.adobe.epubcheck.messages.MessageId;
@@ -38,6 +39,7 @@ import com.adobe.epubcheck.util.GenericResourceProvider;
 import com.adobe.epubcheck.xml.XMLHandler;
 import com.adobe.epubcheck.xml.XMLParser;
 import com.adobe.epubcheck.xml.XMLValidators;
+import com.google.common.collect.ImmutableSet;
 
 public class NavChecker implements ContentChecker, DocumentValidator
 {
@@ -49,6 +51,7 @@ public class NavChecker implements ContentChecker, DocumentValidator
   private final String mimeType;
   private final EPUBVersion version;
   private final GenericResourceProvider resourceProvider;
+  private final Set<String> pubTypes;
 
   public NavChecker(GenericResourceProvider resourceProvider, Report report,
       String path, String mimeType, EPUBVersion version)
@@ -63,10 +66,11 @@ public class NavChecker implements ContentChecker, DocumentValidator
     this.properties = "singleFileValidation";
     this.mimeType = mimeType;
     this.version = version;
+    this.pubTypes = ImmutableSet.of();
   }
 
   public NavChecker(OCFPackage ocf, Report report, String path,
-      String mimeType, String properties, XRefChecker xrefChecker, EPUBVersion version)
+      String mimeType, String properties, XRefChecker xrefChecker, EPUBVersion version, Set<String> pubTypes)
   {
     if (version == EPUBVersion.VERSION_2)
     {
@@ -80,6 +84,7 @@ public class NavChecker implements ContentChecker, DocumentValidator
     this.properties = properties;
     this.mimeType = mimeType;
     this.version = version;
+    this.pubTypes = pubTypes;
   }
 
   public void runChecks()
@@ -111,7 +116,7 @@ public class NavChecker implements ContentChecker, DocumentValidator
           "application/xhtml+xml", report, version);
 
       XMLHandler navHandler = new OPSHandler30(ocf, path, mimeType,
-          properties, xrefChecker, navParser, report, version);
+          properties, xrefChecker, navParser, report, version, pubTypes);
       navParser.addXMLHandler(navHandler);
       navParser.addValidator(XMLValidators.NAV_30_RNC.get());
       navParser.addValidator(XMLValidators.XHTML_30_SCH.get());

--- a/src/main/java/com/adobe/epubcheck/nav/NavCheckerFactory.java
+++ b/src/main/java/com/adobe/epubcheck/nav/NavCheckerFactory.java
@@ -42,7 +42,7 @@ public class NavCheckerFactory implements ContentCheckerFactory, DocumentValidat
       String path, String mimeType, String properties,
       XRefChecker xrefChecker, EPUBVersion version, Set<String> types)
   {
-    return new NavChecker(ocf, report, path, mimeType, properties, xrefChecker, version);
+    return new NavChecker(ocf, report, path, mimeType, properties, xrefChecker, version, types);
   }
 
   static public NavCheckerFactory getInstance()

--- a/src/main/java/com/adobe/epubcheck/ops/OPSChecker.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSChecker.java
@@ -175,7 +175,7 @@ public class OPSChecker implements ContentChecker, DocumentValidator
       else
       {
         opsHandler = new OPSHandler30(ocf, path, mimeType, properties,
-            xrefChecker, opsParser, report, version);
+            xrefChecker, opsParser, report, version, pubTypes);
       }
 
       opsParser.addXMLHandler(opsHandler);

--- a/src/main/java/com/adobe/epubcheck/vocab/AggregateVocab.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/AggregateVocab.java
@@ -1,0 +1,34 @@
+package com.adobe.epubcheck.vocab;
+
+import java.util.List;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+
+public class AggregateVocab implements Vocab
+{
+
+  private final List<Vocab> vocabs;
+
+  public static Vocab of(Vocab... vocabs)
+  {
+    return new AggregateVocab(new ImmutableList.Builder<Vocab>().add(vocabs).build());
+  }
+
+  private AggregateVocab(List<Vocab> vocabs)
+  {
+    this.vocabs = vocabs;
+  }
+
+  @Override
+  public Optional<Property> lookup(String name)
+  {
+    for (Vocab vocab : vocabs)
+    {
+      Optional<Property> found = vocab.lookup(name);
+      if (found.isPresent()) return found;
+    }
+    return Optional.absent();
+  }
+
+}

--- a/src/main/java/com/adobe/epubcheck/vocab/StagingEdupubVocab.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/StagingEdupubVocab.java
@@ -1,0 +1,54 @@
+package com.adobe.epubcheck.vocab;
+
+public class StagingEdupubVocab
+{
+  public static final String URI = "http://www.idpf.org/epub/vocab/structure/#";
+  public static final Vocab VOCAB = new EnumVocab(EPUB_TYPES.class, URI);
+
+  public static enum EPUB_TYPES
+  {
+    ABSTRACT,
+    ANSWER,
+    ANSWERS,
+    ASSESSMENTS,
+    BIBLIOREF,
+    CREDIT,
+    CREDITS,
+    FEEDBACK,
+    FILL_IN_THE_BLANK_PROBLEM,
+    GENERAL_PROBLEM,
+    GLOSSREF,
+    INDEX_EDITOR_NOTE,
+    INDEX_ENTRY,
+    INDEX_ENTRY_LIST,
+    INDEX_GROUP,
+    INDEX_HEADNOTES,
+    INDEX_LEGEND,
+    INDEX_LOCATOR,
+    INDEX_LOCATOR_LIST,
+    INDEX_LOCATOR_RANGE,
+    INDEX_TERM,
+    INDEX_TERM_CATEGORIES,
+    INDEX_TERM_CATEGORY,
+    INDEX_XREF_PREFERRED,
+    INDEX_XREF_RELATED,
+    KEYWORD,
+    LABEL,
+    LEARNING_OBJECTIVES,
+    LEARNING_OUTCOME,
+    LEARNING_OUTCOMES,
+    LEARNING_RESOURCES,
+    LEARNING_STANDARD,
+    LEARNING_STANDARDS,
+    MATCH_PROBLEM,
+    MULTIPLE_CHOICE_PROBLEM,
+    ORDINAL,
+    PRACTICE,
+    PRACTICES,
+    PULLQUOTE,
+    QUESTION,
+    REFERRER,
+    TOC_BRIEF,
+    TRUE_FALSE_PROBLEM;
+  }
+}


### PR DESCRIPTION
@mattgarrish  says:

> I think we have to make it so an EDUPUB file can fully validate -- including draft terms -- otherwise people will get frustrated. Getting them to build the draft terms in is too complicated.
> [however] I’m worried about dropping all the terms in as though they’re already valid.

This PR implements the following:
- EDUPUB “specific” terms are defined as a new vocab in `EdupubStagingVocab.java`
- This latter vocab is aggregated with the default SSV when checking Content Docs if the publication has the type `edupub`

@mattgarrish can you confirm this works as expected ?
