### PR TITLE
Fix issue #859: Saxon warning from Jing's Schematron XSLT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,6 +345,19 @@
                 </executions>
             </plugin>
             <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-failsafe-plugin</artifactId>
+              <version>2.22.1</version>
+              <executions>
+                <execution>
+                  <goals>
+                    <goal>integration-test</goal>
+                    <goal>verify</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>xml-maven-plugin</artifactId>
                 <version>1.0.1</version>

--- a/src/main/java/com/adobe/epubcheck/xml/XMLValidator.java
+++ b/src/main/java/com/adobe/epubcheck/xml/XMLValidator.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
+import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 
 import org.idpf.epubcheck.util.saxon.ColumnNumberFunction;
@@ -54,10 +55,12 @@ import com.thaiopensource.validate.schematron.NewSaxonSchemaReaderFactory;
 
 import net.sf.saxon.Configuration;
 import net.sf.saxon.TransformerFactoryImpl;
+import net.sf.saxon.lib.FeatureKeys;
+import net.sf.saxon.lib.StandardErrorListener;
 import net.sf.saxon.sxpath.IndependentContext;
 import net.sf.saxon.sxpath.XPathStaticContext;
 import net.sf.saxon.trans.SymbolicName;
-import net.sf.saxon.om.StandardNames;
+import net.sf.saxon.trans.XPathException;
 
 
 public class XMLValidator
@@ -193,6 +196,20 @@ public class XMLValidator
         {
           configuration.registerExtensionFunction(new SystemIdFunction());
         }
+        // Used to silence Saxon's warning about an XPath expression in Jing's built-in Schematron XSLT
+        // See issue #859
+        factory.setAttribute(FeatureKeys.XSLT_STATIC_ERROR_LISTENER_CLASS, SilencingErrorListener.class.getName());
+      }
+    }
+  }
+
+  public static class SilencingErrorListener extends StandardErrorListener {
+
+    @Override
+    public void warning(TransformerException exception) {
+      XPathException xe = XPathException.makeXPathException(exception);
+      if (!"SXWN9000".equals(xe.getErrorCodeLocalPart())) {
+        super.warning(exception);
       }
     }
   }

--- a/src/test/java/com/adobe/epubcheck/cli/CheckerIT.java
+++ b/src/test/java/com/adobe/epubcheck/cli/CheckerIT.java
@@ -1,0 +1,59 @@
+package com.adobe.epubcheck.cli;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.Test;
+
+import com.google.common.collect.ObjectArrays;
+
+public class CheckerIT
+{
+
+  private static final String[] cmd = new String[] { "java", "-jar", "target/epubcheck.jar" };
+  private static String valid30EPUB = "src/test/resources/30/epub/valid/";
+
+  @Test
+  public void testValidEPUB()
+  {
+    try
+    {
+      Process process = run(valid30EPUB + "lorem.epub");
+      InputStream stderr = process.getErrorStream();
+      process.waitFor();
+      assertEmpty(stderr);
+      assertEquals(0, process.exitValue());
+    } catch (Exception e)
+    {
+      fail(e.getMessage());
+    }
+  }
+
+  private static Process run(String epub)
+  {
+    ProcessBuilder builder = new ProcessBuilder(ObjectArrays.concat(cmd, epub));
+    try
+    {
+      return builder.start();
+    } catch (IOException e)
+    {
+      fail(e.getMessage());
+      return null;
+    }
+  }
+
+  private static void assertEmpty(InputStream inputStream)
+  {
+    try
+    {
+      if (inputStream.read() == -1) return;
+      fail("stream is not empty");
+    } catch (IOException e)
+    {
+      fail(e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
The Schematron XSLT built in Jing as an `/..` XPath expression which
always evaluates to the empty sequence.
Saxon 9.8 consequently raises a SXWN9000 warning, when the validators
are created (statically, during EPUBCheck's intializations).

This PR initalizes Jing's transformer factory with a static error listener
that ignores this warning.

This is tested as an integration test (since the warning is produced
on the standard error stream at initialization time), run via the
Maven failsafe plugin.

Fixes #859