### PR TITLE
fix: messages of missing/incorrect locale cannot be translated

### DIFF
--- a/src/main/java/com/adobe/epubcheck/tool/EpubChecker.java
+++ b/src/main/java/com/adobe/epubcheck/tool/EpubChecker.java
@@ -823,7 +823,7 @@ public class EpubChecker
         {
             if(args[i + 1].startsWith("-"))
             {
-                System.err.println(String.format(messages.get("incorrect_locale"), args[i + 1], "incorrect"));
+                System.err.println(String.format(messages.get("incorrect_locale"), args[i + 1]));
                 displayHelp();
                 return false;
             }
@@ -839,7 +839,7 @@ public class EpubChecker
         }
         else
         {
-            System.err.println(String.format(messages.get("incorrect_locale"), "", "missing"));
+            System.err.println(String.format(messages.get("missing_locale")));
             displayHelp();
             return false;
         }

--- a/src/main/resources/com/adobe/epubcheck/util/messages.properties
+++ b/src/main/resources/com/adobe/epubcheck/util/messages.properties
@@ -34,7 +34,8 @@ error_creating_config_file=Error creating config file '%1$s'.
 expected_message_filename=Expected the Custom message file name, but found '%1$s'
 unrecognized_argument=Unrecognized argument: '%1$s'
 epubcheck_version_text=EPUBCheck v%1$s
-incorrect_locale=Argument '%1$s' to the --locale option is %2$s.
+incorrect_locale=Argument '%1$s' to the --locale option is incorrect.
+missing_locale=Argument to the --locale option is missing.
 
 help_text = \
           EPUBCheck v%1$s\n\n\


### PR DESCRIPTION
Congrats to release 4.1.0 🎉 

By the way, to translate error messages, the words "incorrect" and "missing" in
com/adobe/epubcheck/tool/EpubChecker.java should be in messages.properties.