### PR TITLE
Remove epubsc from reserved prefixes

### DIFF
--- a/src/main/java/com/adobe/epubcheck/opf/OPFHandler30.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFHandler30.java
@@ -68,8 +68,7 @@ public class OPFHandler30 extends OPFHandler
       .put(SCHEMA_PREFIX, SCHEMA_VOCAB).put(XSD_PREFIX, XSD_VOCAB).build();
   private static final Map<String, Vocab> RESERVED_META_VOCABS = new ImmutableMap.Builder<String, Vocab>()
       .put("", META_VOCAB).put(MediaOverlaysVocab.PREFIX, MediaOverlaysVocab.VOCAB)
-      .put(RenditionVocabs.PREFIX, RenditionVocabs.META_VOCAB)
-      .put(ScriptedCompVocab.PREFIX, ScriptedCompVocab.VOCAB).putAll(RESERVED_VOCABS).build();
+      .put(RenditionVocabs.PREFIX, RenditionVocabs.META_VOCAB).putAll(RESERVED_VOCABS).build();
   private static final Map<String, Vocab> RESERVED_ITEM_VOCABS = new ImmutableMap.Builder<String, Vocab>()
       .put("", ITEM_VOCAB).put(MediaOverlaysVocab.PREFIX, VocabUtil.EMPTY_VOCAB)
       .put(RenditionVocabs.PREFIX, VocabUtil.EMPTY_VOCAB).putAll(RESERVED_VOCABS).build();
@@ -85,6 +84,7 @@ public class OPFHandler30 extends OPFHandler
       .put(SCHEMA_URI, SCHEMA_VOCAB).put(XSD_URI, XSD_VOCAB).build();
   private static final Map<String, Vocab> KNOWN_META_VOCAB_URIS = new ImmutableMap.Builder<String, Vocab>()
       .putAll(KNOWN_VOCAB_URIS).put(MediaOverlaysVocab.URI, MediaOverlaysVocab.VOCAB)
+      .put(ScriptedCompVocab.URI, ScriptedCompVocab.VOCAB)
       .put(RenditionVocabs.URI, RenditionVocabs.META_VOCAB).build();
   private static final Map<String, Vocab> KNOWN_ITEM_VOCAB_URIS = new ImmutableMap.Builder<String, Vocab>()
       .putAll(KNOWN_VOCAB_URIS).put(MediaOverlaysVocab.URI, VocabUtil.EMPTY_VOCAB)

--- a/src/test/java/com/adobe/epubcheck/opf/OPFCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/opf/OPFCheckerTest.java
@@ -930,6 +930,14 @@ public class OPFCheckerTest
   {
     testValidateDocument("valid/sc-embedded.opf", EPUBVersion.VERSION_3);
   }
+  
+  @Test
+  public void testSC_InvalidUndeclaredPrefix()
+  {
+    // verifies that the epubsc: prefix is not recognized as an reserved prefix -- pulled from epub 3.2
+    Collections.addAll(expectedErrors, MessageId.OPF_028);
+    testValidateDocument("invalid/sc-undeclared-prefix.opf", EPUBVersion.VERSION_3);
+  }
 
   @Test
   public void testIDX_Collection()

--- a/src/test/resources/30/single/opf/invalid/sc-undeclared-prefix.opf
+++ b/src/test/resources/30/single/opf/invalid/sc-undeclared-prefix.opf
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="pub-id" version="3.0">
+	<metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+		
+		<!--General -->
+		<dc:identifier id="pub-id">urn:uuid:2FF31B77-955D-4624-BF5D-DBFC3CD5769D</dc:identifier>
+		<meta property="dcterms:modified">2015-05-26T00:12:53Z</meta>
+		<dc:type>scriptable-component</dc:type>
+		<dc:title>My Embedded Component</dc:title>
+		<dc:creator>John Doe</dc:creator>
+		<dc:description>Demo of the Logger Widget</dc:description>
+		<dc:publisher>ACME</dc:publisher>
+		<dc:date>2015-05-26</dc:date>
+		<dc:language>en</dc:language>
+	</metadata>
+	
+	<manifest>
+		<item id="content" href="xhtml/content.xhtml" media-type="application/xhtml+xml"
+			properties="scripted"/>
+		<item id="nav" href="xhtml/nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+		<item id="css" href="css/comp.css" media-type="text/css"/>
+		<item id="js" href="js/main.js" media-type="text/javascript"/>
+		
+		<!-- Scriped Component items -->
+		<item id="comp_6E693C5D58E5" href="components/acme/comp/EPUB/xhtml/comp.xhtml"
+			media-type="application/xhtml+xml" properties="scripted"/>
+		<item id="css_6E693C5D58E5" href="components/acme/comp/EPUB/css/comp.css"
+			media-type="text/css"/>
+		<item id="js_6E693C5D58E5" href="components/acme/comp/EPUB/js/comp.js"
+			media-type="text/javascript"/>
+	</manifest>
+	
+	<spine>
+		<itemref idref="content"/>
+	</spine>
+	
+	<collection role="scriptable-component">
+		<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+			<dc:type>scriptable-component</dc:type>
+			<dc:title>comp</dc:title>
+			<dc:creator>acme</dc:creator>
+			<dc:language>en</dc:language>
+			<meta property="epubsc:version">1.0.1</meta>
+		</metadata>
+		
+		<collection role="manifest">
+			<link href="components/acme/comp/xhtml/comp.xhtml"/>
+			<link href="components/acme/comp/css/comp.css"/>
+			<link href="components/acme/comp/js/comp.js"/>
+		</collection>
+		
+		<link href="components/acme/comp/xhtml/comp.xhtml"/>
+	</collection>
+</package>

--- a/src/test/resources/30/single/opf/valid/sc-embedded.opf
+++ b/src/test/resources/30/single/opf/valid/sc-embedded.opf
@@ -1,54 +1,54 @@
 <?xml version="1.0"?>
-<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="pub-id" version="3.0">
-    <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
-
-        <!--General -->
-        <dc:identifier id="pub-id">urn:uuid:2FF31B77-955D-4624-BF5D-DBFC3CD5769D</dc:identifier>
-        <meta property="dcterms:modified">2015-05-26T00:12:53Z</meta>
-        <dc:type>scriptable-component</dc:type>
-        <dc:title>My Embedded Component</dc:title>
-        <dc:creator>John Doe</dc:creator>
-        <dc:description>Demo of the Logger Widget</dc:description>
-        <dc:publisher>ACME</dc:publisher>
-        <dc:date>2015-05-26</dc:date>
-        <dc:language>en</dc:language>
-    </metadata>
-
-    <manifest>
-        <item id="content" href="xhtml/content.xhtml" media-type="application/xhtml+xml"
-            properties="scripted"/>
-        <item id="nav" href="xhtml/nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
-        <item id="css" href="css/comp.css" media-type="text/css"/>
-        <item id="js" href="js/main.js" media-type="text/javascript"/>
-
-        <!-- Scriped Component items -->
-        <item id="comp_6E693C5D58E5" href="components/acme/comp/EPUB/xhtml/comp.xhtml"
-            media-type="application/xhtml+xml" properties="scripted"/>
-        <item id="css_6E693C5D58E5" href="components/acme/comp/EPUB/css/comp.css"
-            media-type="text/css"/>
-        <item id="js_6E693C5D58E5" href="components/acme/comp/EPUB/js/comp.js"
-            media-type="text/javascript"/>
-    </manifest>
-
-    <spine>
-        <itemref idref="content"/>
-    </spine>
-
-    <collection role="scriptable-component">
-        <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-            <dc:type>scriptable-component</dc:type>
-            <dc:title>comp</dc:title>
-            <dc:creator>acme</dc:creator>
-            <dc:language>en</dc:language>
-            <meta property="epubsc:version">1.0.1</meta>
-        </metadata>
-
-        <collection role="manifest">
-            <link href="components/acme/comp/xhtml/comp.xhtml"/>
-            <link href="components/acme/comp/css/comp.css"/>
-            <link href="components/acme/comp/js/comp.js"/>
-        </collection>
-
-        <link href="components/acme/comp/xhtml/comp.xhtml"/>
-    </collection>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="pub-id" version="3.0" prefix="epubsc: http://idpf.org/epub/vocab/sc/#">
+	<metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+		
+		<!--General -->
+		<dc:identifier id="pub-id">urn:uuid:2FF31B77-955D-4624-BF5D-DBFC3CD5769D</dc:identifier>
+		<meta property="dcterms:modified">2015-05-26T00:12:53Z</meta>
+		<dc:type>scriptable-component</dc:type>
+		<dc:title>My Embedded Component</dc:title>
+		<dc:creator>John Doe</dc:creator>
+		<dc:description>Demo of the Logger Widget</dc:description>
+		<dc:publisher>ACME</dc:publisher>
+		<dc:date>2015-05-26</dc:date>
+		<dc:language>en</dc:language>
+	</metadata>
+	
+	<manifest>
+		<item id="content" href="xhtml/content.xhtml" media-type="application/xhtml+xml"
+			properties="scripted"/>
+		<item id="nav" href="xhtml/nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+		<item id="css" href="css/comp.css" media-type="text/css"/>
+		<item id="js" href="js/main.js" media-type="text/javascript"/>
+		
+		<!-- Scriped Component items -->
+		<item id="comp_6E693C5D58E5" href="components/acme/comp/EPUB/xhtml/comp.xhtml"
+			media-type="application/xhtml+xml" properties="scripted"/>
+		<item id="css_6E693C5D58E5" href="components/acme/comp/EPUB/css/comp.css"
+			media-type="text/css"/>
+		<item id="js_6E693C5D58E5" href="components/acme/comp/EPUB/js/comp.js"
+			media-type="text/javascript"/>
+	</manifest>
+	
+	<spine>
+		<itemref idref="content"/>
+	</spine>
+	
+	<collection role="scriptable-component">
+		<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+			<dc:type>scriptable-component</dc:type>
+			<dc:title>comp</dc:title>
+			<dc:creator>acme</dc:creator>
+			<dc:language>en</dc:language>
+			<meta property="epubsc:version">1.0.1</meta>
+		</metadata>
+		
+		<collection role="manifest">
+			<link href="components/acme/comp/xhtml/comp.xhtml"/>
+			<link href="components/acme/comp/css/comp.css"/>
+			<link href="components/acme/comp/js/comp.js"/>
+		</collection>
+		
+		<link href="components/acme/comp/xhtml/comp.xhtml"/>
+	</collection>
 </package>


### PR DESCRIPTION
This removes epubsc from the reserved prefixes, per issue #875, and adds it to the known vocabularies so that property names can still be verified.

I could be easily swayed that we should just remove all traces of scriptable components entirely, though, as it seems very remote that those particular specifications will ever be finished in the post-IDPF world.