### PR TITLE
fix: wrong report of duplicate landmarks in Nav Doc

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/20/sch/opf.sch
+++ b/src/main/resources/com/adobe/epubcheck/schema/20/sch/opf.sch
@@ -20,7 +20,7 @@
         count(//opf:reference[
           normalize-space(lower-case(@type)) = $current_type_normalized and
           normalize-space(lower-case(@href)) = $current_href_normalized
-        ]) = 1">WARNING: Duplicate 'reference' elements with the same 'type' and 'href' attributes</sch:assert>
+        ]) le 1">WARNING: Duplicate 'reference' elements with the same 'type' and 'href' attributes</sch:assert>
     </sch:rule>
   </sch:pattern>
 

--- a/src/main/resources/com/adobe/epubcheck/schema/30/epub-nav-30.sch
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/epub-nav-30.sch
@@ -24,8 +24,8 @@
 
     <pattern id="landmarks">
         <rule context="html:nav[tokenize(@epub:type,'\s+')='landmarks']//html:ol//html:a">
-            <let name="current_type_normalized" value="normalize-space(lower-case(@epub:type))"/>
-            <let name="current_href_normalized" value="normalize-space(lower-case(@html:href))"/>
+            <let name="current_type_normalized" value="tokenize(lower-case(@epub:type),'\s+')"/>
+            <let name="current_href_normalized" value="normalize-space(lower-case(@href))"/>
 
             <!-- Check for missing epub:type attributes -->
             <assert test="@epub:type">Missing epub:type attribute on anchor inside 'landmarks' nav element</assert>
@@ -35,10 +35,10 @@
                 and only reported within the same ancestor landmarks element
             -->
             <assert test="
-                count(ancestor::html:nav[tokenize(@epub:type,'\s+')='landmarks']//html:ol//html:a[
-                    normalize-space(lower-case(@epub:type)) = $current_type_normalized and
-                    normalize-space(lower-case(@html:href)) = $current_href_normalized
-                    ]) = 1">WARNING: Duplicate 'a' elements with the same 'epub:type' and 'href' attributes inside 'landmarks' nav element</assert>
+                count(ancestor::html:nav//html:ol//html:a[
+                    tokenize(lower-case(@epub:type),'\s+') = $current_type_normalized and
+                    normalize-space(lower-case(@href)) = $current_href_normalized
+                    ]) le 1">WARNING: Duplicate 'a' elements with the same 'epub:type' and 'href' attributes inside 'landmarks' nav element</assert>
         </rule>
     </pattern>
 

--- a/src/main/resources/com/adobe/epubcheck/schema/30/package-30.sch
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/package-30.sch
@@ -290,7 +290,7 @@
                 count(//opf:reference[
                     normalize-space(lower-case(@type)) = $current_type_normalized and
                     normalize-space(lower-case(@href)) = $current_href_normalized
-                ]) = 1">WARNING: Duplicate 'reference' elements with the same 'type' and 'href' attributes</assert>
+                ]) le 1">WARNING: Duplicate 'reference' elements with the same 'type' and 'href' attributes</assert>
         </rule>
     </pattern>
     

--- a/src/test/java/com/adobe/epubcheck/nav/NavCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/nav/NavCheckerTest.java
@@ -180,6 +180,13 @@ public class NavCheckerTest
     Collections.addAll(expectedWarnings, MessageId.RSC_017, MessageId.RSC_017);
     testValidateDocument("invalid/nav-landmarks-duplicates.xhtml");
   }
+  
+  @Test
+  public void testValidateDocumentNavLandmarksNoDuplicates()
+  {
+    // tests multiple occurrences of the 'landmarks' nav element without duplicates
+    testValidateDocument("valid/nav-landmarks-noduplicates.xhtml");
+  }
 
   @Test
   public void testValidateDocumentNavNoPagelist001()

--- a/src/test/resources/30/single/nav/valid/nav-landmarks-noduplicates.xhtml
+++ b/src/test/resources/30/single/nav/valid/nav-landmarks-noduplicates.xhtml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?oxygen RNGSchema="../../../src/schema/epub-nav-30.rnc" type="compact"?>
-<?oxygen SCHSchema="../../../src/schema/epub-xhtml-30.sch"?>
-<?oxygen SCHSchema="../../../src/schema/epub-nav-30.sch"?>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
-    <head></head>
+    <head>
+        <title>Test</title>
+    </head>
     <body>
         
         <nav epub:type="toc" id="toc">
@@ -19,17 +18,15 @@
                 <li><a href="chap1.xhtml">Chapter 2</a></li>
             </ol>
         </nav>
-
+        
         <nav epub:type="landmarks">
             <!-- the guide -->
             <h2>Guide</h2>
             <ol>
-                <li><a epub:type="toc" href="#toc">Table of Contents</a></li>
-                <li><a epub:type="loi" href="content.html#loi">List of Illustrations</a></li>
-                <li><a epub:type="bodymatter" href="content.html#bodymatter">Start of Content</a></li>
-                <li><a epub:type="loa loi" href="content.html#loi">List of Illustrations</a></li>
+                <li><a epub:type="loi" href="loi-A.html">List of Illustrations A</a></li>
+                <li><a epub:type="loi" href="loi-B.html">List of Illustrations B</a></li>
             </ol>
         </nav>
-
+        
     </body>
 </html>


### PR DESCRIPTION
The XPath in Schematron was using `@html:href` instead of `@href`,
which faked the href equality test.

This change also covers the case of multiple `epub:type` values.

Fixes #926