### PR TITLE
fix: `switch` item property doesn't apply to `svg:switch`

### DIFF
--- a/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
@@ -245,7 +245,7 @@ public class OPSHandler30 extends OPSHandler
     {
       requiredProperties.add(ITEM_PROPERTIES.SCRIPTED);
     }
-    else if (!context.mimeType.equals("image/svg+xml") && name.equals("switch"))
+    else if (EpubConstants.EpubTypeNamespaceUri.equals(e.getNamespace()) && name.equals("switch"))
     {
       requiredProperties.add(ITEM_PROPERTIES.SWITCH);
     }

--- a/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
@@ -419,6 +419,13 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   }
 
   @Test
+  public void testValidateEPUB30_svgSwitch()
+  {
+    // tests that svg:switch doesn't trigger the OPF 'switch' property check
+    testValidateDocument("valid/svg-switch/");
+  }
+
+  @Test
   public void testValidateEPUB30_videoAudioTrigger()
   {
     testValidateDocument("valid/cc-shared-culture/", "valid/cc-shared-culture.txt");

--- a/src/test/resources/30/expanded/valid/svg-switch/META-INF/container.xml
+++ b/src/test/resources/30/expanded/valid/svg-switch/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+   <rootfiles>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+   </rootfiles>
+</container>

--- a/src/test/resources/30/expanded/valid/svg-switch/OPS/content_001.xhtml
+++ b/src/test/resources/30/expanded/valid/svg-switch/OPS/content_001.xhtml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops"
+	xmlns:svg="http://www.w3.org/2000/svg" xml:lang="en" lang="en">
+	<head>
+		<title>Minimal EPUB</title>
+	</head>
+	<body epub:type="bodymatter">
+		<h1>Loomings</h1>
+		<p>Call me Ishmael.</p>
+		<svg:svg width="400px" height="300px" viewBox="0 0 400 300">
+			<svg:switch>
+				<svg:foreignObject width="100" height="50" requiredExtensions="http://www.idpf.org/2007/ops">
+					<p xmlns="http://www.w3.org/1999/xhtml">foo</p>
+				</svg:foreignObject>
+				<svg:text font-size="10" font-family="Verdana">
+					<svg:tspan x="10" y="10">bar</svg:tspan>
+				</svg:text>
+			</svg:switch>
+		</svg:svg>
+	</body>
+</html>

--- a/src/test/resources/30/expanded/valid/svg-switch/OPS/nav.xhtml
+++ b/src/test/resources/30/expanded/valid/svg-switch/OPS/nav.xhtml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+		<nav epub:type="landmarks">
+			<ol>
+				<li><a href="content_001.xhtml" epub:type="bodymatter">Start Reading</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/30/expanded/valid/svg-switch/OPS/package.opf
+++ b/src/test/resources/30/expanded/valid/svg-switch/OPS/package.opf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="q">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+</metadata>
+<manifest>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml" properties="svg"/>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/src/test/resources/30/expanded/valid/svg-switch/mimetype
+++ b/src/test/resources/30/expanded/valid/svg-switch/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip


### PR DESCRIPTION
The `switch` property of Package Documents `item` elements indicates
that the described Publication Resource contains one or more instances
of the `epub:switch` element. It should not be declared when the EPUB
contains SVG using the `svg:switch` element.

Fixes #857