### PR TITLE
Some OSGi related changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.5.4</version>
+                <version>3.2.0</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -298,6 +298,10 @@
                 </executions>
                 <configuration>
                     <instructions>
+                        <Import-Package>
+                            net.sf.saxon.*;version="[9.8.0,9.8.1)",
+                            *
+                        </Import-Package>
                         <_removeheaders>Include-Resource,Private-Package, Bnd-LastModified, Build-Jdk, Built-By</_removeheaders>
                     </instructions>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,7 @@
                         </goals>
                         <configuration>
                             <includedScopes>runtime,compile</includedScopes>
-                            <fileTemplate>src/main/licenses/third-party.ftl</fileTemplate>
+                            <fileTemplate>${project.basedir}/src/main/licenses/third-party.ftl</fileTemplate>
                             <useMissingFile>true</useMissingFile>
                             <missingFile>src/main/licenses/third-party.properties</missingFile>
                             <deployMissingFile>false</deployMissingFile>


### PR DESCRIPTION
- The version of Saxon needs to be restricted to a more specific range because Saxon doesn't do semantic versioning.
- Update to more recent version of maven-bundle-plugin to solve a problem when using two versions of jing (20120724.0.0 + a newer one) in the same OSGi application.