### PR TITLE
Make sure tests reset the default locale

### DIFF
--- a/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
@@ -493,13 +493,13 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   @Test
   public void testPageList()
   {
-    Locale l = Locale.getDefault();
-    // E.g., tests that I is not lower-cased to \u0131 based on locale's collation rules:
-    Locale.setDefault(new Locale("tr", "TR"));
+    Locale previousLocale = Locale.getDefault();
     try {
+      // E.g., tests that I is not lower-cased to \u0131 based on locale's collation rules:
+      Locale.setDefault(new Locale("tr", "TR"));
       testValidateDocument("valid/page-list");
     } finally { // restore the original locale
-      Locale.setDefault(l);
+      Locale.setDefault(previousLocale);
     }
   }
 

--- a/src/test/java/com/adobe/epubcheck/cli/CLITest.java
+++ b/src/test/java/com/adobe/epubcheck/cli/CLITest.java
@@ -261,19 +261,22 @@ public class CLITest
         // Rather than attempt to validate locales or match them with available
         // translations, it seems preferrable to follow the pattern that the JDK
         // has set and allow it to naturally fall back to the default (JVM) default.
-        Locale temp = Locale.getDefault();
-        Locale.setDefault(Locale.FRANCE);
-        PrintStream outOrig = System.out;
-        CountingOutStream stream = new CountingOutStream();
-        System.setOut(new PrintStream(stream));
-        EpubChecker epubChecker = new EpubChecker();
-        epubChecker.run(new String[]{
-            getAbsoluteBasedir(epubPath + "valid/lorem.epub"),
-            "--locale", "foobar"
-        });
-        System.setOut(outOrig);
-        assertTrue("Invalid Locale should use JVM default.", stream.getValue().indexOf("faites en utilisant") >= 0);
-        Locale.setDefault(temp);
+        Locale previousLocale = Locale.getDefault();
+        try {
+          Locale.setDefault(Locale.FRANCE);
+          PrintStream outOrig = System.out;
+          CountingOutStream stream = new CountingOutStream();
+          System.setOut(new PrintStream(stream));
+          EpubChecker epubChecker = new EpubChecker();
+          epubChecker.run(new String[]{
+              getAbsoluteBasedir(epubPath + "valid/lorem.epub"),
+              "--locale", "foobar"
+          });
+          System.setOut(outOrig);
+          assertTrue("Invalid Locale should use JVM default.", stream.getValue().indexOf("faites en utilisant") >= 0);
+        } finally {
+          Locale.setDefault(previousLocale);
+        }
         
   }
   

--- a/src/test/java/com/adobe/epubcheck/test/MessageDictionary_LocalizationTest.java
+++ b/src/test/java/com/adobe/epubcheck/test/MessageDictionary_LocalizationTest.java
@@ -22,26 +22,28 @@ public class MessageDictionary_LocalizationTest {
     
     Locale newLocale = new Locale("es");
     Locale previousLocale = Locale.getDefault();
-    Locale.setDefault(newLocale);
-    
-    // should return the default localization
-    LocalizedMessageDictionary messages = new LocalizedMessageDictionary(); 
-    Locale locale = messages.getLocale();
-    Locale defaultLocale = Locale.getDefault();
-    Assert.assertEquals( "Messages with default locale should use host Locale.",
-            locale, defaultLocale);
-    
-    System.out.format( "Locales are: %s & %s\n", locale.getLanguage(), defaultLocale.getLanguage());
-    
-    LocalizedMessageDictionary messagesWithExplicitLocale = new LocalizedMessageDictionary(newLocale);
-
-    // Messages should be the same for default locale and explicitly set locale
-    Assert.assertEquals( "Messages using an explicit locale same as default should be the same.",
-            messagesWithExplicitLocale.getMessage(MessageId.ACC_001).getMessage(), 
-            messages.getMessage(MessageId.ACC_001).getMessage());
-    
-    // Reset the global host JVM locale
-    Locale.setDefault(previousLocale);
+    try {
+      Locale.setDefault(newLocale);
+      
+      // should return the default localization
+      LocalizedMessageDictionary messages = new LocalizedMessageDictionary(); 
+      Locale locale = messages.getLocale();
+      Locale defaultLocale = Locale.getDefault();
+      Assert.assertEquals( "Messages with default locale should use host Locale.",
+          locale, defaultLocale);
+      
+      System.out.format( "Locales are: %s & %s\n", locale.getLanguage(), defaultLocale.getLanguage());
+      
+      LocalizedMessageDictionary messagesWithExplicitLocale = new LocalizedMessageDictionary(newLocale);
+      
+      // Messages should be the same for default locale and explicitly set locale
+      Assert.assertEquals( "Messages using an explicit locale same as default should be the same.",
+          messagesWithExplicitLocale.getMessage(MessageId.ACC_001).getMessage(), 
+          messages.getMessage(MessageId.ACC_001).getMessage());
+    } finally {
+      // Reset the global host JVM locale
+      Locale.setDefault(previousLocale);
+    }
   }
   
   @Test

--- a/src/test/java/com/adobe/epubcheck/test/UtilMessage_LocalizationTest.java
+++ b/src/test/java/com/adobe/epubcheck/test/UtilMessage_LocalizationTest.java
@@ -38,24 +38,25 @@ public class UtilMessage_LocalizationTest {
     
     Locale newLocale = new Locale("es");
     Locale previousLocale = Locale.getDefault();
-    Locale.setDefault(newLocale);
-    
-    Messages messages = Messages.getInstance(); // should return the default localization
-    Locale locale = messages.getLocale();
-    Locale defaultLocale = Locale.getDefault();
-    Assert.assertEquals( "After setting host locale, default constructor should use new host default locale.",
-            locale, defaultLocale);
-    
-    System.out.format( "Locales are: %s & %s\n", locale.getLanguage(), defaultLocale.getLanguage());
-    
-    Messages messagesWithExplicitLocale = Messages.getInstance(newLocale);
-    
-    // Messages should be the same for default locale and explicitly set locale
-    Assert.assertEquals( "Messages should match if explicit and host locales are the same.",
-            messagesWithExplicitLocale.get(NO_ERRORS_OR_WARNINGS), 
-            messages.get(NO_ERRORS_OR_WARNINGS));
-    // Reset the global host JVM locale
-    Locale.setDefault(previousLocale);
+    try {
+      Locale.setDefault(newLocale);
+      
+      Messages messages = Messages.getInstance(); // should return the default localization
+      Locale locale = messages.getLocale();
+      Locale defaultLocale = Locale.getDefault();
+      Assert.assertEquals( "After setting host locale, default constructor should use new host default locale.",
+          locale, defaultLocale);
+      
+      Messages messagesWithExplicitLocale = Messages.getInstance(newLocale);
+      
+      // Messages should be the same for default locale and explicitly set locale
+      Assert.assertEquals( "Messages should match if explicit and host locales are the same.",
+          messagesWithExplicitLocale.get(NO_ERRORS_OR_WARNINGS), 
+          messages.get(NO_ERRORS_OR_WARNINGS));
+    } finally {
+      // Reset the global host JVM locale
+      Locale.setDefault(previousLocale);
+    }
   }
   
   @Test

--- a/src/test/java/com/adobe/epubcheck/test/common.java
+++ b/src/test/java/com/adobe/epubcheck/test/common.java
@@ -164,6 +164,7 @@ public class common
         outWriter.printf("Start %s test('%s')\n", componentName, testName);
       }
       int result = Integer.MAX_VALUE;
+      Locale previousLocale = Locale.getDefault();
       try
       {
         Locale.setDefault(Locale.US);
@@ -172,6 +173,9 @@ public class common
       catch (NoExitSecurityManager.ExitException e)
       {
         result = e.status;
+      }
+      finally {
+        Locale.setDefault(previousLocale);
       }
 
       Assert.assertEquals("Return code", expectedReturnCode, result);


### PR DESCRIPTION
Some tests were setting the default Locale, but were not setting it back to the original value. This side effect caused later localization tests to fail.

This PR fixes that by making sure the default locale is reset, in a `finally` block, whenever it is explicitly set in tests.

Fixes #916