### PR TITLE
Update the Travis JDK build matrix + dependency update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 jdk:
   - openjdk11
+  - oraclejdk11
   - openjdk10
-  - oraclejdk10
   - oraclejdk9
   - oraclejdk8
   - openjdk7

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.5</version>
+            <version>1.18</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.tukaani</groupId>


### PR DESCRIPTION
- remove Oracle JDK 10 from the build matrix
- add Oracle JDK 11 to the build matrix
- updated `commons-compress` to v1.18 (the previous version had a security vulnerability)