### PR TITLE
Move the rendition vocab from default to reserved

### DIFF
--- a/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
@@ -330,8 +330,8 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   public void testValidateEPUB30_CSSURLS_2()
   {
     List<MessageId> expectedErrors = new ArrayList<MessageId>();
-    Collections.addAll(expectedErrors, MessageId.OPF_027);
     List<MessageId> expectedWarnings = new ArrayList<MessageId>();
+    Collections.addAll(expectedErrors, MessageId.OPF_027);
     //'imgs/table_header_bg_uni.jpg': referenced resource missing in the package
     testValidateDocument("invalid/lorem-css-urls-2/", expectedErrors, expectedWarnings);
   }

--- a/src/test/java/com/adobe/epubcheck/opf/OPFCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/opf/OPFCheckerTest.java
@@ -465,7 +465,7 @@ public class OPFCheckerTest
   @Test
   public void testValidateRedeclaredReservedPrefixes()
   {
-    Collections.addAll(expectedErrors, MessageId.OPF_007b);
+    Collections.addAll(expectedErrors, MessageId.OPF_007b, MessageId.OPF_007b);
     Collections.addAll(expectedWarnings, MessageId.OPF_007, MessageId.OPF_007);
     // should generate 2 warnings (redeclaration of reserved prefixes) and 1 error (redeclaration of default vocab)
     testValidateDocument("invalid/prefixes-redeclare.opf", expectedErrors, expectedWarnings, EPUBVersion.VERSION_3);
@@ -605,6 +605,13 @@ public class OPFCheckerTest
   {
     expectedErrors.add(MessageId.RSC_005);
     testValidateDocument("invalid/meta-collection-type-refines-noncollection.opf", expectedErrors, expectedWarnings, expectedFatalErrors,
+        EPUBVersion.VERSION_3);
+  }
+  
+  @Test
+  public void testRenditionPropertiesValid()
+  {
+    testValidateDocument("valid/rendition-properties.opf", expectedErrors, expectedWarnings, expectedFatalErrors,
         EPUBVersion.VERSION_3);
   }
   

--- a/src/test/resources/30/single/opf/invalid/prefixes-redeclare.opf
+++ b/src/test/resources/30/single/opf/invalid/prefixes-redeclare.opf
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
-		prefix="media: http://forbidden/to/redeclare
-				dcterms: http://forbidden/to/redeclare/too
-				foo: http://www.idpf.org/vocab/rendition/#">
+		prefix="media: http://should/not/redeclare
+		        rendition: http://should/not/redeclare/too
+		        foo: http://idpf.org/epub/vocab/package/#
+		        bar: http://idpf.org/epub/vocab/package/link/#">
 				
 	<!-- redeclaring 2 reserved prefixes -->			
 				

--- a/src/test/resources/30/single/opf/valid/rendition-properties.opf
+++ b/src/test/resources/30/single/opf/valid/rendition-properties.opf
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="BOGUS" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Missing TOC Sample Book</dc:title>
+    <dc:language>en</dc:language>
+    <dc:identifier id="BOGUS">000000000000000000</dc:identifier>
+    <meta property="dcterms:modified">2012-10-10T12:00:00Z</meta>
+    <meta property="rendition:layout">pre-paginated</meta>
+    <meta property="rendition:orientation">landscape</meta>
+    <meta property="rendition:spread">landscape</meta>
+  </metadata>
+  <manifest>
+    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
+    <item id="toc" properties="nav" href="toc.xhtml" media-type="application/xhtml+xml"/>
+    <item id="page01" href="page01.xhtml" media-type="application/xhtml+xml" />
+    <item id="page02" href="page02.xhtml" media-type="application/xhtml+xml" />
+    <item id="page03" href="page03.xhtml" media-type="application/xhtml+xml" />
+  </manifest>
+  <spine toc="ncx">
+    <itemref idref="page01" properties="rendition:orientation-auto"/>
+    <itemref idref="page02" properties="rendition:layout-reflowable"/>
+    <itemref idref="page03" properties="rendition:spread-both"/>
+  </spine>
+</package>


### PR DESCRIPTION
Fixes #437
- the 'rendition' prefix is still reserved and predefined
- the 'rendition' prefix is allowed to be redeclared explicitly
  (with a `WARNING`)
- the Rendition vocab URI may be associated to another prefix (with a
  `WARNING`)

Take the opportunity to better separate the vocabs computed for each
"class" of properties (`meta` & `scheme`, `item`, `itemref`, `link`).
