### PR TITLE
improve handling of dates/times/durations

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/mod/datatypes.rnc
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/mod/datatypes.rnc
@@ -101,19 +101,22 @@ div {
   datatype.html5.name = xsd:string
   datatype.html5.name.reference = xsd:string { pattern = "#.+" }
   
+  datatype.html5.year = xsd:token { pattern ='[0-9]{4}' }
+  datatype.html5.yearless = xsd:token { pattern ='(--)?(0[0-9]|1[0-2])-(0[0-9]|[1-2][0-9]|3[0-1])' }
+  datatype.html5.duration = xsd:token { pattern ='((P([0-9]+D))|(P([0-9]+D)?T([0-9]+H)([0-9]+M)?([0-9]+(\.[0-9]{1,3})?S)?)|(P([0-9]+D)?T([0-9]+H)?([0-9]+M)([0-9]+(\.[0-9]{1,3})?S)?)|(P([0-9]+D)?T([0-9]+H)?([0-9]+M)?([0-9]+(\.[0-9]{1,3})?S))|( *(([0-9]+ *[WDHM])|([0-9]+(\.[0-9]{1,3})? *S)) *)+)' }
   # http://www.w3.org/TR/html5/common-microsyntaxes.html#months
   datatype.html5.month = xsd:token { pattern ='([0-9]{4,})-([0-9]{2})' }  
   # http://www.w3.org/TR/html5/common-microsyntaxes.html#dates
   datatype.html5.date = xsd:token { pattern ='([0-9]{4,})-([0-9]{2})-([0-9]{2})'}
   # http://www.w3.org/TR/html5/common-microsyntaxes.html#times
-  datatype.html5.time = xsd:token { pattern ='([0-9]{2}):([0-9]{2})(:[0-9]{2}(\.[0-9]+)?)?'}
+  datatype.html5.time = xsd:token { pattern ='([0-9]{2}):([0-9]{2})(:[0-9]{2}(\.[0-9]{1,3})?)?'}
   # http://www.w3.org/TR/html5/common-microsyntaxes.html#local-dates-and-times
-  datatype.html5.datetime.local = xsd:token { pattern = '([0-9]{4,})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2})(:[0-9]{2}(\.[0-9]+)?)?' }
+  datatype.html5.datetime.local = xsd:token { pattern = '([0-9]{4,})-([0-9]{2})-([0-9]{2})([T ])([0-9]{2}):([0-9]{2})(:[0-9]{2}(\.[0-9]{1,3})?)?' }
   # http://www.w3.org/TR/html5/common-microsyntaxes.html#global-dates-and-times
-  datatype.html5.datetime.global = xsd:token { pattern = '([0-9]{4,})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2})(:[0-9]{2}(\.[0-9]+)?)?(Z|((\+|-)([0-9]{2}):([0-9]{2})))' }  
+  datatype.html5.datetime.global = xsd:token { pattern = '([0-9]{4,})-([0-9]{2})-([0-9]{2})([T ])([0-9]{2}):([0-9]{2})(:[0-9]{2}(\.[0-9]{1,3})?)?(Z|((\+|-)([0-9]{2}):?([0-9]{2})))?' }  
   datatype.html5.datetime = datatype.html5.datetime.global
   # http://www.w3.org/TR/html5/common-microsyntaxes.html#vaguer-moments-in-time
-  datatype.html5.date.or.time = datatype.html5.date | datatype.html5.month | datatype.html5.time | datatype.html5.datetime.global
+  datatype.html5.date.or.time = datatype.html5.year | datatype.html5.yearless | datatype.html5.week | datatype.html5.date | datatype.html5.month | datatype.html5.time | datatype.html5.datetime.global | datatype.html5.duration
   # http://www.w3.org/TR/html5/common-microsyntaxes.html#vaguer-moments-in-time
   datatype.html5.date.optional.time = datatype.html5.date | datatype.html5.datetime.global
   datatype.html5.week = xsd:token { pattern ='([0-9]{4,})-W([0-9]{2})' }

--- a/src/main/resources/com/adobe/epubcheck/schema/30/mod/datatypes.rnc
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/mod/datatypes.rnc
@@ -103,7 +103,7 @@ div {
   
   datatype.html5.year = xsd:token { pattern ='[0-9]{4}' }
   datatype.html5.yearless = xsd:token { pattern ='(--)?(0[0-9]|1[0-2])-(0[0-9]|[1-2][0-9]|3[0-1])' }
-  datatype.html5.duration = xsd:token { pattern ='((P([0-9]+D))|(P([0-9]+D)?T([0-9]+H)([0-9]+M)?([0-9]+(\.[0-9]{1,3})?S)?)|(P([0-9]+D)?T([0-9]+H)?([0-9]+M)([0-9]+(\.[0-9]{1,3})?S)?)|(P([0-9]+D)?T([0-9]+H)?([0-9]+M)?([0-9]+(\.[0-9]{1,3})?S))|( *(([0-9]+ *[WDHM])|([0-9]+(\.[0-9]{1,3})? *S)) *)+)' }
+  datatype.html5.duration = xsd:token { pattern ='(((P[0-9]+D)|(P([0-9]+D)?T((([0-9]+H)([0-9]+M)?([0-9]+(\.[0-9]{1,3})?S)?)|(([0-9]+H)?([0-9]+M)([0-9]+(\.[0-9]{1,3})?S)?)|(([0-9]+H)?([0-9]+M)?([0-9]+(\.[0-9]{1,3})?S)))))|( *(([0-9]+ *[WDHM])|([0-9]+(\.[0-9]{1,3})? *S)) *)+)' }
   # http://www.w3.org/TR/html5/common-microsyntaxes.html#months
   datatype.html5.month = xsd:token { pattern ='([0-9]{4,})-([0-9]{2})' }  
   # http://www.w3.org/TR/html5/common-microsyntaxes.html#dates

--- a/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
@@ -1184,5 +1184,24 @@ public class OPSCheckerTest
     testValidateDocument("xhtml/invalid/time-in-time.xhtml", "application/xhtml+xml",
         EPUBVersion.VERSION_3);
   }
+  
+  @Test
+  public void testValidTimes()
+  {
+    testValidateDocument("xhtml/valid/times.xhtml", "application/xhtml+xml",
+        EPUBVersion.VERSION_3);
+  }
+  
+  @Test
+  public void testInvalidTimes()
+  {
+    Collections.addAll(expectedErrors, MessageId.RSC_005, MessageId.RSC_005, MessageId.RSC_005, MessageId.RSC_005, MessageId.RSC_005,
+    									MessageId.RSC_005, MessageId.RSC_005, MessageId.RSC_005, MessageId.RSC_005, MessageId.RSC_005,
+    									MessageId.RSC_005, MessageId.RSC_005, MessageId.RSC_005, MessageId.RSC_005, MessageId.RSC_005,
+    									MessageId.RSC_005, MessageId.RSC_005, MessageId.RSC_005, MessageId.RSC_005, MessageId.RSC_005,
+    									MessageId.RSC_005, MessageId.RSC_005, MessageId.RSC_005, MessageId.RSC_005, MessageId.RSC_005);
+    testValidateDocument("xhtml/invalid/times.xhtml", "application/xhtml+xml",
+        EPUBVersion.VERSION_3);
+  }
 
 }

--- a/src/test/resources/30/single/xhtml/invalid/times.xhtml
+++ b/src/test/resources/30/single/xhtml/invalid/times.xhtml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+    <head>
+        <title>times</title>
+    </head>
+    <body>
+    	<ul>
+    		<li><time datetime="201">test</time></li>
+    		<li><time datetime="09999001">test</time></li>
+    		<li><time datetime="01--31">test</time></li>
+    		<li><time datetime="---12-31">test</time></li>
+    		<li><time datetime="3123-05-31-12">test</time></li>
+    		<li><time datetime="2019-01-25T 12:12:12Z">test</time></li>
+    		<li><time datetime="2019-01-2512:12:12">test</time></li>
+    		<li><time datetime="2019-01-25A12:12:12Z">test</time></li>
+    		<li><time datetime="2019-01-25T12:12:12-0500Z">test</time></li>
+    		<li><time datetime="2019-01-25 12:12:12-05 00">test</time></li>
+    		<li><time datetime="2019-01-25 12:12:12.33777">test</time></li>
+    		<li><time datetime="2018-W522">test</time></li>
+    		<li><time datetime="2019W01">test</time></li>
+    		<li><time datetime="08::40">test</time></li>
+    		<li><time datetime="19:24:291">test</time></li>
+    		<li><time datetime="14:08:59.999999">test</time></li>
+    		<li><time datetime="P32DT">test</time></li>
+    		<li><time datetime="P32D223T12H">test</time></li>
+    		<li><time datetime="P23DT32M12H">test</time></li>
+    		<li><time datetime="PT2.1112S">test</time></li>
+    		<li><time datetime="PT12H9">test</time></li>
+    		<li><time datetime="P12T431M">test</time></li>
+    		<li><time datetime="9123W12">test</time></li>
+    		<li><time datetime="  1231 23D  ">test</time></li>
+    		<li><time datetime="343HD">test</time></li>
+    	</ul>
+    </body>
+</html>

--- a/src/test/resources/30/single/xhtml/valid/times.xhtml
+++ b/src/test/resources/30/single/xhtml/valid/times.xhtml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+    <head>
+        <title>times</title>
+    </head>
+    <body>
+    	<ul>
+    		<li><time datetime="2019">test</time></li>
+    		<li><time datetime="0001">test</time></li>
+    		<li><time datetime="01-31">test</time></li>
+    		<li><time datetime="02-28">test</time></li>
+    		<li><time datetime="--12-31">test</time></li>
+    		<li><time datetime="3123-05-31">test</time></li>
+    		<li><time datetime="1200-08">test</time></li>
+    		<li><time datetime="2019-01-25T12:12:12Z">test</time></li>
+    		<li><time datetime="2019-01-25 12:12:12">test</time></li>
+    		<li><time datetime="2019-01-25 12:12:12Z">test</time></li>
+    		<li><time datetime="2019-01-25 12:12:12-0500">test</time></li>
+    		<li><time datetime="2019-01-25 12:12:12-05:00">test</time></li>
+    		<li><time datetime="2019-01-25 12:12:12.777">test</time></li>
+    		<li><time datetime="2018-W52">test</time></li>
+    		<li><time datetime="2019-W01">test</time></li>
+    		<li><time datetime="08:40">test</time></li>
+    		<li><time datetime="19:24:29">test</time></li>
+    		<li><time datetime="14:08:59.999">test</time></li>
+    		<li><time datetime="P32D">test</time></li>
+    		<li><time datetime="P32DT12H">test</time></li>
+    		<li><time datetime="P23DT12H32M1231S">test</time></li>
+    		<li><time datetime="PT12H23M12.112S">test</time></li>
+    		<li><time datetime="PT12H">test</time></li>
+    		<li><time datetime="PT431M">test</time></li>
+    		<li><time datetime="PT12.433S">test</time></li>
+    		<li><time datetime="9123W">test</time></li>
+    		<li><time datetime="  123123D  ">test</time></li>
+    		<li><time datetime="343H">test</time></li>
+    		<li><time datetime="1M">test</time></li>
+    		<li><time datetime="12S">test</time></li>
+    		<li><time datetime="12.12S">test</time></li>
+    		<li><time datetime="123W 123H   32D 12S">test</time></li>
+    	</ul>
+    </body>
+</html>


### PR DESCRIPTION
Per the report in #775, the handling of dates and times is much more limited in epubcheck than html allows. This PR isn't going to fix all the issues, as some checks can really only be programmed; it's more an interim step to future integration.

What it does is make the following changes to better align with the html definitions:

- adds support for yearless dates, year-only dates, and durations for `time/datetime`
- allows a space in addition to 'T' for separating dates and times
- makes the colon optional in timezone offsets
- limits seconds to three digits after a period

I checked the valid/invalid files against validator.nu and the only discrepancy I found is that it doesn't recognize a yearless date that begins with two hyphens. It looks like a bug on that end, though, as the HTML specification clearly says [two optional hyphens are allowed at the start](https://www.w3.org/TR/html/infrastructure.html#yearless-dates).