### PR TITLE
German translation

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_de.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_de.properties
@@ -1,0 +1,282 @@
+# This is the German translation of MessageBundle.properties file
+# Translation by Tobias Fischer (https://github.com/tofi86)
+
+#Accessibility
+ACC_001=Einem 'img' oder 'area' HTML-Element fehlt das 'alt'-Attribut.
+ACC_002=Ein 'input' HTML-Element wird von keinem zugehörigen 'label'-Element referenziert.
+ACC_003=HTML-Elemente ohne Text-Inhalt sollten ein 'title'-Attribut für bessere Barrierefreiheit besitzen.
+ACC_004=Ein 'a'-Element darf nicht leer sein.
+ACC_005=Tabellenkopfzellen sollten für bessere Barrierefreiheit mit 'th'-Elementen ausgezeichnet werden.
+ACC_006=Tabellen sollten für bessere Barrierefreiheit ein 'thead'-Element besitzen.
+ACC_007=Das Dokument nutzt keine 'epub:type'-Attribute für semantische Auszeichnung.
+ACC_008=Die Navigationsdatei enthält kein 'landmarks nav'-Element.
+ACC_009=MathML sollte entweder ein 'alt'-Attribut besitzen oder ein 'annotation-xml'-Kindelement.
+ACC_010=Überschriften sollten nicht innerhalb von 'blockquote' oder 'figure'-Elementen benutzt werden.
+ACC_011=Link-Elemente innerhalb von SVG sollten ein 'xlink:title'-Attribut besitzen.
+ACC_012=Tabellen sollten ein 'caption'-Element besitzen.
+ACC_013=Die Datei enthält mindestens eine Inline-CSS-Deklaration.
+ACC_013_SUG=Inline-Styles sind nicht kompatibel mit Einstellungen für Barrierefreiheit und benutzerspezifische Display-Anpassungen. Stattdessen sollten CSS-Klassen verwendet werden.
+ACC_014=Wert der CSS-Eigenschaft 'font-size' ist keine relative Größenangabe.
+ACC_014_SUG=Erlaubte Werte sind Prozentangaben, 'em'-Werte, 'larger', 'smaller', 'normal' oder 'inherit'.
+ACC_015=Wert der CSS-Eigenschaft 'line-height' ist keine relative Größenangabe.
+ACC_015_SUG=Erlaubte Werte sind Prozentangaben, Zahlen, 'larger', 'smaller', 'normal' oder 'inherit'.
+ACC_016=CSS-Eigenschaft 'font-size' sollte in einer relativen Größe angegeben werden.
+ACC_016_SUG=Erlaubte Werte sind Prozentangaben, 'em'-Werte, 'larger', 'smaller', 'normal' oder 'inherit'.
+ACC_017=Wert der CSS-Eigenschaft 'line-height' ist keine relative Größenangabe.
+ACC_017_SUG=Erlaubte Werte sind Prozentangaben, Zahlen, 'larger', 'smaller', 'normal' oder 'inherit'.
+
+#Checker Errors
+CHK_001=Die benutzerspezifische Datei zum Überschreiben von Warnungen und Fehlermeldungen wurde nicht gefunden.
+CHK_002=Unbekannte benutzerdefinierte Message-ID '%1$s' in Datei zum Überschreiben von Warnungen und Fehlermeldungen '%2$s'.
+CHK_003=Unbekannter benutzerdefinierter Fehlerlevel '%1$s' in Datei zum Überschreiben von Warnungen und Fehlermeldungen '%2$s'.
+CHK_004=Die benutzerdefinierte Meldung enthält zu viele Parameter in der Datei zum Überschreiben von Warnungen und Fehlermeldungen '%1$s'.
+CHK_005=Der benutzerdefinierte Vorschlag enthält zu viele Parameter in der Datei zum Überschreiben von Warnungen und Fehlermeldungen '%1$s'.
+CHK_006=Der benutzerdefinierte Formatierungs-Parameter ist ungültig in der Datei zum Überschreiben von Warnungen und Fehlermeldungen '%1$s'.
+CHK_007=Fehler beim Einlesen der Datei zum Überschreiben von Warnungen und Fehlermeldungen '%1$s': %2$s
+
+#CSS
+CSS_001=Die CSS-Eigenschaft '%1$s' darf im EPUB nicht verwendet werden!
+CSS_002=Leere oder Keine Referenz gefunden.
+CSS_003=Es sind nur UTF-8 und UTF-16 Zeichenkodierungen erlaubt, die Datei ist aber '%1$s' kodiert.
+CSS_004=Es sind nur UTF-8 und UTF-16 Zeichenkodierungen erlaubt, die Datei ist aber '%1$s' kodiert (mit 'Byte Order Mark').
+CSS_005=Unverträgliche Style-Eigenschaften gefunden: '%1$s'
+CSS_006=CSS-Eigenschaft 'position:fixed' sollte in EPUBs nicht verwendet werden.
+CSS_007=Die 'font-face' Deklaration '%1$s' referenziert einen nicht-standardisierten Schriftentyp: '%2$s'
+CSS_008=CSS-Validierungsfehler: %1$s
+CSS_009=Die Verwendung spezieller CSS-Eigenschaften wie etwa Columns, Transforms, Transitions, box-sizing oder KeyFrames kann Fehler bei der Paginierung erzeugen!
+CSS_010=Es wird ein Stylesheet genutzt das nicht den Standards entspricht.
+CSS_011=Zu viele CSS-Dateien!
+CSS_011_SUG=Denke darüber nach, einige CSS-Dateien zusammenzufassen um die Anzahl der Dateien zu verringern.
+CSS_012=Im Dokument sind zu viele CSS-Dateien referenziert!
+CSS_013=CSS-Eigenschaft wurde mit '!important' markiert.
+CSS_015=Alternatives Stylesheet hat keinen Titel!
+CSS_016=Alternatives Stylesheet wird vor dem Haupt-Stylesheet aufgerufen!
+CSS_017=CSS-Selektor enthält Anweisungen zu absoluter Positionierung.
+CSS_019=CSS-Deklaration 'font-face' enthält keine Anweisungen!
+CSS_020=CSS-Eigenschaft enthält unerwartete Schriftgröße '%1$s'.
+CSS_020_SUG=Erlaubte Werte sind Prozentangaben, 'em'-Werte, 'larger', 'smaller', 'normal' oder 'inherit'.
+CSS_021=CSS-Eigenschaft referenziert eine ungültige Systemschrift!
+CSS_021_SUG=Erlaubte Werte sind 'caption', 'icon', 'menu', 'message-box', 'small-caption',  'status-bar' oder 'inherit'.
+CSS_022=CSS-Selektor enthält globale 'margin'-Anweisungen.
+CSS_023=CSS-Selektor deklariert eine MediaQuery.
+CSS_024=CSS-Klasse wird nicht verwendet.
+CSS_024_SUG=Entferne unbenutzte CSS-Selektoren/-Klassen.
+CSS_025=CSS-Klasse wurde nicht gefunden.
+CSS_025_SUG=Überprüfe die Angabe der CSS-Klasse auf Schreibfehler oder definiere einen neuen Klassen-Selektor im CSS.
+CSS_027=CSS-Selektor enthält Anweisungen zu absoluter Positionierung.
+CSS_028=Eine 'font-face'-Deklaration wird genutzt.
+
+#HTM - XHTML related messages
+HTM_001=Jede EPUB-Ressource mit XML-basiertem MIME-Type muss ein valides XML 1.0 Dokument sein. Gefundene XML-Version: '%1$s'
+HTM_002=Der installierte XML-Parser unterstützt die Verifikation von XML-Versionen nicht. XML-Dateien müssen valide XML 1.0 Dokumente sein.
+HTM_003=Externe Entity-Deklaration gefunden: '%1$s'. Externe Entities sind in EPUB 3 Dokumenten jedoch nicht erlaubt!
+HTM_004=Ungültiger DOCTYPE '%1$s'. Erwartet wird '%2$s'
+HTM_005=Eine externe Referenz wurde gefunden.
+HTM_006=Ein benanntes XHTML-Entity wurde gefunden.
+HTM_007=Leeres Attribut 'ssml:ph'.
+HTM_008=Das 'src'-Attribut ist verpflichtend!
+HTM_009=Der angegebene DOCTYPE ist veraltet oder ungültig und kann entfernt werden.
+HTM_010=Namespace-URI '%1$s' wurde gefunden.
+HTM_011=Entity ist nicht deklariert!
+HTM_011_SUG=Deklariere das benannte Entity oder nutze die nummerische Variante.
+HTM_012=CFI-Link zu einem externen Buch gefunden.
+HTM_013=Interner CFI-Link wurde in diesem Dokument gefunden.
+HTM_014=Ungültige Dateiendung für HTML-Dateien. Erwartet wird 'html', 'htm' oder 'xhtml'.
+HTM_014a=Die XHTML-Datei '%1$s' sollte die Endung '.xhtml' tragen.
+HTM_015=HTML4 DOCTYPE innerhalb eines EPUB 3.
+HTM_016=HTML5 DOCTYPE innerhalb eines EPUB 2.
+HTM_017=Datei hat verschiedene Sprachangaben in den Attributen 'xml:lang' und 'lang'.
+HTM_018=Datei enthält ungültige Sprachangabe im Attribut 'xml:lang'.
+HTM_019=Datei enthält ungültige Sprachangabe im Attribut 'lang'.
+HTM_020=Datei enthält das 'xml:lang'-Attribut nicht!
+HTM_021=Datei enthält das 'lang'-Attribut nicht!
+HTM_022=Datei enthält offenbar zu viele 'div' oder 'span'-Elemente.
+HTM_022_SUG=Denke darüber nach, 'div' oder 'span'-Elemente zusammenzufassen wenn sie aufeinanderfolgen und das gleiche Aussehen haben.
+HTM_023=Ein ungültiges benanntes XHTML-Entity wurde gefunden: '%1$s'.
+HTM_023_SUG=Prüfe die Schreibweise oder nutze die nummerische Variante.
+HTM_024=Ein benanntes XHTML-Entity wurde gefunden. Erlaubt sind nur '&amp;' '&apos;' '&quote;' '&lt;' und '&gt;'.
+HTM_024_SUG=Prüfe die Schreibweise oder nutze die nummerische Variante.
+HTM_025=Nicht-definiertes URI-Schema im 'href'-Attribut gefunden.
+HTM_027=Liste enthält weniger als 2 Listeneinträge.
+HTM_027_SUG=Listen sollten mehr als einen Listeneintrag besitzen.
+HTM_028='input'-Elemente sollten ein 'id'-Attribut besitzen.
+HTM_029='label'-Elemente sollten ein 'for'-Attribut besitzen und damit die ID des zugehörigen 'input'-Elements referenzieren.
+HTM_033=Das 'head'-Element besitzt kein 'title'-Kindelement!
+HTM_036=Von der Nutzung von IFrames wird stark abgeraten!
+HTM_038=Stelle sicher, dass die Elemente 'b', 'i', 'em' und 'strong' auch korrekt nach den W3C HTML5 Richtlinien eingesetzt werden.
+HTM_038_SUG=Normalerweise sind CSS-Stile der bessere Weg um Text zu fetten oder zu kursivieren.
+HTM_043=SVG-Elemente sollten die Attribute 'xml:lang' und 'lang' besitzen.
+HTM_044=Namespace-URI '%1$s' ist deklariert, wird aber nicht genutzt. 
+HTM_044_SUG=Entferne ungenutzte Namespaces.
+HTM_045=Leeres 'href'-Attribut gefunden!
+HTM_045_SUG=Leere 'href'-Attribute sind gültige Selbst-Referenzen. Bitte prüfe, ob das so gewollt ist.
+HTM_046=FixedLayout-Dokument ohne 'viewport'-Deklaration!
+HTM_046_SUG=Diese ist erforderlich für FixedLayout-Dokumente.
+HTM_047=Der HTML-'viewport'-Angabe fehlt die Breiten oder Höhenangabe.
+HTM_047_SUG=Die 'viewport'-Deklaration muss 'width' und 'height' enhalten.
+HTM_048=Die SVG-'ViewBox'-Angabe fehlt für das FixedLayout-Dokument.
+HTM_048_SUG=Diese ist erforderlich für FixedLayout-Dokumente.
+HTM_049=Das 'html'-Element besitzt kein Namespace-Attribut 'xmlns' mit dem Wert 'http://www.w3.org/1999/xhtml'.
+HTM_049_SUG=Füge das Attribut am 'html'-Element hinzu: xmlns="http://www.w3.org/1999/xhtml".
+HTM_050=Das Attribut epub:type="pagebreak" wurde im Dokument gefunden.
+
+#media
+MED_001=Das Video-Standbild muss in einem vom OPF-Standard unterstützten Dateiformate für Bilder vorliegen!
+MED_002=Für das '%1$s'-Element ist kein Fallback definiert!
+MED_003=Bilder vom Typ '%1$s' sind laut OPF-Standard nicht erlaubt.
+MED_004=Der Datei-Header des Bildes scheint fehlerhaft zu sein.
+MED_005=Im MediaOverlay wurde eine Audio-Referenz '%1$s' zu einem nicht unterstützten Audio-MimeType '%2$s' gefunden.
+MED_006=Hinweis: Einige Browser unterstützen die Darstellung von SVG-Grafiken nicht, die einen Dateinamen im 'xlink:href'-Attribut verwenden.
+
+#NAV ePub v3 Table of contents
+NAV_001=Die Navigationsdatei wird von EPUB 2 nicht unterstützt.
+NAV_002=Attribut epub:type="page-list" in der Navigationsdatei gefunden.
+NAV_003=Es wurden sowohl Attribute epub:type="page-list" in der Navigationsdatei als auch Attribute epub:type="pagebreak" in Inhaltsdokumenten gefunden
+NAV_003_SUG=Mehrere Paginierungseinstellungen zu nutzen kann auf einigen Lesegeräten Probleme verursachen.
+
+#NCX ePub v2 Table of Contents
+NCX_001=NCX-Schematron-Tests konnten nicht ausgeführt werden: %1$s
+NCX_002=Das 'spine'-Element enthält kein 'toc'-Attribut!
+NCX_003=Eine NCX-Datei ist für die TOC-Navigation in EPUB 2-Dokumenten erforderlich.
+NCX_004=Das 'identifier'-Element im TOC muss mit dem 'unique-identifier'-Attribut am 'package'-Element der OPF-Datei übereinstimmen: '%1$s'
+NCX_005=NCX "page-list" in der .ncx-Datei gefunden
+NCX_006=Es wurde sowohl eine "page-list" in der .ncx-Datei als auch ein Adobe "page-map" Attribut am 'spine'-Element gefunden.
+NCX_006_SUG=Mehrere Paginierungseinstellungen zu nutzen kann auf einigen Lesegeräten Probleme verursachen.
+
+#OPF
+OPF_001=Fehler beim Parsen der EPUB-Version: %1$s
+OPF_002=Die OPF-Datei '%1$s' wurde nicht im EPUB gefunden.
+OPF_003=Die Datei '%1$s' ist im EPUB vorhanden, wurde jedoch nicht in der OPF-Datei deklariert.
+OPF_004=Ungültige Präfix-Deklaration: Führende oder anhängende Leerzeichen sind nicht erlaubt.
+OPF_004a=Ungültige Präfix-Deklaration: Leerer Präfix gefunden.
+OPF_004b=Ungültiger Präfix '%1$s': Muss ein gültiger NCName sein ('non-colonized name').
+OPF_004c=Ungültige Präfix-Deklaration: Auf das Präfix '%1$s' muss direkt ein Doppelpunkt folgen.
+OPF_004d=Ungültige Präfix-Deklaration: Präfix '%1$s' muss von der zugehörigen URI durch ein Leerzeichen getrennt sein.
+OPF_004e=Ungültige Präfix-Deklaration: Ungültige Leerzeichen zwischen Präfix und URI.
+OPF_004f=Ungültige Präfix-Deklaration: Ungültige Leerzeichen zwischen Präfix-Mappings.
+OPF_005=Ungültige Präfix-Deklaration: Die URI für den Präfix '%1$s' existiert nicht!
+OPF_006=Ungültige Präfix-Deklaration: Die URI '%1$s' ist keine gültige URI!
+OPF_007=Erneute Deklaration eines reservierten Präfixes: '%1$s'
+OPF_007a=Ungültiges Präfix-Mapping: Präfix '_' darf nicht deklariert werden!
+OPF_007b=Ungültiges Präfix-Mapping: Standard-Vokabular '%1$s' darf nicht erneut deklariert werden!
+OPF_008=Die Bindung eines Handlers ist für den Core-MediaType '%1$s' nicht erlaubt.
+OPF_009=Der MIME-Type %1$s wurde bereits dem folgenden Handler zugeordnet: %2$s
+OPF_010=Fehler beim Auflösen der Referenz: '%1$s'
+OPF_011=Element 'itemref' darf die Eigenschaften 'page-spread-right' und 'page-spread-left' nicht gleichzeitig aufweisen.
+OPF_012=Die Eigenschaft '%1$s' ist für den MimeType '%2$s' nicht definiert.
+OPF_013=Die 'type'-Eigenschaft '%1$s' am 'object'-Element entspricht nicht dem MimeType '%2$s' aus dem OPF-Manifest.
+OPF_014=Die Eigenschaft '%1$s' sollte in der OPF-Datei deklariert werden.
+OPF_015=Die Eigenschaft '%1$s' sollte NICHT in der OPF-Datei deklariert sein.
+OPF_016=Am Element 'rootfile' fehlt das erforderliche Attribut 'full-path'.
+OPF_017=Das Attribut 'full-path' am Element 'rootfile' darf nicht leer sein.
+OPF_018=Diese Datei weist die Eigenschaft 'remote-resources' auf, es wurden jedoch keine Referenzen auf entfernte Ressourcen gefunden.
+OPF_019=Das 'spine'-Element wurde in der OPF-Datei nicht gefunden.
+OPF_020=Sehr viele 'spine'-Einträge gefunden!
+OPF_021=Nicht-definiertes URI-Schema im 'href'-Attribut benutzt: '%1$s'
+OPF_022=Ungültiger Pfad: '%1$s'
+OPF_024=Unbekannte EPUB-Versionsnummer gefunden: '%1$s'
+OPF_025=Der Eigenschaft '%1$s' kann nur ein einziger Wert zugewiesen werden.
+OPF_026=Ungültigen Eigenschaftswert gefunden: '%1$s'
+OPF_027=Nicht definierte Eigenschaft: '%1$s'
+OPF_028=Nicht definierter Präfix: '%1$s'
+OPF_029=Die Datei '%1$s' scheint nicht vom MimeType '%2$s' zu sein, welcher in der OPF-Datei für diese Datei deklariert wurde.
+OPF_030=Das 'unique-identifier'-Attribut mit dem Wert '%1$s' wurde nicht gefunden.
+OPF_031=Der EPUB-'Guide' referenziert die Datei '%1$s' welche aber nicht im OPF-Manifest deklariert wurde.
+OPF_032=Der EPUB-'Guide' referenziert die Datei '%1$s' welche kein gültiges EPUB-Inhaltsdokument ist.
+OPF_033=Der EPUB-'Spine' enthält keine Einträge die als 'linear' gekennzeichnet sind.
+OPF_034=Der EPUB-'Spine' enthält mehrfache Referenzen auf die manifestierte Datei mit der ID '%1$s'.
+OPF_035=Der MimeType 'text/html' ist für XHTML/OPS nicht gültig.
+OPF_035_SUG= Verwende stattdessen 'application/xhtml+xml'.
+OPF_036=Der Video-MimeType '%1$s' wird unter Umständen nicht von allen Lesegeräten unterstützt.
+OPF_036_SUG=Erlaubt sind 'video/mp4', 'video/h264' oder 'video/webm'.
+OPF_037=Veralteter MimeType '%1$s'.
+OPF_038=Der MimeType '%1$s' ist im Kontext von OEBPS 1.2 nicht gültig. Bitte stattdessen 'text/x-oeb1-document' verwenden.
+OPF_039=Der MimeType '%1$s' ist im Kontext von OEBPS 1.2 nicht gültig. Bitte stattdessen 'text/x-oeb1-css' verwenden.
+OPF_040=Der Fallback-Eintrag konnte nicht gefunden werden.
+OPF_041=Der 'style'-Fallback-Eintrag konnte nicht gefunden werden.
+OPF_042='%1$s' ist kein im 'Spine' erlaubter MimeType (laut OPF-Standard).
+OPF_043=Ein 'spine'-Eintrag mit MimeType '%1$s' ist nicht erlaubt und enthält auch kein Fallback.
+OPF_044=Ein 'spine'-Eintrag mit MimeType '%1$s' ist nicht erlaubt und er enthält einen Fallback zu einem im 'Spine' nicht erlaubten MimeType.
+OPF_045=Nicht erlaubter zirkulärer/gegenseitiger Bezug von Fallback-Referenzen.
+OPF_046=Die "scripted"-Eigenschaft ist am mediaType-Handler nicht gesetzt.
+OPF_047=Die OPF-Datei nutzt OEBPS-1.2-Syntax, welche Abwärtskompatibilität gewährleistet.
+OPF_048=Am 'package'-Element fehlt das erforderliche 'unique-identifier'-Attribut.
+OPF_049=Die Datei '%1$s' wurde nicht im OPF-Manifest gefunden.
+OPF_050=Das TOC-Attribut referenziert eine Ressource ohne NCX-MimeType; erwartet wird aber der MimeType 'application/x-dtbncx+xml'.
+OPF_051=Die Bild-Abmessungen überschreiten die empfohlenen Maße.
+OPF_052=Wert des 'role'-Attributs am Element 'dc:creator' ist ungültig: '%1$s'
+OPF_053=Datumseintrag '%1$s' folgt nicht dem vorgegebenen Schema aus http://www.w3.org/TR/NOTE-datetime : %2$s
+OPF_054=Datumseintrag '%1$s' ist invalide per Definition (siehe http://www.w3.org/TR/NOTE-datetime): %2$s
+OPF_055='%1$s'-Element ist leer.
+OPF_056=MimeType '%1$s' ist kein gültiger Audio-MimeType.
+OPF_056_SUG=Erlaubt sind 'audio/mp3', 'audio/mp4' oder 'audio/ogg'.
+OPF_057=Die Bild-Dateigröße überschreiten die empfohlenen Vorgaben.
+OPF_058='spine'-Eintrag wird nicht aus der '.ncx'-Datei referenziert.
+OPF_058_SUG=Jeder 'spine'-Eintrag im OPF-Manifest sollte von mindestens einem TOC-Eintrag in der '.ncx'-Datei referenziert werden.
+OPF_059='spine'-Eintrag wird nicht aus der Navigationsdatei referenziert.
+OPF_059_SUG=Jeder 'spine'-Eintrag im OPF-Manifest sollte von mindestens einem 'nav'-Eintrag in der Navigationsdatei referenziert werden.
+OPF_060=Doppelte Datei im EPUB-Archiv: '%1$f'
+OPF_061=Doppelte Datei im EPUB-Archiv (nach Unicode-NFC-Normalisierung): '%1$f'
+OPF_062=Adobe "page-map" Attribut am 'spine'-Element der OPF-Datei gefunden.
+OPF_063=Die in der Adobe 'page-map' referenzierte Datei '%1$s' wurde nicht im OPF-Manifest gefunden.
+
+#Package
+PKG_001=Validierung gegen den EPUB-Standard Version %1$s, es wurde aber die EPUB-Version %2$s entdeckt.
+PKG_003=Der EPUB Datei-Header kann nicht ausgelesen werden. Diese EPUB-Datei scheint kaputt zu sein.
+PKG_004=Fehlerhafter EPUB ZIP-Header.
+PKG_005=Die 'mimetype'-Datei hat eine Dateiendung der Länge %1$s. Es sind keine Dateiendungen für die 'mimetype'-Datei erlaubt!
+PKG_006=MimeType-Eintrag fehlt oder ist nicht der Erste im EPUB-Archiv.
+PKG_007=Die Mimetype-Datei darf nur den String 'application/epub+zip' als Inhalt haben!
+PKG_008=Kann die Datei '%1$s' nicht lesen.
+PKG_009=Dateiname enthält Zeichen die nicht in OCF-Dateinamen erlaubt sind: %1$s
+PKG_010=Dateiname enthält Leerzeichen! Leerzeichen sollten vermieden werden.
+PKG_011=Dateiname darf nicht mit einem Punkt '.' enden.
+PKG_012=Dateiname enthält die folgenden Nicht-ASCII-Zeichen: '%1$s'. Versuche den Dateinamen zu ändern!
+PKG_013=Das EPUB enthält mehrere OPS-Darstellungen ('renditions').
+PKG_014=Das EPUB enthält ein leeres Verzeichnis: %1$s
+PKG_015=Folgende Inhalte des EPUBs können nicht gelesen werden: %1$s
+PKG_016=Benutze nur Kleinbuchstaben für die EPUB-Dateiendung um die Kompatibilität zu erhöhen.
+PKG_016_SUG=Es sollte '.epub' verwendet werden.
+PKG_017=Ungewöhnliche EPUB-Dateiendung.
+PKG_017_SUG=Es sollte '.epub' verwendet werden.
+PKG_018=Die EPUB-Datei wurde nicht gefunden.
+PKG_020=Die OPF-Datei '%1$s' wurde nicht gefunden.
+PKG_021=Fehlerhafte Bild-Datei gefunden.
+PKG_022=Falsche Dateiendung für das Bild. Es ist eine '%1$s'-Datei, besitzt aber die Dateiendung '%2$s'.
+
+#Resources
+RSC_001=Datei '%1$s' wurde nicht gefunden.
+RSC_002=Benötigte Datei 'META-INF/container.xml' fehlt.
+RSC_003=Es wurde kein 'rootfile'-Element mit MimeType 'application/oebps-package+xml' im EPUB gefunden.
+RSC_004=Die DRM-geschützte Datei '%1$s' kann nicht entschlüsselt werden.
+RSC_005=Validierungsfehler: %1$s
+RSC_006=Verlinkte Ressourcen sind nicht erlaubt. Platzieren Sie den Inhalt stattdessen im EPUB selbst.
+RSC_006_SUG=Remote-Ressourcen sind nur für Audio und Video erlaubt!
+RSC_007=Die Datei wurde im EPUB nicht gefunden.
+RSC_008=Die referenzierte Datei ist im OPF-Manifest nicht deklariert.
+RSC_009=Im 'src'-Attribut am 'img'-Element darf keine 'fragment identifier' (ID-Referenz) angegeben werden.
+RSC_010=Referenz auf eine Ressource gefunden, die laut Standard nicht erlaubt ist.
+RSC_011=Referenz auf eine Ressource gefunden, die nicht im OPF 'Spine' deklariert ist.
+RSC_012=Fragmentbezeichner ist nicht angegeben.
+RSC_013=Fragmentbezeichner wird in einem Link zu einem Stylesheet-Dokument genutzt.
+RSC_014=Fragmentbezeichner an einer inkompatiblen Ressource.
+RSC_015=Das SVG-Element <use> benötigt zwingend einen Fragmentbezeichner zur Referenzierung.
+RSC_016=Schwerer Fehler beim Parsen der Datei '%1$s'.
+RSC_017=Warnung beim Parsen der Datei '%1$s'.
+RSC_018=Bildatei '%1$s' wurde nicht gefunden.
+
+#Scripting
+SCP_001=Die Nutzung der JavaScript-Funktion 'eval()' in EPUBs ist ein Sicherheitsrisiko!
+SCP_002=Die Nutzung der JavaScript-Funktionalität 'XMLHttpRequest' in EPUBs ist ein Sicherheitsrisiko!
+SCP_003="Local Storage" und "Session Storage" werden derzeit nicht unterstützt.
+SCP_004=Datei enthält ein Skript welches in EPUB 2 derzeit nicht unterstützt wird.
+SCP_005=Datei enthält ein Skript, wurde aber im OPF nicht als 'scripted' gekennzeichnet.
+SCP_006=Inzeilige JavaScript-Anweisungen gefunden.
+SCP_007=Skript nutzt 'innerHtml'.
+SCP_007_SUG=Benutze besser einen DOM-Handler.
+SCP_008=Skript nutzt 'innerText'.
+SCP_008_SUG=Benutze besser 'textContent'.
+SCP_009=Datei nutzt Maus-EventHandler.
+SCP_009_SUG=Stelle sicher, dass alle Maus-basierten Events auch per Tastatur oder Touch-Eingabe funktionieren.
+SCP_010=EPUB 3 Inhaltsdatei enthält Skripte.
+

--- a/src/main/resources/com/adobe/epubcheck/util/messages_de.properties
+++ b/src/main/resources/com/adobe/epubcheck/util/messages_de.properties
@@ -1,0 +1,74 @@
+single_file=Die Datei wird als Einzeldatei vom Typ %1$s in Version %2$s validiert. Nur ein Bruchteil der verfügbaren Tests wird ausgeführt.
+opv_version_test=*** Candidate for msg deletion *** Tests are performed only for the OPF version.
+mode_version_not_supported=EpubCheck validiert Dateien vom Typ %1$s und Version %2$s nicht.
+
+no_errors__or_warnings=Das EPUB enthält keine Fehler oder Warnungen.\nEs ist valide.
+there_were_errors=\nEpubCheck mit Fehlern abgeschlossen.\n
+there_were_warnings=\nEpubCheck mit Warnungen abgeschlossen.\n
+
+error_processing_unexpanded_epub=\nDiese Prüfung kann entpackte EPUB's nicht validieren!\n
+deleting_archive=\nEPUB-Erstellung abgebrochen, weil Fehler aufgetreten sind.\n
+display_help=-help zeigt die Hilfe zu EpubCheck an.
+argument_needed=Es wird mindestens ein Parameter erwartet!
+version_argument_expected=Dem Versions-Parameter -v fehlt die Versionsnummer!
+mode_argument_expected=Dem --mode Parameter fehlt der Typ!.
+no_file_specified=In den Parametern wurde keine Datei spezifiziert. EpubCheck wird beendet!
+mode_version_ignored=Die Parameter --mode und -v werden für EPUB-Dateien ignoriert. Die Werte werden aus dem EPUB entnommen.
+mode_required=Parameter --mode ist für Dateien die kein EPUB sind zwingend erforderlich. Die Standard-Version zur Validierung ist 3.0
+validating_version_message=Verwendung der EPUB %1$s Prüfungen
+output_type_conflict=Es kann nur ein Ausgabeformat gleichzeitig angegeben werden!
+validating_against_epub_version=Validierung gegen den EPUB-Standard Version %1$s
+file_not_found=Datei wurde nicht gefunden: '%1$s'
+epubcheck_completed=EpubCheck abgeschlossen
+error_creating_config_file=Fehler beim Erstellen der Konfigurationsdatei: '%1$s'
+expected_message_filename=Es wird die benutzerspezifische Datei zum Überschreiben von Warnungen und Fehlermeldungen erwartet, gefunden wurde aber '%1$s'
+unrecognized_argument=Unbekannter Parameter: '%1$s'
+
+help_text = \
+          EpubCheck v%1$s\n\n\
+          Der erste Parameter der an dieses Tool übergeben werden sollte,\n\
+          sollte der Dateipfad der zu prüfenden Datei sein.\n\
+          \n\
+          Wenn eine Datei geprüft wird die kein gezipptes EPUB ist,\n\
+          dann muss die EPUB-Versionsnummer gegen die geprüft werden soll\n\
+          mit dem Parameter -v angegeben werden, sowie der Typ der Datei\n\
+          mit dem Parameter --mode\n\
+          Die Standard-Version zur Validierung ist 3.0\n\
+          \n\
+          Unterstützte Werte für die Parameter --mode und -v:\n\
+          --mode opf -v 2.0       // Für OPF-Dateien der Version 2.0\n\
+          --mode opf -v 3.0       // Für OPF-Dateien der Version 3.0\n\
+          --mode xhtml -v 2.0     // Für XHTML-Dateien der Version 2.0\n\
+          --mode xhtml -v 3.0     // Für XHTML-Dateien der Version 3.0\n\
+          --mode svg -v 2.0       // Für SVG-Dateien der Version 2.0\n\
+          --mode svg -v 3.0       // Für SVG-Dateien der Version 3.0\n\
+          --mode nav -v 3.0       // Für EPUB-Navigationsdokumente der Version 3.0\n\
+          --mode mo  -v 3.0       // Für EPUB-MediaOverlays der Version 3.0\n\
+          --mode exp              // Für entpackte EPUB-Archive\n\
+          \n\
+          EpubCheck akzeptiert diese weiteren Optionen:\n\
+          --save                  = generiert ein EPUB aus dem entpackten Ordner\n\
+          --out <datei>           = speichert das Ergebnis der Validierung im XML-Format\n\
+          --xmp <datei>           = speichert das Ergebnis der Validierung im XMP-Format\n\
+          --json <datei>          = speichert das Ergebnis der Validierung im JSON-Format\n\
+          -m <datei>              = Synonym zu --mode\n\
+          -o <datei>              = Synonym zu --out\n\
+          -x <datei>              = Synonym zu --xmp\n\
+          -j <datei>              = Synonym zu --json\n\
+          --failonwarnings[+|-]   = Standardmäßig endet EpubCheck mit ExitCode 1 falls Fehler im EPUB gefunden wurden\n\
+          \                          und mit ExitCode 0, falls keine Fehler gefunden wurden. Bei Nutzung von --failonwarnings\n\
+          \                          wird EpubCheck auch bereits bei Auftreten von Warnungen mit ExitCode 1 beendet.\n\
+          -q, --quiet             = Nur Fehler werden auf der Konsole ausgegeben\n\
+          -f, --fatal             = Nur Fatale Fehler ausgeben\n\
+          -e, --error             = Nur Fatale Fehler und Fehler ausgeben\n\
+          -w, --warn              = Fatale Fehler, Fehler und Warnungen ausgeben\n\
+          -u, --usage             = Informationen zur Nutzung bestimmter EPUB-Features ausgeben (Standardmäßig ausgeschaltet);\n\
+          \                          wenn aktiviert, dann werden Informationen immer auch in die Ausgabedatei aufgenommen.\n\
+          \n\
+          -l, --listChecks [<datei>]       = Ausgabe aller Message-ID's und Fehler-Level in eine\n\
+          \                                   benutzerdefinierte Datei <datei> oder auf der Konsole.\n\
+          -c, --customMessages [<datei>]   = Überschreibt die Fehler-Level von EpubCheck wie in der\n\
+          \                                   benutzerdefinierten Datei <datei> angegeben.\n\
+          \n\
+          -h, -? or --help = Zeigt diese Hilfe an\n
+

--- a/src/main/resources/com/thaiopensource/datatype/xsd/resources/Messages_de.properties
+++ b/src/main/resources/com/thaiopensource/datatype/xsd/resources/Messages_de.properties
@@ -1,0 +1,71 @@
+# This is German translation of org/thaiopensource/datatype/xsd/resources/Messages.properties file.
+# Translation by Tobias Fischer (https://github.com/tofi86)
+# 
+# First block doesn't need to be translated for epubcheck, as @murata0204 noted in
+# https://github.com/IDPF/epubcheck/pull/472#issuecomment-58265808
+# 
+# Non-unicode chars (german umlauts, etc..) must be escaped like \u00DF
+# because otherwise Jing can't parse them. Bad UTF8-support
+
+
+# Properties file specifying messages
+enumeration_param=\"enumeration\" facet is not allowed as a parameter: use \"value\" element instead
+whiteSpace_param=\"whiteSpace\" facet is not allowed as a parameter
+unrecognized_param=unrecognized parameter \"{0}\"
+invalid_regex=invalid regular expression: {0}
+not_ordered=parameter can only be applied to ordered datatype
+invalid_limit=\"{0}\" is not allowed by the base type: {1}
+no_length=base datatype does not define a units of length
+scale_not_derived_from_decimal=\"scale\" parameter can only be applied to datatype derived from \"decimal\"
+scale_not_non_negative_integer=\"scale\" parameter must be non negative integer
+length_not_non_negative_integer=\"length\" parameter must be non negative integer
+precision_not_derived_from_decimal=\"precision\" parameter can only be applied to datatype derived from \"decimal\"
+precision_not_positive_integer=\"precision\" parameter must be positive integer
+regex_impl_not_found=cannot find regular expression implementation; use JDK 1.4 or add Xerces2 to your classpath
+regex_internal_error=internal error in regular expression for datatype {0}
+
+# validation errors
+length_violation=es muss {0} sein, mit einer exakten L\u00E4nge von {1} (L\u00E4nge ist derzeit {2})
+max_length_violation=es muss {0} sein, mit einer maximalen L\u00E4nge von {1} (L\u00E4nge ist derzeit {2})
+min_length_violation=es muss {0} sein, mit einer minimalen L\u00E4nge von {1} (L\u00E4nge ist derzeit {2})
+min_inclusive_violation=es muss {0} sein, gr\u00F6\u00DFer gleich  {1}
+min_exclusive_violation=es muss {0} sein, gr\u00F6\u00DFer als {1}
+max_inclusive_violation=es muss {0} sein, kleiner gleich {1}
+max_exclusive_violation=es muss {0} sein, kleiner als {1}
+pattern_violation=es muss {0} sein, der auf folgenden regul\u00E4ren Ausdruck zutrifft: \"{1}\"
+entity_violation=es muss ein Name sein, der in der DTD als 'unparsed entity' deklariert ist
+undeclared_prefix=es muss ein QName sein, dessen Pr\u00E4fix deklariert ist, falls vorhanden (Pr\u00E4fix \"{0}\" ist nicht deklariert)
+precision_violation=es muss {0} sein, mit mindestens {1} signifikanten Stellen (gefundene Stellen: {2})
+precision_1_violation=es muss {0} sein, mit genau einer signifikanten Stelle (gefundene Stellen: {1})
+# part of the point is to avoid ugly "digit(s)" in the error message
+scale_violation=es muss eine Dezimalzahl mit mindestens {0} Nachkommastellen sein (gefundene Stellen: {1})
+scale_0_violation=es muss eine Dezimalzahl ohne Nachkommastellen sein
+scale_1_violation=es muss eine Dezimalzahl mit maximal einer Nachkommastelle sein (gefundene Stellen: {1})
+lexical_violation=es muss {0} sein
+
+# fragments substituted in above
+lexical_space_string=ein String
+lexical_space_uri=eine URI
+lexical_space_boolean=ein Boolean
+lexical_space_decimal=eine Dezimalzahl
+lexical_space_float=eine Flie\u00DFkommazahl
+lexical_space_duration=eine Zeitangabe
+lexical_space_hex=ein hexadezimaler String
+lexical_space_base64=ein Base64-String
+lexical_space_integer=ein Integer-Wert
+lexical_space_name=ein XML-Name
+lexical_space_ncname=ein XML-Name ohne Doppelpunkt
+lexical_space_nmtoken=ein XML-NMTOKEN
+lexical_space_qname=ein XML-QName
+lexical_space_list=eine Leerzeichen-separierte Liste
+lexical_space_list_ncname=eine Liste von XML-Namen ohne Doppelpunkt
+lexical_space_list_nmtoken=eine Liste von XML-NMTOKENs
+lexical_space_date_y_m_d_time=ein Datums- und Zeitangabe im ISO-Format
+lexical_space_time=eine Zeitangabe im ISO-Format
+lexical_space_date_y_m_d=ein Datum im ISO-Format
+lexical_space_date_y_m=Jahr und Monat im ISO-Format
+lexical_space_date_y=eine Jahresangabe
+lexical_space_date_m_d=eine Datumsangabe im ISO-Format f\u00FCr Monat und Tag (in der Form --MM-DD)
+lexical_space_date_m=ein Monat im ISO-Format (in der Form --MM)
+lexical_space_date_d=ein Tage im Monat im ISO-Format (in der Form ---DD)
+lexical_space_language=eine Sprachangabe im RFC-3066-Format

--- a/src/main/resources/com/thaiopensource/relaxng/pattern/resources/Messages_de.properties
+++ b/src/main/resources/com/thaiopensource/relaxng/pattern/resources/Messages_de.properties
@@ -1,0 +1,148 @@
+# This is German translation of org/thaiopensource/relaxng/pattern/resources/Messages.properties file.
+# Translation by Tobias Fischer (https://github.com/tofi86)
+# 
+# First two blocks doesn't need to be translated for epubcheck, as @murata0204 noted in
+# https://github.com/IDPF/epubcheck/pull/472#issuecomment-58265808
+# 
+# Non-unicode chars (german umlauts, etc..) must be escaped like \u00DF
+# because otherwise Jing can't parse them. Bad UTF8-support
+
+
+# Properties file specifying messages
+illegal_href_attribute=illegal \"href\" attribute
+ns_attribute_ignored=\"ns\" attribute ignored
+reference_to_undefined=reference to undefined pattern \"{0}\"
+missing_start_element=missing \"start\" element
+recursive_reference=bad recursive reference to pattern \"{0}\"
+recursive_include=recursive inclusion of URL \"{0}\"
+duplicate_define=multiple definitions of \"{0}\" without \"combine\" attribute
+duplicate_start=multiple definitions of start without \"combine\" attribute
+conflict_combine_define=conflicting values of \"combine\" attribute for definition of \"{0}\"
+conflict_combine_start=conflicting values of \"combine\" attribute for definition of start
+missing_start_replacement=\"start\" in \"include\" does not override anything
+missing_define_replacement=definition of \"{0}\" in \"include\" does not override anything
+interleave_string=interleave of \"string\" or \"data\" element
+group_string=group of \"string\" or \"data\" element
+one_or_more_string=repeat of \"string\" or \"data\" element
+unrecognized_datatype=datatype \"{1}\" from library \"{0}\" not recognized
+unsupported_datatype_detail=datatype \"{1}\" from library \"{0}\" not supported: {2}
+unrecognized_datatype_library=datatype library \"{0}\" not recognized
+unrecognized_builtin_datatype=no such builtin datatype \"{0}\": must be \"string\" or \"token\"
+invalid_value=\"{0}\" is not a valid value of the datatype
+parent_ref_outside_grammar=reference to non-existent parent grammar
+ref_outside_grammar=reference to non-existent grammar
+expected_one_name_class=found \"{0}\" element but expected no further content
+builtin_param=builtin datatypes do not have any parameters
+invalid_param_display=invalid parameter:\n{0}
+invalid_param_detail_display=invalid parameter: {0}:\n{1}
+display_param={0}>>>>{1}
+invalid_param_detail=invalid parameter: {0}
+invalid_param=invalid parameter
+invalid_params_detail=invalid parameters: {0}
+invalid_params=invalid parameters
+datatype_requires_parameter=datatype cannot be used without parameters
+datatype_requires_parameter_detail=datatype cannot be used without parameters: {0}
+
+attribute_contains_attribute=an attribute pattern must not contain an attribute pattern (section 7.1 of the RELAX NG specification requires that the simplified XML form of the schema not contain any elements matching the path attribute//attribute)
+attribute_contains_element=an attribute pattern must not contain an element pattern (section 7.1 of the RELAX NG specification requires that the simplified XML form of the schema not contain any elements matching the path attribute//ref)
+data_except_contains_attribute=a data pattern must not exclude an attribute pattern (section 7.1 of the RELAX NG specification requires that the simplified XML form of the schema not contain any elements matching the path data/except//attribute)
+data_except_contains_element=a data pattern must not exclude an element pattern (section 7.1 of the RELAX NG specification requires that the simplified XML form of the schema not contain any elements matching the path data/except//ref)
+data_except_contains_empty=a data pattern must not exclude an empty pattern (section 7.1 of the RELAX NG specification requires that the simplified XML form of the schema not contain any elements matching the path data/except//empty)
+data_except_contains_group=a data pattern must not exclude a group (section 7.1 of the RELAX NG specification requires that the simplified XML form of the schema not contain any elements matching the path data/except//group)
+data_except_contains_interleave=a data pattern must not exclude an interleaved group (section 7.1 of the RELAX NG specification requires that the simplified XML form of the schema not contain any elements matching the path data/except//interleave)
+data_except_contains_list=a data pattern must not exclude a list pattern (section 7.1 of the RELAX NG specification requires that the simplified XML form of the schema not contain any elements matching the path data/except//list)
+data_except_contains_one_or_more=a data pattern must not exclude a repetition (section 7.1 of the RELAX NG specification requires that the simplified XML form of the schema not contain any elements matching the path data/except//oneOrMore)
+data_except_contains_text=a data pattern must not exclude a text pattern (section 7.1 of the RELAX NG specification requires that the simplified XML form of the schema not contain any elements matching the path data/except//text)
+list_contains_attribute=a list pattern must not contain an attribute pattern (section 7.1 of the RELAX NG specification requires that the simplified XML form of the schema not contain any elements matching the path list//attribute)
+list_contains_element=a list pattern must not contain an element pattern (section 7.1 of the RELAX NG specification requires that the simplified XML form of the schema not contain any elements matching the path list//ref)
+list_contains_list=a list pattern must not contain a list pattern (section 7.1 of the RELAX NG specification requires that the simplified XML form of the schema not contain any elements matching the path list//list)
+list_contains_text=a list pattern must not contain a text pattern (section 7.1 of the RELAX NG specification requires that the simplified XML form of the schema not contain any elements matching the path list//text)
+list_contains_interleave=a list pattern must not contain an interleave pattern (section 7.1 of the RELAX NG specification requires that the simplified XML form of the schema not contain any elements matching the path list//interleave)
+one_or_more_contains_group_contains_attribute=a group of attributes must not be repeatable (section 7.1 of the RELAX NG specification requires that the simplified XML form of the schema not contain any elements matching the path oneOrMore//group//attribute)
+one_or_more_contains_interleave_contains_attribute=an interleaved group of attributes must not be repeatable (section 7.1 of the RELAX NG specification requires that the simplified XML form of the schema not contain any elements matching the path oneOrMore//interleave//attribute)
+start_contains_attribute=found element matching the prohibited path start//attribute in the simplified XML form of the schema (see section 7.1 of the RELAX NG specification)
+start_contains_data=found element matching the prohibited path start//data in the simplified XML form of the schema (see section 7.1 of the RELAX NG specification)
+start_contains_empty=found element matching the prohibited path start//empty in the simplified XML form of the schema (see section 7.1 of the RELAX NG specification)
+start_contains_group=found element matching the prohibited path start//group in the simplified XML form of the schema (see section 7.1 of the RELAX NG specification)
+start_contains_interleave=found element matching the prohibited path start//interleave in the simplified XML form of the schema (see section 7.1 of the RELAX NG specification)
+start_contains_list=found element matching the prohibited path start//list in the simplified XML form of the schema (see section 7.1 of the RELAX NG specification)
+start_contains_one_or_more=found element matching the prohibited path start//oneOrMore in the simplified XML form of the schema (see section 7.1 of the RELAX NG specification)
+start_contains_text=found element matching the prohibited path start//text in the simplified XML form of the schema (see section 7.1 of the RELAX NG specification)
+start_contains_value=found element matching the prohibited path start//value in the simplified XML form of the schema (see section 7.1 of the RELAX NG specification)
+duplicate_attribute=duplicate attribute
+duplicate_attribute_name=duplicate attribute {0}
+duplicate_attribute_ns=attributes from namespace \"{0}\" can occur more than once
+interleave_element_overlap=overlapping element names in operands of \"interleave\"
+interleave_element_overlap_name=the element {0} can occur in more than one operand of \"interleave\"
+interleave_element_overlap_ns=elements from namespace \"{0}\" can occur in more than one operand of \"interleave\"
+interleave_text_overlap=both operands of \"interleave\" contain \"text\"
+open_name_class_not_repeated=attribute using \"nsName\" or \"anyName\" must be in \"oneOrMore\"
+xmlns_uri_attribute=attribute must not have namespace URI \"http://www.w3.org/2000/xmlns\"
+xmlns_attribute=attribute must not be named \"xmlns\"
+
+# Validation errors
+unknown_element=Element {0} ist nicht erlaubt{1}
+unexpected_element_required_element_missing=Das Element {0} ist an dieser Stelle noch nicht erlaubt. Es fehlt das Element {1}
+unexpected_element_required_elements_missing=Das Element {0} ist an dieser Stelle noch nicht erlaubt. Es fehlen die Elemente {1}
+element_not_allowed_yet=Element {0} ist an dieser Stelle noch nicht erlaubt{1}
+out_of_context_element=Element {0} ist an dieser Stelle nicht erlaubt{1}
+no_attributes_allowed=Attribut {0} vorhanden. Attribute sind an dieser Stelle jedoch nicht erlaubt!
+invalid_attribute_name=Attribut {0} ist an diesem Element nicht erlaubt{1}
+invalid_attribute_value=Der Wert des Attributs {0} ist ung\u00FCltig{1}
+required_attributes_missing_expected=Dem Element {0} fehlen ein oder mehrere erforderliche Attribute{1}
+required_attribute_missing=Dem Element {0} fehlt das erforderliche {1} Attribut
+required_attributes_missing=Dem Element {0} fehlen die folgenden erforderlichen Attribute: {1}
+incomplete_element_required_elements_missing_expected=Das Element {0} ist nicht vollst\u00E4ndig{1}
+incomplete_element_required_element_missing=Das Element {0} ist nicht vollst\u00E4ndig. Es fehlt das erforderliche Kind-Element {1}
+incomplete_element_required_elements_missing=Das Element {0} ist nicht vollst\u00E4ndig. Es fehlen die erforderlichen Kind-Elemente {1}
+text_not_allowed=Text ist an dieser Stelle nicht erlaubt{0}
+document_incomplete=Dokument scheint unvollst\u00E4ndig zu sein
+invalid_element_value=Der Inhalt des Elements {0} ist ung\u00FCltig{1}
+blank_not_allowed=Das Element {0} muss Inhalt besitzen{1}
+schema_allows_nothing=Das Schema erlaubt an dieser Stelle keine Elemente: <notAllowed/>
+
+# ID correctness errors
+id_element_name_class=an \"element\" pattern containing an \"attribute\" pattern with a non-null ID-type must have a name class that contains only \"choice\" and \"name\" elements
+id_attribute_name_class=an \"attribute\" pattern with a non-null ID-type must have a name class that is a single name
+id_parent=a \"data\" or \"value\" pattern with non-null ID-type must occur as the child of an \"attribute\" pattern
+id_type_conflict=conflicting ID-types for attribute {1} of element {0}
+
+# ID soundness errors
+id_no_tokens=Attributwert enth\u00E4lt keinen ID-Aufruf
+id_multiple_tokens=Attributwert enth\u00E4lt mehrere ID-Aufrufe
+idref_no_tokens=Attributwert enth\u00E4lt keinen IDREF-Aufruf
+idref_multiple_tokens=Attributwert enth\u00E4lt mehrere IDREF-Aufrufe
+idrefs_no_tokens=Attributwert enth\u00E4lt keine IDREF-Aufrufe
+missing_id=IDREF \"{0}\" ohne zugeh\u00F6rige ID
+duplicate_id=die ID \"{0}\" wurde bereits definiert
+first_id=erste Fundstelle der ID \"{0}\"
+
+# Fragments
+name_absent_namespace=\"{0}\"
+name_with_namespace=\"{1}\" aus dem Namespace \"{0}\"
+qname=\"{0}\"
+qnames_nsdecls={0} (mit {1})
+or_list_pair={0} oder {1}
+or_list_many_first={0}
+or_list_many_middle={0}, {1}
+or_list_many_last={0} oder {1}
+and_list_pair={0} und {1}
+and_list_many_first={0}
+and_list_many_middle={0}, {1}
+and_list_many_last={0} und {1}
+
+expected=. Erwartet wird {0}
+element_end_tag=das Element-Ende-Tag
+text=Text
+data=Daten
+element_list=Element {0}
+element_other_ns=ein Element aus einem anderen Namespace
+expected_attribute=. Erlaubt ist nur das Attribut {0}
+expected_attribute_or_other_ns=. Erlaubte Attribute sind {0} oder Attribute aus einem anderen Namespace
+data_failures=; {0}
+token_failures=; Ausdruck {0} ist ung\u00FCltig; {1}
+missing_token=; fehlender Ausdruck; {0}
+expected_data=; erwartet werden Daten
+require_values=muss {0} gleichen
+require_qnames=muss ein QName sein, der {0} gleicht
+require_datatype=muss ein valider Datentyp vom Typ {0} sein

--- a/src/main/resources/org/idpf/epubcheck/util/css/messages_de.properties
+++ b/src/main/resources/org/idpf/epubcheck/util/css/messages_de.properties
@@ -1,0 +1,20 @@
+css.scanner.token.syntax=Ungültige Syntax syntax "{0}"
+css.scanner.token.syntax.char=Das Zeichen "{0}" ist in folgendem Ausdruck nicht erlaubt: "{1}"
+css.scanner.token.syntax.firstChar=Das Zeichen "{0}" ist an erster Stelle des folgenden Ausdrucks nicht erlaubt: "{1}"
+css.scanner.token.syntax.escape=Ungültige Escape-Sequenz "{0}"
+css.scanner.token.syntax.urange=Ungültiger Unicode-Bereich-Ausdruck "{0}"
+css.scanner.prematureEOF=Vorzeitiges Ende der CSS-Datei.
+
+css.grammar.prematureEOF=Vorzeitiges Ende der CSS-Datei. Erwartet wird {0}
+css.grammar.token.unexpected=Die Zeichenkette "{0}" ist an dieser Stelle nicht erlaubt.
+css.grammar.token.expecting=Die Zeichenkette "{0}" ist an dieser Stelle nicht erlaubt. Erwartet wird {1}
+css.grammar.invalidSelector=Ungültiger Selektor: "{0}" 
+
+or=oder
+a_property_name=eine CSS-Eigenschaft
+a_property_value=ein Eigenschaftswert
+a_type_or_universal_selector=ein Typ- oder Universal-Selektor
+a_string_or_dentifier=ein String oder eine ID
+an_attribute_value_matcher=ein Ausdruck der auf den Attributwert matcht
+negation_arguments=Argumente der not()-Funktion
+a_selectors=ein Selektor


### PR DESCRIPTION
Still missing a few translations:
- `OPF_008=Handler binding for core Media-type '%1$s' is not allowed.`
- `OPF_009=The media-type %1$s has already been assigned handler '%2$s'.`
- `OPF_046=Scripted property is not set on mediaType handler.`
- `RSC_012=Fragment identifier is not defined.`
- `RSC_013=Fragment identifier is used in a reference to a stylesheet resource.`
- `RSC_014=Fragment identifier defines an incompatible resource type.`
- `RSC_015=A fragment identifier is required for svg use tag references.`

**Übersetzungsvorschläge sind herzlich Willkommen!** :smiley: 

@santoch: Can you ask Holm to revise the translation?

I hereby also ask my colleagues @duenckel and @andreaskaemmerle whether they're in the mood to revise the translation.
