### PR TITLE
replaced javatuples lib with small utility class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,11 +215,6 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.javatuples</groupId>
-            <artifactId>javatuples</artifactId>
-            <version>1.2</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/adobe/epubcheck/util/KeyValue.java
+++ b/src/main/java/com/adobe/epubcheck/util/KeyValue.java
@@ -1,0 +1,26 @@
+package com.adobe.epubcheck.util;
+
+public final class KeyValue<A,B> {
+
+	private final A key;
+	private final B value;
+
+
+	public static <A,B> KeyValue<A,B> with(final A key, final B value) {
+		return new KeyValue<A,B>(key,value);
+	}
+
+	public KeyValue(final A key, final B value) {
+		this.key = key;
+		this.value = value;
+	}
+
+	public A getKey() {
+		return this.key;
+	}
+
+	public B getValue() {
+		return this.value;
+	}
+
+}

--- a/src/main/java/com/adobe/epubcheck/util/XmlReportAbstract.java
+++ b/src/main/java/com/adobe/epubcheck/util/XmlReportAbstract.java
@@ -10,8 +10,6 @@ import java.io.*;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
-import org.javatuples.KeyValue;
-
 
 public abstract class XmlReportAbstract extends MasterReport
 {

--- a/src/main/java/com/adobe/epubcheck/util/XmlReportImpl.java
+++ b/src/main/java/com/adobe/epubcheck/util/XmlReportImpl.java
@@ -7,8 +7,6 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.javatuples.KeyValue;
-
 import com.adobe.epubcheck.messages.MessageLocation;
 import com.adobe.epubcheck.reporting.CheckMessage;
 

--- a/src/main/java/com/adobe/epubcheck/util/XmpReportImpl.java
+++ b/src/main/java/com/adobe/epubcheck/util/XmpReportImpl.java
@@ -7,8 +7,6 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.javatuples.KeyValue;
-
 import com.adobe.epubcheck.messages.MessageLocation;
 import com.adobe.epubcheck.reporting.CheckMessage;
 


### PR DESCRIPTION
The javatuples library is not OSGi-enabled, which as a consequence makes epubcheck unusable in a OSGi-context. Only a small portion of it is used in epubcheck anyway so it can be replaced by this small utility class.
