### PR TITLE
remove default locale setting in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.18.1</version>
                 <configuration>
-                    <argLine>-Xmx1g -Duser.language=en -Duser.country=US</argLine>
+                    <argLine>-Xmx1g</argLine>
                     <workingDirectory>${project.build.directory}/test-classes</workingDirectory>
                     <!-- manifestFile>${project.build.directory}/classes/META-INF/MANIFEST.MF</manifestFile -->
                 </configuration>

--- a/src/test/java/com/adobe/epubcheck/ocf/OCFCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/ocf/OCFCheckerTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.Test;
 
@@ -49,7 +50,7 @@ public class OCFCheckerTest
     ValidationReport testReport = new ValidationReport(fileName,
         String.format("Package is being checked as EPUB version %s",
             version == null ? "null" : version.toString()));
-
+    testReport.setLocale(Locale.ENGLISH);
     OCFChecker checker = new OCFChecker(
         new ValidationContextBuilder().ocf(ocf).report(testReport).version(version).build());
 

--- a/src/test/java/com/adobe/epubcheck/test/api_Test.java
+++ b/src/test/java/com/adobe/epubcheck/test/api_Test.java
@@ -6,6 +6,7 @@ import java.io.FileOutputStream;
 import java.io.PrintWriter;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -24,6 +25,7 @@ public class api_Test
   {
     File epub = getTestEpub();
     EpubCheck check = new EpubCheck(epub);
+    check.setLocale(Locale.ENGLISH);
     Assert.assertEquals("The file should have generated errors.", 2, 2 & check.doValidate());
   }
 
@@ -39,6 +41,7 @@ public class api_Test
       FileOutputStream outputStream = new FileOutputStream(actualResults);
       PrintWriter out = new PrintWriter(outputStream);
       EpubCheck check = new EpubCheck(epub, out);
+      check.setLocale(Locale.ENGLISH);
       Assert.assertEquals("The file should have generated errors.", 2, 2 & check.doValidate());
       out.flush();
       outputStream.close();
@@ -66,6 +69,7 @@ public class api_Test
       FileInputStream epubStream = new FileInputStream(epub);
       Report report = new WriterReportImpl(out, "Testing 123");
       EpubCheck check = new EpubCheck(epubStream, report, epub.getPath());
+      check.setLocale(Locale.ENGLISH);
       Assert.assertEquals("The file should have generated errors.", 2, 2 & check.doValidate());
       out.flush();
       outputStream.close();

--- a/src/test/java/com/adobe/epubcheck/test/command_line_Test.java
+++ b/src/test/java/com/adobe/epubcheck/test/command_line_Test.java
@@ -8,6 +8,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URL;
+import java.util.Locale;
 
 import junit.framework.Assert;
 
@@ -33,7 +34,7 @@ public class command_line_Test
   private SecurityManager originalManager;
   private PrintStream originalOut;
   private PrintStream originalErr;
-  private final Messages messages = Messages.getInstance();
+  private final Messages messages = Messages.getInstance(Locale.ENGLISH);
 
   @Before
   public void setUp() throws Exception

--- a/src/test/java/com/adobe/epubcheck/test/package_Test.java
+++ b/src/test/java/com/adobe/epubcheck/test/package_Test.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.After;
 import org.junit.Before;
@@ -258,6 +259,7 @@ public class package_Test
     String expectedOutputPath = inputPath + "/wrong_extension_expected_results.json";
     inputPath += "/wrong_extension.zip";
     CheckingReport report = new CheckingReport(inputPath, outputPath);
+    report.setLocale(Locale.ENGLISH);
     report.initialize();
     File inputEpub = new File(inputPath);
     EpubCheck check = new EpubCheck(inputEpub, report);
@@ -282,6 +284,7 @@ public class package_Test
     String expectedOutputPath = inputPath + "/wrong_extension_v3_expected_results.json";
     inputPath += "/wrong_extension_v3.zip";
     CheckingReport report = new CheckingReport(inputPath, outputPath);
+    report.setLocale(Locale.ENGLISH);
     report.initialize();
     File inputEpub = new File(inputPath);
     EpubCheck check = new EpubCheck(inputEpub, report);
@@ -305,6 +308,7 @@ public class package_Test
     String expectedOutputPath = inputPath + "/missing_file_expected_results.json";
     inputPath += "/no_existence.epub";
     CheckingReport report = new CheckingReport(inputPath, outputPath);
+    report.setLocale(Locale.ENGLISH);
     report.initialize();
     File inputEpub = new File(inputPath);
     EpubCheck check = new EpubCheck(inputEpub, report);
@@ -329,6 +333,7 @@ public class package_Test
     inputPath += "/missing_opf_file";
     OCFPackage ocf = new OCFMockPackage(inputPath);
     CheckingReport report = new CheckingReport(inputPath, outputPath);
+    report.setLocale(Locale.ENGLISH);
     report.initialize();
     ocf.setReport(report);
     OPFChecker opfChecker = new OPFChecker(new ValidationContextBuilder().path("test_single_opf")

--- a/src/test/java/com/adobe/epubcheck/test/single_file_Test.java
+++ b/src/test/java/com/adobe/epubcheck/test/single_file_Test.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.Locale;
 
 /**
  * Test the processing of single files that are not ePubs
@@ -15,7 +16,7 @@ import java.io.PrintStream;
 public class single_file_Test
 {
   private SecurityManager originalManager;
-  private final Messages messages = Messages.getInstance();
+  private final Messages messages = Messages.getInstance(Locale.ENGLISH);
 
   @Before
   public void setUp() throws Exception


### PR DESCRIPTION
fix #919.

set locale as English per methods/classes if needed.

I've tested in my environments: `ja_JP`.
