### PR TITLE
Add application/javascript to CMTs

### DIFF
--- a/src/main/java/com/adobe/epubcheck/ctc/EpubScriptCheck.java
+++ b/src/main/java/com/adobe/epubcheck/ctc/EpubScriptCheck.java
@@ -17,6 +17,7 @@ import com.adobe.epubcheck.ctc.epubpackage.ManifestItem;
 import com.adobe.epubcheck.ctc.xml.ScriptTagHandler;
 import com.adobe.epubcheck.ctc.xml.XMLContentDocParser;
 import com.adobe.epubcheck.messages.MessageId;
+import com.adobe.epubcheck.opf.OPFChecker30;
 import com.adobe.epubcheck.opf.DocumentValidator;
 import com.adobe.epubcheck.util.EPUBVersion;
 import com.adobe.epubcheck.util.FeatureEnum;
@@ -91,13 +92,13 @@ public class EpubScriptCheck implements DocumentValidator
     }
     return result;
   }
-
+  
   void checkJavascript(ManifestItem mi)
   {
     InputStream is = null;
     BufferedReader reader = null;
     String mediaType = mi.getMediaType();
-    if (mediaType != null && "text/javascript".equalsIgnoreCase(mediaType))
+    if (mediaType != null && OPFChecker30.isBlessedScriptType(mediaType.toLowerCase()))
     {
       String fileToParse = epack.getManifestItemFileName(mi);
       ZipEntry entry = this.zip.getEntry(fileToParse);

--- a/src/main/java/com/adobe/epubcheck/opf/OPFChecker30.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFChecker30.java
@@ -479,12 +479,17 @@ public class OPFChecker30 extends OPFChecker implements DocumentValidator
     return type.equals("application/vnd.ms-opentype") || type.equals("application/font-woff")
         || type.equals("image/svg+xml");
   }
+  
+  public static boolean isBlessedScriptType(String type) {
+    return type.equals("text/javascript") || type.equals("application/javascript");
+  }
 
   public static boolean isCoreMediaType(String type)
   {
     return isBlessedAudioType(type) || isBlessedVideoType(type) || isBlessedFontType(type)
         || isBlessedItemType(type, EPUBVersion.VERSION_3) || isBlessedImageType(type)
-        || type.equals("text/javascript") || type.equals("application/pls+xml")
-        || type.equals("application/smil+xml") || type.equals("image/svg+xml");
+        || isBlessedScriptType(type)
+        || type.equals("application/pls+xml") || type.equals("application/smil+xml")
+        || type.equals("image/svg+xml");
   }
 }

--- a/src/test/java/com/adobe/epubcheck/opf/OPFCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/opf/OPFCheckerTest.java
@@ -130,6 +130,13 @@ public class OPFCheckerTest
   
 
   @Test
+  public void testCMTSupport()
+  {
+    // tests that core media types are supported without fallbacks
+    testValidateDocument("valid/cmt.opf", EPUBVersion.VERSION_3);
+  }
+
+  @Test
   public void testBindingsIsDeprecated()
   {
     // tests that 'bindings' is reported as deprecated

--- a/src/test/resources/30/single/opf/valid/cmt.opf
+++ b/src/test/resources/30/single/opf/valid/cmt.opf
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="q">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+</metadata>
+<manifest>
+	<item id="css"  href="epub.css" media-type="text/css"/>
+	<item id="js_001"  href="script_001.js" media-type="application/javascript"/>
+	<item id="js_002"  href="script_002.js" media-type="text/javascript"/>
+	<item id="font_001"  href="font_001.otf" media-type="application/vnd.ms-opentype"/>
+	<item id="font_002"  href="font_002.woff" media-type="application/font-woff"/>
+	<item id="font_003"  href="font_003.svg" media-type="image/svg+xml"/>
+	<item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml"/>
+	<item id="audio_001"  href="audio_001.mpg" media-type="audio/mpeg"/>
+	<item id="audio_002"  href="audio_002.mp4" media-type="audio/mp4"/>
+	<item id="video_001"  href="video_001.webm" media-type="video/webm"/>
+	<item id="video_002"  href="video_002.mp4" media-type="video/mp4"/>
+	<item id="video_003"  href="video_003.mp4" media-type="video/h264"/>
+	<item id="pls_001"  href="pls_001.pls" media-type="application/pls+xml"/>
+	<item id="smil_001"  href="smil_001.smil" media-type="application/smil+xml"/>
+	<item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>


### PR DESCRIPTION
Add "application/javascript" for identifying javascript in the package doc, per issue #874 

Also consolidates checking of script media types.