### PR TITLE
[WIP] [fix #702] Validate content of <dc:language>

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/MessageDictionary.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageDictionary.java
@@ -283,7 +283,7 @@ public class MessageDictionary
       map.put(MessageId.OPF_082, Severity.ERROR);
       map.put(MessageId.OPF_083, Severity.ERROR);
       map.put(MessageId.OPF_084, Severity.ERROR);
-      map.put(MessageId.OPF_085, Severity.WARNING);
+      map.put(MessageId.OPF_085, Severity.INFO);
       map.put(MessageId.OPF_086, Severity.ERROR);
 
       // PKG

--- a/src/main/java/com/adobe/epubcheck/messages/MessageDictionary.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageDictionary.java
@@ -283,6 +283,8 @@ public class MessageDictionary
       map.put(MessageId.OPF_082, Severity.ERROR);
       map.put(MessageId.OPF_083, Severity.ERROR);
       map.put(MessageId.OPF_084, Severity.ERROR);
+      map.put(MessageId.OPF_085, Severity.WARNING);
+      map.put(MessageId.OPF_086, Severity.ERROR);
 
       // PKG
       map.put(MessageId.PKG_001, Severity.WARNING);

--- a/src/main/java/com/adobe/epubcheck/messages/MessageId.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageId.java
@@ -246,6 +246,8 @@ public enum MessageId implements Comparable<MessageId>
   OPF_082("OPF-082"),
   OPF_083("OPF-083"),
   OPF_084("OPF-084"),
+  OPF_085("OPF-085"),
+  OPF_086("OPF-086"),
 
   // Messages relating to the entire package
   PKG_001("PKG-001"),

--- a/src/main/java/com/adobe/epubcheck/opf/OPFChecker30.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFChecker30.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Set;
 
 import com.adobe.epubcheck.api.EPUBLocation;
@@ -89,6 +90,7 @@ public class OPFChecker30 extends OPFChecker implements DocumentValidator
     checkSemantics();
     checkNav();
     checkSpecifics();
+    checkLanguage();
   }
 
   @Override
@@ -393,6 +395,26 @@ public class OPFChecker30 extends OPFChecker implements DocumentValidator
         }
       }
     }
+  }
+
+  private void checkLanguage() {
+    Set<Metadata> dcLanguageMetas = ((OPFHandler30) opfHandler).getMetadata()
+            .getPrimary(DCMESVocab.VOCAB.get(DCMESVocab.PROPERTIES.LANGUAGE));
+    if (!dcLanguageMetas.isEmpty())
+    {
+      for(Metadata metadata : dcLanguageMetas)
+      {
+        Locale l = Locale.forLanguageTag(metadata.getValue());
+        if (l == null || l.getLanguage().length() > 2) {
+          report.message(MessageId.OPF_086, EPUBLocation.create(path), metadata.getValue());
+        }
+        else if (!l.getVariant().isEmpty())
+        {
+          report.message(MessageId.OPF_085, EPUBLocation.create(path), metadata.getValue());
+        }
+      }
+    }
+
   }
 
   private void checkSemantics()

--- a/src/main/java/com/adobe/epubcheck/opf/OPFChecker30.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFChecker30.java
@@ -405,7 +405,7 @@ public class OPFChecker30 extends OPFChecker implements DocumentValidator
       for(Metadata metadata : dcLanguageMetas)
       {
         Locale l = Locale.forLanguageTag(metadata.getValue());
-        if (l == null || l.getLanguage().length() > 2) {
+        if (l == null || l.getLanguage().length() > 3) {
           report.message(MessageId.OPF_086, EPUBLocation.create(path), metadata.getValue());
         }
         else if (!l.getVariant().isEmpty())

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -244,6 +244,9 @@ OPF_081=Resource '%1$s' (referenced from an EPUB Dictionary collection) was not 
 OPF_082=Found an EPUB Dictionary collection containing more than one Search Key Map Document.
 OPF_083=Found an EPUB Dictionary collection containing no Search Key Map Document.
 OPF_084=Found an EPUB Dictionary collection containing resource '%1$s' which is neither a Search Key Map Document nor an XHTML Content Document.
+OPF_085=Using language with variant in package description '%1$s'
+OPF_086=Incorrect language in package description '%1$s'
+
 
 #Package
 PKG_001=Validating the EPUB against version %1$s but detected version %2$s.

--- a/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
@@ -611,7 +611,7 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   public void testIssue702()
   {
     Collections.addAll(expectedErrors, MessageId.OPF_086);
-    Collections.addAll(expectedWarnings, MessageId.OPF_085);
+    Collections.addAll(expectedInfos, MessageId.OPF_085);
     testValidateDocument("valid/issue702/");
   }
 

--- a/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
@@ -617,8 +617,6 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
 
   @Test
   public void testIssue615_langtag() {
-    Collections.addAll(expectedErrors, MessageId.OPF_086);
-
     testValidateDocument("valid/issue615-langtags/");
   }
   

--- a/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
@@ -607,7 +607,15 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   {
     testValidateDocument("valid/issue567/");
   }
-  
+
+  @Test
+  public void testIssue702()
+  {
+    Collections.addAll(expectedErrors, MessageId.OPF_086);
+    Collections.addAll(expectedWarnings, MessageId.OPF_085);
+    testValidateDocument("valid/issue702/");
+  }
+
   @Test
   public void testIssue615_langtag() {
     testValidateDocument("valid/issue615-langtags/");

--- a/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
@@ -521,8 +521,7 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   @Test
   public void testIssue198()
   {
-    // Collections.addAll(expectedErrors, );
-
+    Collections.addAll(expectedErrors, MessageId.OPF_086);
     // also data-* removal
     testValidateDocument("valid/issue198/");
   }
@@ -618,6 +617,8 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
 
   @Test
   public void testIssue615_langtag() {
+    Collections.addAll(expectedErrors, MessageId.OPF_086);
+
     testValidateDocument("valid/issue615-langtags/");
   }
   

--- a/src/test/java/com/adobe/epubcheck/cli/CLITest.java
+++ b/src/test/java/com/adobe/epubcheck/cli/CLITest.java
@@ -71,7 +71,7 @@ public class CLITest
   @Test
   public void testValidSingle()
   {
-    assertEquals(0, run(new String[]{singlePath + "nav/valid/nav001.xhtml", "-mode", "nav"},true));
+    assertEquals(0, run(new String[]{singlePath + "nav/valid/nav001.xhtml", "-mode", "nav"}));
   }
 
   @Test

--- a/src/test/resources/30/expanded/valid/issue702/EPUB/lorem.css
+++ b/src/test/resources/30/expanded/valid/issue702/EPUB/lorem.css
@@ -1,0 +1,6 @@
+body {
+    margin-left : 6em;
+    margin-right : 16em;
+    color:black;
+    font-family: arial, helvetica, sans-serif;
+}

--- a/src/test/resources/30/expanded/valid/issue702/EPUB/lorem.opf
+++ b/src/test/resources/30/expanded/valid/issue702/EPUB/lorem.opf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+    <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <dc:identifier id="uid">urn:uuid:550e8400-e29b-41d4-a716-4466674412314</dc:identifier>
+        <dc:title>Lorem Ipsum</dc:title>        
+        <dc:language>en-US</dc:language>
+        <dc:language>en-US-POSIX</dc:language>
+        <dc:language>invalid-language</dc:language>
+        <dc:date>2011-09-01</dc:date>
+        <meta property="dcterms:modified">2011-09-01T17:18:00Z</meta>
+    </metadata> 
+    <manifest>
+        <item id="t1" href="lorem.xhtml" properties="nav" media-type="application/xhtml+xml" />                
+        <item id="css" href="lorem.css" media-type="text/css" />
+    </manifest>
+    <spine>
+        <itemref idref="t1" />        
+    </spine>    
+</package>

--- a/src/test/resources/30/expanded/valid/issue702/EPUB/lorem.xhtml
+++ b/src/test/resources/30/expanded/valid/issue702/EPUB/lorem.xhtml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="la" lang="la"
+	xmlns:epub="http://www.idpf.org/2007/ops">
+	<head>
+		<title>Lorem Ipsum</title>
+		<link type="text/css" rel="stylesheet" href="lorem.css" />
+		<meta name="viewport" content="width=device-width" />
+	</head>
+	<body>
+		<h1>Lorem Ipsum</h1>
+		<section>
+			<h2>Table of Contents</h2>
+			<nav epub:type="toc">
+				<ol>
+					<li><a href="#ch1">Chapter 1</a></li>
+					<li><a href="#ch2">Chapter 2</a></li>
+				</ol>
+			</nav>
+		</section>
+		<section id="ch1">
+			<h2>Chapter 1</h2>
+			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam vel purus mauris, ut
+				auctor massa. Pellentesque non nunc risus. Fusce a massa augue. Nunc erat ante,
+				auctor id varius ac, vestibulum non purus. Quisque non dui in sem consectetur
+				condimentum non ac quam. Quisque ultricies nulla nec urna fringilla pretium.
+				Pellentesque dictum pulvinar purus in mattis. Aliquam vestibulum orci sed magna
+				vestibulum a sollicitudin lectus pharetra. Suspendisse luctus risus imperdiet nunc
+				condimentum malesuada. Nulla fringilla vulputate vestibulum. Sed diam dui, fringilla
+				quis sagittis nec, viverra et nibh.</p>
+
+			<p>Sed sollicitudin accumsan augue, quis pulvinar sem volutpat at. Vestibulum rutrum
+				bibendum augue sit amet accumsan. Etiam tempus malesuada libero vestibulum
+				fringilla. Maecenas diam nulla, ultricies ac sodales vitae, viverra ut velit.
+				Vivamus posuere, mi sit amet vehicula tempus, nibh purus scelerisque enim, non
+				vestibulum erat arcu in libero. Aliquam vel convallis nibh. Sed in nisi ipsum. Sed
+				sed est justo, in lacinia nulla.</p>
+
+			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed luctus est vel lacus
+				ullamcorper vestibulum. Mauris est sapien, pharetra id feugiat in, ornare a erat.
+				Nam consectetur vehicula nisi vel faucibus. Morbi blandit augue nec lacus malesuada
+				venenatis. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
+				ridiculus mus. Maecenas consectetur, odio vitae suscipit ullamcorper, arcu ligula
+				pellentesque sem, quis rhoncus enim eros id lectus. Nam ornare dui est, vel posuere
+				metus. Quisque non nisl metus. Pellentesque id mi nunc, in gravida metus. Nullam
+				neque tellus, ultricies quis laoreet vitae, imperdiet at nunc. Ut laoreet massa quis
+				quam vulputate et ultricies nibh consectetur. Donec convallis, nulla id ultricies
+				ullamcorper, diam tortor interdum dolor, vel tempor lectus urna ut est. Praesent
+				convallis lacus vitae justo lobortis euismod. In at ante elit.</p>
+
+			<p>Aenean quis consectetur justo. Nulla nec enim nisl. Etiam rutrum volutpat tellus, a
+				scelerisque mauris malesuada sit amet. Suspendisse quis urna augue. Proin tempus
+				hendrerit libero non cursus. Praesent non massa at nisl luctus facilisis. Nullam
+				pulvinar, ligula eu porta ornare, mi mi accumsan orci, a iaculis tortor lorem quis
+				dolor. Phasellus ante nibh, pulvinar ac pulvinar eu, pulvinar ac enim.</p>
+
+			<p>Donec vel velit id elit volutpat vestibulum vitae a erat. Duis id est id magna
+				aliquam pretium nec sit amet nibh. Nullam condimentum suscipit felis, sed interdum
+				felis dictum ac. Phasellus non nisi quis magna pellentesque auctor. Cras risus
+				lectus, viverra eu fringilla malesuada, rhoncus et est. Etiam rhoncus pharetra
+				accumsan. Nullam suscipit tellus felis.</p>
+		</section>
+		<section id="ch2">
+			<h2>Chapter 2</h2>
+			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla laoreet nibh felis.
+				Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia
+				Curae; Etiam est sapien, dapibus eget gravida nec, accumsan a turpis. Nunc in nisi
+				ut dolor elementum porttitor. Mauris hendrerit pulvinar tincidunt. Etiam metus
+				metus, ullamcorper ut varius lacinia, luctus et nibh. Donec ut metus enim, id
+				faucibus nunc. Quisque ut iaculis mauris. Duis pellentesque nulla ut eros ultricies
+				quis condimentum eros adipiscing. Sed porta ultrices diam, ut sagittis lectus mattis
+				a. Phasellus gravida, sapien vitae mollis interdum, dui neque tempor arcu, ac ornare
+				leo ipsum ut nisl.</p>
+
+			<p>Donec porta, odio et aliquet molestie, felis tellus fermentum leo, id interdum magna
+				massa quis ligula. Integer elementum mauris eget nisl eleifend facilisis nec sit
+				amet tellus. Morbi consectetur dignissim egestas. Donec pulvinar, enim eu auctor
+				cursus, turpis arcu venenatis turpis, eu cursus magna nisl sit amet ante. Curabitur
+				eleifend arcu eget nibh facilisis mattis. Etiam nisl nunc, semper vitae condimentum
+				sed, viverra sit amet lacus. Curabitur et orci augue. Suspendisse sollicitudin
+				vulputate risus, sit amet consequat erat mollis eu. Nunc sodales tincidunt
+				tincidunt.</p>
+
+			<p>Aliquam erat volutpat. Aliquam ornare augue et nulla consequat commodo. Quisque
+				dictum rhoncus orci vel euismod. Proin leo turpis, adipiscing quis facilisis id,
+				condimentum sed metus. Nullam pellentesque scelerisque est nec tristique. Nunc augue
+				turpis, consequat non varius quis, aliquam auctor dolor. Cras luctus dignissim justo
+				sit amet laoreet. Quisque vel ipsum quis massa suscipit vehicula.</p>
+
+			<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis
+				egestas. Vivamus fringilla eleifend magna, vel commodo turpis egestas at.
+				Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis
+				egestas. Sed eu lorem quam, et sagittis libero. Maecenas vel ante id sem bibendum
+				laoreet nec dignissim justo. Class aptent taciti sociosqu ad litora torquent per
+				conubia nostra, per inceptos himenaeos. Fusce eu lorem orci, eu viverra nisi. Lorem
+				ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum dapibus commodo
+				pellentesque. Maecenas quis est accumsan est interdum pharetra egestas nec lorem.
+				Nam a lectus sit amet justo facilisis suscipit.</p>
+
+			<p>Integer dolor dolor, volutpat id commodo id, gravida id risus. Donec consectetur
+				sollicitudin sem, non auctor urna pulvinar non. Vivamus ipsum nisi, commodo sed
+				scelerisque id, porta nec massa. Vestibulum ac risus et augue faucibus fermentum ut
+				et nisi. Integer tincidunt suscipit ipsum, sed interdum felis mollis sed.
+				Suspendisse potenti. Praesent et mauris et quam consequat tristique. Morbi mi dolor,
+				pharetra quis rutrum quis, fringilla in tortor. Sed a nulla vitae leo dapibus
+				cursus. Aliquam erat volutpat. Integer purus purus, dictum id bibendum at, lobortis
+				quis metus.</p>
+		</section>
+	</body>
+</html>

--- a/src/test/resources/30/expanded/valid/issue702/META-INF/container.xml
+++ b/src/test/resources/30/expanded/valid/issue702/META-INF/container.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
+	<rootfiles>
+		<rootfile full-path="EPUB/lorem.opf" 	
+			media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/30/expanded/valid/issue702/mimetype
+++ b/src/test/resources/30/expanded/valid/issue702/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip    


### PR DESCRIPTION
With this implementation, I try to fix the issue of #702.

This current fix will generate an error if the language prefix is longer than 3 characters.
The specification says that you could have pre-registered language subtags or could use 4 letter codes but these are reserved for future use and currently not used to my knowledge.

If this test passes it will check if this language has a variant specified and if so it will generate a warning informing the user of this discrepancy.

I hope this fix will start discussion towards a complete solution.