### PR TITLE
Re-enable openjdk11 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
+  - openjdk11
   - oraclejdk11
   - openjdk10
   - oraclejdk9


### PR DESCRIPTION
The builds are now run on `xenial`, where openjdk 10 and 11 are pre-installed.

See also this [Travis CI community discussion](https://travis-ci.community/t/install-of-openjdk11-is-failing/1914).