### PR TITLE
Better support for the accessibility vocab

### DIFF
--- a/src/main/java/com/adobe/epubcheck/opf/OPFHandler30.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFHandler30.java
@@ -22,8 +22,27 @@
 
 package com.adobe.epubcheck.opf;
 
-import static com.adobe.epubcheck.vocab.ForeignVocabs.*;
-import static com.adobe.epubcheck.vocab.PackageVocabs.*;
+import static com.adobe.epubcheck.vocab.ForeignVocabs.DCTERMS_PREFIX;
+import static com.adobe.epubcheck.vocab.ForeignVocabs.DCTERMS_URI;
+import static com.adobe.epubcheck.vocab.ForeignVocabs.DCTERMS_VOCAB;
+import static com.adobe.epubcheck.vocab.ForeignVocabs.MARC_PREFIX;
+import static com.adobe.epubcheck.vocab.ForeignVocabs.MARC_URI;
+import static com.adobe.epubcheck.vocab.ForeignVocabs.MARC_VOCAB;
+import static com.adobe.epubcheck.vocab.ForeignVocabs.ONIX_PREFIX;
+import static com.adobe.epubcheck.vocab.ForeignVocabs.ONIX_URI;
+import static com.adobe.epubcheck.vocab.ForeignVocabs.ONIX_VOCAB;
+import static com.adobe.epubcheck.vocab.ForeignVocabs.SCHEMA_PREFIX;
+import static com.adobe.epubcheck.vocab.ForeignVocabs.SCHEMA_URI;
+import static com.adobe.epubcheck.vocab.ForeignVocabs.SCHEMA_VOCAB;
+import static com.adobe.epubcheck.vocab.ForeignVocabs.XSD_PREFIX;
+import static com.adobe.epubcheck.vocab.ForeignVocabs.XSD_URI;
+import static com.adobe.epubcheck.vocab.ForeignVocabs.XSD_VOCAB;
+import static com.adobe.epubcheck.vocab.PackageVocabs.ITEMREF_VOCAB;
+import static com.adobe.epubcheck.vocab.PackageVocabs.ITEM_VOCAB;
+import static com.adobe.epubcheck.vocab.PackageVocabs.LINKREL_VOCAB;
+import static com.adobe.epubcheck.vocab.PackageVocabs.LINKREL_VOCAB_URI;
+import static com.adobe.epubcheck.vocab.PackageVocabs.META_VOCAB;
+import static com.adobe.epubcheck.vocab.PackageVocabs.PACKAGE_VOCAB_URI;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -41,7 +60,6 @@ import com.adobe.epubcheck.util.EpubConstants;
 import com.adobe.epubcheck.util.FeatureEnum;
 import com.adobe.epubcheck.util.PathUtil;
 import com.adobe.epubcheck.vocab.DCMESVocab;
-import com.adobe.epubcheck.vocab.EnumVocab;
 import com.adobe.epubcheck.vocab.EpubCheckVocab;
 import com.adobe.epubcheck.vocab.MediaOverlaysVocab;
 import com.adobe.epubcheck.vocab.PackageVocabs.ITEM_PROPERTIES;
@@ -476,7 +494,7 @@ public class OPFHandler30 extends OPFHandler
       {
         report.message(MessageId.OPF_012,
             EPUBLocation.create(path, parser.getLineNumber(), parser.getColumnNumber()),
-            EnumVocab.ENUM_TO_NAME.apply(itemProp), mimeType);
+            ITEM_VOCAB.getName(itemProp), mimeType);
       }
     }
     builder.properties(properties);

--- a/src/main/java/com/adobe/epubcheck/opf/OPFHandler30.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFHandler30.java
@@ -59,6 +59,7 @@ import com.adobe.epubcheck.opf.XRefChecker.Type;
 import com.adobe.epubcheck.util.EpubConstants;
 import com.adobe.epubcheck.util.FeatureEnum;
 import com.adobe.epubcheck.util.PathUtil;
+import com.adobe.epubcheck.vocab.AccessibilityVocab;
 import com.adobe.epubcheck.vocab.DCMESVocab;
 import com.adobe.epubcheck.vocab.EpubCheckVocab;
 import com.adobe.epubcheck.vocab.MediaOverlaysVocab;
@@ -85,7 +86,8 @@ public class OPFHandler30 extends OPFHandler
       .put(DCTERMS_PREFIX, DCTERMS_VOCAB).put(MARC_PREFIX, MARC_VOCAB).put(ONIX_PREFIX, ONIX_VOCAB)
       .put(SCHEMA_PREFIX, SCHEMA_VOCAB).put(XSD_PREFIX, XSD_VOCAB).build();
   private static final Map<String, Vocab> RESERVED_META_VOCABS = new ImmutableMap.Builder<String, Vocab>()
-      .put("", META_VOCAB).put(MediaOverlaysVocab.PREFIX, MediaOverlaysVocab.VOCAB)
+      .put("", META_VOCAB).put(AccessibilityVocab.PREFIX, AccessibilityVocab.META_VOCAB)
+      .put(MediaOverlaysVocab.PREFIX, MediaOverlaysVocab.VOCAB)
       .put(RenditionVocabs.PREFIX, RenditionVocabs.META_VOCAB)
       .put(ScriptedCompVocab.PREFIX, ScriptedCompVocab.VOCAB).putAll(RESERVED_VOCABS).build();
   private static final Map<String, Vocab> RESERVED_ITEM_VOCABS = new ImmutableMap.Builder<String, Vocab>()
@@ -95,14 +97,16 @@ public class OPFHandler30 extends OPFHandler
       .put("", ITEMREF_VOCAB).put(MediaOverlaysVocab.PREFIX, VocabUtil.EMPTY_VOCAB)
       .put(RenditionVocabs.PREFIX, RenditionVocabs.ITEMREF_VOCAB).putAll(RESERVED_VOCABS).build();
   private static final Map<String, Vocab> RESERVED_LINKREL_VOCABS = new ImmutableMap.Builder<String, Vocab>()
-      .put("", LINKREL_VOCAB).put(MediaOverlaysVocab.PREFIX, VocabUtil.EMPTY_VOCAB)
+      .put("", LINKREL_VOCAB).put(AccessibilityVocab.PREFIX, AccessibilityVocab.LINKREL_VOCAB)
+      .put(MediaOverlaysVocab.PREFIX, VocabUtil.EMPTY_VOCAB)
       .put(RenditionVocabs.PREFIX, VocabUtil.EMPTY_VOCAB).putAll(RESERVED_VOCABS).build();
 
   private static final Map<String, Vocab> KNOWN_VOCAB_URIS = new ImmutableMap.Builder<String, Vocab>()
       .put(DCTERMS_URI, DCTERMS_VOCAB).put(MARC_URI, MARC_VOCAB).put(ONIX_URI, ONIX_VOCAB)
       .put(SCHEMA_URI, SCHEMA_VOCAB).put(XSD_URI, XSD_VOCAB).build();
   private static final Map<String, Vocab> KNOWN_META_VOCAB_URIS = new ImmutableMap.Builder<String, Vocab>()
-      .putAll(KNOWN_VOCAB_URIS).put(MediaOverlaysVocab.URI, MediaOverlaysVocab.VOCAB)
+      .putAll(KNOWN_VOCAB_URIS).put(AccessibilityVocab.URI, AccessibilityVocab.META_VOCAB)
+      .put(MediaOverlaysVocab.URI, MediaOverlaysVocab.VOCAB)
       .put(RenditionVocabs.URI, RenditionVocabs.META_VOCAB).build();
   private static final Map<String, Vocab> KNOWN_ITEM_VOCAB_URIS = new ImmutableMap.Builder<String, Vocab>()
       .putAll(KNOWN_VOCAB_URIS).put(MediaOverlaysVocab.URI, VocabUtil.EMPTY_VOCAB)
@@ -111,7 +115,8 @@ public class OPFHandler30 extends OPFHandler
       .putAll(KNOWN_VOCAB_URIS).put(MediaOverlaysVocab.URI, VocabUtil.EMPTY_VOCAB)
       .put(RenditionVocabs.URI, RenditionVocabs.ITEMREF_VOCAB).build();
   private static final Map<String, Vocab> KNOWN_LINKREL_VOCAB_URIS = new ImmutableMap.Builder<String, Vocab>()
-      .putAll(KNOWN_VOCAB_URIS).put(MediaOverlaysVocab.URI, VocabUtil.EMPTY_VOCAB)
+      .putAll(KNOWN_VOCAB_URIS).put(AccessibilityVocab.URI, AccessibilityVocab.LINKREL_VOCAB)
+      .put(MediaOverlaysVocab.URI, VocabUtil.EMPTY_VOCAB)
       .put(RenditionVocabs.URI, VocabUtil.EMPTY_VOCAB).build();
 
   private static final Set<String> DEFAULT_VOCAB_URIS = ImmutableSet.of(PACKAGE_VOCAB_URI,

--- a/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
@@ -38,6 +38,7 @@ import com.adobe.epubcheck.vocab.VocabUtil;
 import com.adobe.epubcheck.xml.XMLAttribute;
 import com.adobe.epubcheck.xml.XMLElement;
 import com.adobe.epubcheck.xml.XMLParser;
+import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.Collections2;
@@ -713,7 +714,7 @@ public class OPSHandler30 extends OPSHandler
     for (ITEM_PROPERTIES requiredProperty : Sets.difference(requiredProperties, itemProps))
     {
       report.message(MessageId.OPF_014, EPUBLocation.create(path),
-          EnumVocab.ENUM_TO_NAME.apply(requiredProperty));
+          PackageVocabs.ITEM_VOCAB.getName(requiredProperty));
     }
 
     Set<ITEM_PROPERTIES> uncheckedProperties = Sets.difference(itemProps, requiredProperties)
@@ -732,7 +733,7 @@ public class OPSHandler30 extends OPSHandler
     if (!uncheckedProperties.isEmpty())
     {
       report.message(MessageId.OPF_015, EPUBLocation.create(path), Joiner.on(", ")
-          .join(Collections2.transform(uncheckedProperties, EnumVocab.ENUM_TO_NAME)));
+          .join(PackageVocabs.ITEM_VOCAB.getNames(uncheckedProperties)));
     }
   }
 }

--- a/src/main/java/com/adobe/epubcheck/vocab/AccessibilityVocab.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/AccessibilityVocab.java
@@ -1,0 +1,28 @@
+package com.adobe.epubcheck.vocab;
+
+import com.google.common.base.CaseFormat;
+
+public final class AccessibilityVocab
+{
+  public static final String PREFIX = "a11y";
+  public static final String URI = "http://www.idpf.org/epub/vocab/package/a11y/#";
+  public static final EnumVocab<META_PROPERTIES> META_VOCAB = new EnumVocab<META_PROPERTIES>(
+      META_PROPERTIES.class, CaseFormat.LOWER_CAMEL, URI, PREFIX);
+  public static final EnumVocab<LINKREL_PROPERTIES> LINKREL_VOCAB = new EnumVocab<LINKREL_PROPERTIES>(
+      LINKREL_PROPERTIES.class, CaseFormat.LOWER_CAMEL, URI, PREFIX);
+
+  public static enum META_PROPERTIES
+  {
+    CERTIFIED_BY,
+    CERTIFIER_CREDENTIAL,
+  }
+
+  public static enum LINKREL_PROPERTIES
+  {
+    CERTIFIER_REPORT;
+  }
+
+  private AccessibilityVocab()
+  {
+  }
+}

--- a/src/main/java/com/adobe/epubcheck/vocab/ComicsVocab.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/ComicsVocab.java
@@ -1,6 +1,6 @@
 package com.adobe.epubcheck.vocab;
 
-public class ComicsVocab
+public final class ComicsVocab
 {
   public static final String URI = "http://www.idpf.org/epub/vocab/structure/#";
   public static final EnumVocab<EPUB_TYPES> VOCAB = new EnumVocab<EPUB_TYPES>(EPUB_TYPES.class, URI);
@@ -13,4 +13,6 @@ public class ComicsVocab
       TEXT_AREA,
       SOUND_AREA
   }
+  
+  private ComicsVocab() {}
 }

--- a/src/main/java/com/adobe/epubcheck/vocab/DCMESVocab.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/DCMESVocab.java
@@ -1,6 +1,6 @@
 package com.adobe.epubcheck.vocab;
 
-public class DCMESVocab
+public final class DCMESVocab
 {
   public static final String URI = "http://purl.org/dc/elements/1.1/";
   public static final EnumVocab<PROPERTIES> VOCAB = new EnumVocab<PROPERTIES>(PROPERTIES.class, URI, "dc");
@@ -24,4 +24,6 @@ public class DCMESVocab
     TITLE,
     TYPE;
   }
+  
+  private DCMESVocab() {}
 }

--- a/src/main/java/com/adobe/epubcheck/vocab/DataNavVocab.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/DataNavVocab.java
@@ -1,6 +1,6 @@
 package com.adobe.epubcheck.vocab;
 
-public class DataNavVocab
+public final class DataNavVocab
 {
   public static final String URI = "http://www.idpf.org/epub/vocab/structure/#";
   public static final EnumVocab<EPUB_TYPES> VOCAB = new EnumVocab<EPUB_TYPES>(EPUB_TYPES.class,
@@ -10,4 +10,6 @@ public class DataNavVocab
   {
     REGION_BASED;
   }
+  
+  private DataNavVocab() {}
 }

--- a/src/main/java/com/adobe/epubcheck/vocab/DictVocab.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/DictVocab.java
@@ -1,6 +1,6 @@
 package com.adobe.epubcheck.vocab;
 
-public class DictVocab
+public final class DictVocab
 {
   public static final String URI = "http://www.idpf.org/epub/vocab/structure/#";
   public static final EnumVocab<EPUB_TYPES> VOCAB = new EnumVocab<EPUB_TYPES>(EPUB_TYPES.class,
@@ -29,4 +29,6 @@ public class DictVocab
     TRAN,
     TRAN_INFO;
   }
+  
+  private DictVocab() {}
 }

--- a/src/main/java/com/adobe/epubcheck/vocab/IndexVocab.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/IndexVocab.java
@@ -1,6 +1,6 @@
 package com.adobe.epubcheck.vocab;
 
-public class IndexVocab
+public final class IndexVocab
 {
   public static final String URI = "http://www.idpf.org/epub/vocab/structure/#";
   public static final EnumVocab<EPUB_TYPES> VOCAB = new EnumVocab<EPUB_TYPES>(EPUB_TYPES.class, URI);
@@ -23,4 +23,6 @@ public class IndexVocab
     INDEX_XREF_PREFERRED,
     INDEX_XREF_RELATED;
   }
+  
+  private IndexVocab() {}
 }

--- a/src/main/java/com/adobe/epubcheck/vocab/StagingEdupubVocab.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/StagingEdupubVocab.java
@@ -1,6 +1,6 @@
 package com.adobe.epubcheck.vocab;
 
-public class StagingEdupubVocab
+public final class StagingEdupubVocab
 {
   public static final String URI = "http://www.idpf.org/epub/vocab/structure/#";
   public static final EnumVocab<EPUB_TYPES> VOCAB = new EnumVocab<EPUB_TYPES>(EPUB_TYPES.class, URI);
@@ -40,4 +40,6 @@ public class StagingEdupubVocab
     TOC_BRIEF,
     TRUE_FALSE_PROBLEM;
   }
+  
+  private StagingEdupubVocab() {}
 }

--- a/src/main/java/com/adobe/epubcheck/vocab/StructureVocab.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/StructureVocab.java
@@ -1,6 +1,6 @@
 package com.adobe.epubcheck.vocab;
 
-public class StructureVocab
+public final class StructureVocab
 {
   public static final String URI = "http://www.idpf.org/epub/vocab/structure/#";
   public static final EnumVocab<EPUB_TYPES> VOCAB = new EnumVocab<EPUB_TYPES>(EPUB_TYPES.class, URI);
@@ -86,4 +86,6 @@ public class StructureVocab
     WARNING,
     QNA
   }
+  
+  private StructureVocab() {}
 }

--- a/src/test/java/com/adobe/epubcheck/opf/OPFCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/opf/OPFCheckerTest.java
@@ -1049,5 +1049,26 @@ public class OPFCheckerTest
     Collections.addAll(expectedErrors, MessageId.OPF_074);
     testValidateDocument("invalid/manifest-duplicate-resource.opf", EPUBVersion.VERSION_3);
   }
+  
+  @Test
+  public void testVocabA11y() {
+    // tests that the a11y vocb and known properties are allowed
+    testValidateDocument("valid/vocab-a11y-declared.opf", EPUBVersion.VERSION_3);
+  }
+  
+  @Test
+  public void testVocabA11yUndeclared() {
+    // tests that the a11y prefix is predefined
+    testValidateDocument("valid/vocab-a11y-undeclared.opf", EPUBVersion.VERSION_3);
+  }
+  
+  @Test
+  public void testVocabA11yUnknownProperty() {
+    // tests that properties in the a11y vocab are checked
+    // expects 1 error for a `meta` property, and 1 error for a `link/@rel` property
+    Collections.addAll(expectedErrors, MessageId.OPF_027, MessageId.OPF_027);
+    testValidateDocument("invalid/vocab-a11y-unknownproperty.opf", EPUBVersion.VERSION_3);
+  }
+  
 
 }

--- a/src/test/resources/30/single/opf/invalid/vocab-a11y-unknownproperty.opf
+++ b/src/test/resources/30/single/opf/invalid/vocab-a11y-unknownproperty.opf
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    prefix="a11y: http://www.idpf.org/epub/vocab/package/a11y/#">
+    <metadata>
+        <dc:identifier id="uid">uid</dc:identifier>
+        <dc:title>Test</dc:title>
+        <dc:language>en</dc:language>
+        <meta property="dcterms:modified">2011-08-19T12:00:00Z</meta>
+        <!-- unknown property a11y:boo -->
+        <meta property="a11y:boo">Accessibility Testers Group</meta>
+        <!-- unknown property a11y:certifierreport (lower case) -->
+        <link rel="a11y:certifierreport" href="http://example.org/report"/>
+    </metadata>
+    <manifest>
+        <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>
+    </manifest>
+    <spine>
+        <itemref idref="t001"/>
+    </spine>
+</package>

--- a/src/test/resources/30/single/opf/valid/vocab-a11y-declared.opf
+++ b/src/test/resources/30/single/opf/valid/vocab-a11y-declared.opf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    prefix="a11y: http://www.idpf.org/epub/vocab/package/a11y/#">
+    <metadata>
+        <dc:identifier id="uid">uid</dc:identifier>
+        <dc:title>Test</dc:title>
+        <dc:language>en</dc:language>
+        <meta property="dcterms:modified">2011-08-19T12:00:00Z</meta>
+        <meta property="a11y:certifiedBy">Accessibility Testers Group</meta>
+        <meta property="a11y:certifierCredential">DAISY OK</meta>
+        <link rel="a11y:certifierReport" href="http://example.org/report"/>
+    </metadata>
+    <manifest>
+        <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>
+    </manifest>
+    <spine>
+        <itemref idref="t001"/>
+    </spine>
+</package>

--- a/src/test/resources/30/single/opf/valid/vocab-a11y-undeclared.opf
+++ b/src/test/resources/30/single/opf/valid/vocab-a11y-undeclared.opf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <metadata>
+        <dc:identifier id="uid">uid</dc:identifier>
+        <dc:title>Test</dc:title>
+        <dc:language>en</dc:language>
+        <meta property="dcterms:modified">2011-08-19T12:00:00Z</meta>
+        <meta property="a11y:certifiedBy">Accessibility Testers Group</meta>
+        <meta property="a11y:certifierCredential">DAISY OK</meta>
+        <link rel="a11y:certifierReport" href="http://example.org/report"/>
+    </metadata>
+    <manifest>
+        <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>
+    </manifest>
+    <spine>
+        <itemref idref="t001"/>
+    </spine>
+</package>


### PR DESCRIPTION
## Accessibility vocab

- recognize `a11y` as a reserved prefix
- define meta and link rel voabularies for Accessibility properties
- add tests

Fixes #810

## EnumVocab API refactoring

- add a new EnumVocab constructors with a [`CaseFormat`](https://google.github.io/guava/releases/snapshot/api/docs/com/google/common/base/CaseFormat.html) option to be  able to define the rules from converting from the Enum constant to  the property name.  When not specified, the default case format is `LOWER_HYPHEN`.
- replace the `ENUM_TO_NAME` static function by a `Converter` class member (initialized based on the given case format)
- add public methods `getName(P)` and `getNames(Collection<P>)` to get  the string value of property names based on their Enum constant.
- add tests for a vocab specifying the `LOWER_CAMEL` case format