### PR TITLE
Fix #922

### DIFF
--- a/src/main/java/com/adobe/epubcheck/ctc/css/EpubCSSCheckCSSHandler.java
+++ b/src/main/java/com/adobe/epubcheck/ctc/css/EpubCSSCheckCSSHandler.java
@@ -582,6 +582,19 @@ public class EpubCSSCheckCSSHandler implements CssContentHandler, CssErrorHandle
               // report absolute font-size as ACC USAGE message
               getReport().message(id, getCorrectedEPUBLocation(path, declaration.getLocation().getLine(), declaration.getLocation().getColumn(), declaration.toCssString()), construct.toCssString());
               break;
+            case INTEGER:
+              // issue 922: "0" should be allowed as font-size
+              if (quantity.toCssString().equals("0"))
+              {
+                // report absolute font-size as ACC USAGE message
+                getReport().message(id, getCorrectedEPUBLocation(path, declaration.getLocation().getLine(), declaration.getLocation().getColumn(), declaration.toCssString()), construct.toCssString());
+              }
+              else
+              {
+                // report unsupported font-size as ERROR message
+                getReport().message(MessageId.CSS_020, getCorrectedEPUBLocation(path, declaration.getLocation().getLine(), declaration.getLocation().getColumn(), declaration.toCssString()), construct.toCssString());
+              }
+              break;
             default:
               // report unsupported font-size as ERROR message
               getReport().message(MessageId.CSS_020, getCorrectedEPUBLocation(path, declaration.getLocation().getLine(), declaration.getLocation().getColumn(), declaration.toCssString()), construct.toCssString());
@@ -713,6 +726,11 @@ public class EpubCSSCheckCSSHandler implements CssContentHandler, CssErrorHandle
         case EXS:
         case LENGTH:
           return true;
+        case INTEGER:
+          if (quantity.toCssString().equals("0"))
+          {
+            return true;
+          }
       }
     }
     return false;

--- a/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
@@ -614,6 +614,12 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   }
   
   @Test
+  public void testIssue922()
+  {
+    testValidateDocument("valid/issue922/");
+  }
+
+  @Test
   public void testResource_Missing() {
     Collections.addAll(expectedErrors, MessageId.RSC_001);
     testValidateDocument("invalid/resource-missing/");

--- a/src/test/resources/30/expanded/valid/issue922/EPUB/lorem.css
+++ b/src/test/resources/30/expanded/valid/issue922/EPUB/lorem.css
@@ -1,0 +1,8 @@
+body {
+    font-size: 0;
+    margin: 0;
+    padding: 0;
+
+    color:black;
+    font-family: arial, helvetica, sans-serif;
+}

--- a/src/test/resources/30/expanded/valid/issue922/EPUB/lorem.opf
+++ b/src/test/resources/30/expanded/valid/issue922/EPUB/lorem.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+    <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <dc:identifier id="uid">urn:uuid:550e8400-e29b-41d4-a716-446667441231</dc:identifier>
+        <dc:title>Lorem Ipsum</dc:title>        
+        <dc:language>la</dc:language>
+        <dc:date>2011-09-01</dc:date>
+        <meta property="dcterms:modified">2011-09-01T17:18:00Z</meta>
+    </metadata> 
+    <manifest>
+        <item id="t1" href="lorem.xhtml" properties="nav" media-type="application/xhtml+xml" />                
+        <item id="css" href="lorem.css" media-type="text/css" />
+    </manifest>
+    <spine>
+        <itemref idref="t1" />        
+    </spine>    
+</package>

--- a/src/test/resources/30/expanded/valid/issue922/EPUB/lorem.xhtml
+++ b/src/test/resources/30/expanded/valid/issue922/EPUB/lorem.xhtml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="la" lang="la"
+	xmlns:epub="http://www.idpf.org/2007/ops">
+	<head>
+		<title>Lorem Ipsum</title>
+		<link type="text/css" rel="stylesheet" href="lorem.css" />
+	</head>
+	<body>
+		<h1>Lorem Ipsum</h1>
+		<section>
+			<h2>Table of Contents</h2>
+			<nav epub:type="toc">
+				<ol>
+					<li><a href="#ch1">Chapter 1</a></li>
+					<li><a href="#ch2">Chapter 2</a></li>
+				</ol>
+			</nav>
+		</section>
+		<section id="ch1">
+			<h2>Chapter 1</h2>
+			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam vel purus mauris, ut
+				auctor massa. sit amet Pellentesque non nunc risus. Fusce a massa augue. Nunc erat ante,
+				auctor id varius ac, vestibulum non purus. Quisque non dui in sem consectetur
+				condimentum non ac quam. Quisque ultricies nulla nec urna fringilla pretium.
+				Pellentesque dictum pulvinar purus in mattis. Aliquam vestibulum orci sed magna
+				vestibulum a sollicitudin lectus pharetra. Suspendisse luctus risus imperdiet nunc
+				condimentum malesuada. Nulla fringilla vulputate vestibulum. Sed diam dui, fringilla
+				quis sagittis nec, viverra et nibh.</p>
+
+			<p>Sed sollicitudin accumsan augue, quis pulvinar sem volutpat at. Vestibulum rutrum
+				bibendum augue sit amet accumsan. Etiam tempus malesuada libero vestibulum
+				fringilla. Maecenas diam nulla, ultricies ac sodales vitae, viverra ut velit.
+				Vivamus posuere, mi sit amet vehicula tempus, nibh purus scelerisque enim, non
+				vestibulum erat arcu in libero. Aliquam vel convallis nibh. Sed in nisi ipsum. Sed
+				sed est justo, in lacinia nulla.</p>
+
+			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed luctus est vel lacus
+				ullamcorper vestibulum. Mauris est sapien, pharetra id feugiat in, ornare a erat.
+				Nam consectetur vehicula nisi vel faucibus. Morbi blandit augue nec lacus malesuada
+				venenatis. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
+				ridiculus mus. Maecenas consectetur, odio vitae suscipit ullamcorper, arcu ligula
+				pellentesque sem, quis rhoncus enim eros id lectus. Nam ornare dui est, vel posuere
+				metus. Quisque non nisl metus. Pellentesque id mi nunc, in gravida metus. Nullam
+				neque tellus, ultricies quis laoreet vitae, imperdiet at nunc. Ut laoreet massa quis
+				quam vulputate et ultricies nibh consectetur. Donec convallis, nulla id ultricies
+				ullamcorper, diam tortor interdum dolor, vel tempor lectus urna ut est. Praesent
+				convallis lacus vitae justo lobortis euismod. In at ante elit.</p>
+
+			<p>Aenean quis consectetur justo. Nulla nec enim nisl. Etiam rutrum volutpat tellus, a
+				scelerisque mauris malesuada sit amet. Suspendisse quis urna augue. Proin tempus
+				hendrerit libero non cursus. Praesent non massa at nisl luctus facilisis. Nullam
+				pulvinar, ligula eu porta ornare, mi mi accumsan orci, a iaculis tortor lorem quis
+				dolor. Phasellus ante nibh, pulvinar ac pulvinar eu, pulvinar ac enim.</p>
+
+			<p>Donec vel velit id elit volutpat vestibulum vitae a erat. Duis id est id magna
+				aliquam pretium nec sit amet nibh. Nullam condimentum suscipit felis, sed interdum
+				felis dictum ac. Phasellus non nisi quis magna pellentesque auctor. Cras risus
+				lectus, viverra eu fringilla malesuada, rhoncus et est. Etiam rhoncus pharetra
+				accumsan. Nullam suscipit tellus felis.</p>
+		</section>
+		<section id="ch2">
+			<h2>Chapter 2</h2>
+			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla laoreet nibh felis.
+				Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia
+				Curae; Etiam est sapien, dapibus eget gravida nec, accumsan a turpis. Nunc in nisi
+				ut dolor elementum porttitor. Mauris hendrerit pulvinar tincidunt. Etiam metus
+				metus, ullamcorper ut varius lacinia, luctus et nibh. Donec ut metus enim, id
+				faucibus nunc. Quisque ut iaculis mauris. Duis pellentesque nulla ut eros ultricies
+				quis condimentum eros adipiscing. Sed porta ultrices diam, ut sagittis lectus mattis
+				a. Phasellus gravida, sapien vitae mollis interdum, dui neque tempor arcu, ac ornare
+				leo ipsum ut nisl.</p>
+
+			<p>Donec porta, odio et aliquet molestie, felis tellus fermentum leo, id interdum magna
+				massa quis ligula. Integer elementum mauris eget nisl eleifend facilisis nec sit
+				amet tellus. Morbi consectetur dignissim egestas. Donec pulvinar, enim eu auctor
+				cursus, turpis arcu venenatis turpis, eu cursus magna nisl sit amet ante. Curabitur
+				eleifend arcu eget nibh facilisis mattis. Etiam nisl nunc, semper vitae condimentum
+				sed, viverra sit amet lacus. Curabitur et orci augue. Suspendisse sollicitudin
+				vulputate risus, sit amet consequat erat mollis eu. Nunc sodales tincidunt
+				tincidunt.</p>
+
+			<p>Aliquam erat volutpat. Aliquam ornare augue et nulla consequat commodo. Quisque
+				dictum rhoncus orci vel euismod. Proin leo turpis, adipiscing quis facilisis id,
+				condimentum sed metus. Nullam pellentesque scelerisque est nec tristique. Nunc augue
+				turpis, consequat non varius quis, aliquam auctor dolor. Cras luctus dignissim justo
+				sit amet laoreet. Quisque vel ipsum quis massa suscipit vehicula.</p>
+
+			<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis
+				egestas. Vivamus fringilla eleifend magna, vel commodo turpis egestas at.
+				Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis
+				egestas. Sed eu lorem quam, et sagittis libero. Maecenas vel ante id sem bibendum
+				laoreet nec dignissim justo. Class aptent taciti sociosqu ad litora torquent per
+				conubia nostra, per inceptos himenaeos. Fusce eu lorem orci, eu viverra nisi. Lorem
+				ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum dapibus commodo
+				pellentesque. Maecenas quis est accumsan est interdum pharetra egestas nec lorem.
+				Nam a lectus sit amet justo facilisis suscipit.</p>
+
+			<p>Integer dolor dolor, volutpat id commodo id, gravida id risus. Donec consectetur
+				sollicitudin sem, non auctor urna pulvinar non. Vivamus ipsum nisi, commodo sed
+				scelerisque id, porta nec massa. Vestibulum ac risus et augue faucibus fermentum ut
+				et nisi. Integer tincidunt suscipit ipsum, sed interdum felis mollis sed.
+				Suspendisse potenti. Praesent et mauris et quam consequat tristique. Morbi mi dolor,
+				pharetra quis rutrum quis, fringilla in tortor. Sed a nulla vitae leo dapibus
+				cursus. Aliquam erat volutpat. Integer purus purus, dictum id bibendum at, lobortis
+				quis metus.</p>
+		</section>
+	</body>
+</html>

--- a/src/test/resources/30/expanded/valid/issue922/META-INF/container.xml
+++ b/src/test/resources/30/expanded/valid/issue922/META-INF/container.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
+	<rootfiles>
+		<rootfile full-path="EPUB/lorem.opf" 	
+			media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/30/expanded/valid/issue922/mimetype
+++ b/src/test/resources/30/expanded/valid/issue922/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip    


### PR DESCRIPTION
Suppress the error of `font-size: 0;`.

I think `0` is treated as "zero length", so this patch makes an USAGE message `ACC_014` (use a relative size) with `-u` option.  Is it expected?
