### PR TITLE
normalize HTML case-insensitive attributes + basic support for custom elements

### DIFF
--- a/src/main/java/com/adobe/epubcheck/xml/HTMLUtils.java
+++ b/src/main/java/com/adobe/epubcheck/xml/HTMLUtils.java
@@ -75,4 +75,9 @@ public class HTMLUtils
 
   }
 
+  public static boolean isCustomElement(String namespace, String name)
+  {
+    return Namespaces.XHTML.equals(namespace) && Preconditions.checkNotNull(name).contains("-");
+  }
+
 }

--- a/src/main/java/com/adobe/epubcheck/xml/HTMLUtils.java
+++ b/src/main/java/com/adobe/epubcheck/xml/HTMLUtils.java
@@ -1,0 +1,78 @@
+package com.adobe.epubcheck.xml;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Utilities for HTML-specific logic.
+ * 
+ */
+public class HTMLUtils
+{
+  /**
+   * Returns whether an attribute is defined as having a case-insensitive value in
+   * HTML. This is notably the case of boolean attributes and enumerated
+   * attributes.
+   * 
+   * @param name
+   *          the name of an attribute defined in the HTML specification
+   * @return <code>true</code> iff the attribute value is case-insensitive
+   */
+  public static boolean isCaseInsensitiveAttribute(String name)
+  {
+    switch (Preconditions.checkNotNull(name))
+    {
+    case "align":
+    case "allowfullscreen":
+    case "allowpaymentrequest":
+    case "allowusermedia":
+    case "async":
+    case "autocapitalize":
+    case "autocomplete":
+    case "autofocus":
+    case "autoplay":
+    case "checked":
+    case "contenteditable":
+    case "controls":
+    case "crossorigin":
+    case "default":
+    case "defer":
+    case "dir":
+    case "disabled":
+    case "draggable":
+    case "formnovalidate":
+    case "hidden":
+    case "http-equiv":
+    case "ismap":
+    case "itemscope":
+    case "kind":
+    case "loop":
+    case "multiple":
+    case "muted":
+    case "nomodule":
+    case "novalidate":
+    case "open":
+    case "playsinline":
+    case "preload":
+    case "readonly":
+    case "required":
+    case "reversed":
+    case "scope":
+    case "selected":
+    case "shape":
+    case "sizes":
+    case "spellcheck":
+    case "step":
+    case "translate":
+    case "type":
+    case "typemustmatch":
+    case "valign":
+    case "value":
+    case "wrap":
+      return true;
+    default:
+      return false;
+    }
+
+  }
+
+}

--- a/src/main/java/com/adobe/epubcheck/xml/XMLParser.java
+++ b/src/main/java/com/adobe/epubcheck/xml/XMLParser.java
@@ -468,8 +468,16 @@ public class XMLParser extends DefaultHandler implements LexicalHandler, DeclHan
       Attributes parsedAttribs)
     throws SAXException
   {
-
     Attributes attribs = preprocessAttributes(namespaceURI, localName, qName, parsedAttribs);
+    
+    if ("application/xhtml+xml".equals(context.mimeType)
+        && context.version == EPUBVersion.VERSION_3) {
+      // Pre-process HTML custom elements to set them in the proprietary namespace supported
+      // by the Nu Html Checker
+      if (HTMLUtils.isCustomElement(namespaceURI, localName)) {
+        namespaceURI = "http://n.validator.nu/custom-elements/";
+      }
+    }
 
     int vlen = validatorContentHandlers.size();
     for (int i = 0; i < vlen; i++)

--- a/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
@@ -891,9 +891,19 @@ public class OPSCheckerTest
   }
 
   @Test
-  public void testValidateXHTML301CustomAttributes()
+  public void testAttributesInCustomNS()
   {
-    testValidateDocument("xhtml/valid/custom-ns-attrs.xhtml", "application/xhtml+xml",
+    // test that attribute in a custom namespace are ignored
+    testValidateDocument("xhtml/valid/attrs-custom-ns.xhtml", "application/xhtml+xml",
+        EPUBVersion.VERSION_3);
+  }
+
+  @Test
+  public void testAttributesCaseInsensitive()
+  {
+    // test that the value of HTML boolean attributes and enumerated attributes are
+    // parsed in a case-insensitive manner
+    testValidateDocument("xhtml/valid/attrs-case-insensitive.xhtml", "application/xhtml+xml",
         EPUBVersion.VERSION_3);
   }
 

--- a/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
@@ -908,6 +908,14 @@ public class OPSCheckerTest
   }
 
   @Test
+  public void testCustomElements()
+  {
+    // test that HTML custom elements are not rejected by the schema
+    testValidateDocument("xhtml/valid/custom-elements.xhtml", "application/xhtml+xml",
+        EPUBVersion.VERSION_3);
+  }
+
+  @Test
   public void testValidateXHTML301AriaDescribedAt()
   {
     expectedErrors.add(MessageId.RSC_005);

--- a/src/test/resources/30/single/xhtml/valid/attrs-case-insensitive.xhtml
+++ b/src/test/resources/30/single/xhtml/valid/attrs-case-insensitive.xhtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>	 
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <head>
+    <title>Test</title>
+    <meta charset="UTF-8"/>
+  </head>
+  <body>
+    <h1>Test</h1>
+    <div hidden="HIDDEN"></div>
+  </body>
+</html>

--- a/src/test/resources/30/single/xhtml/valid/attrs-custom-ns.xhtml
+++ b/src/test/resources/30/single/xhtml/valid/attrs-custom-ns.xhtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>	 
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:foo="https://example.org" lang="en">
+    <head>
+        <title>Test</title>
+        <meta charset="UTF-8" />
+    </head>
+    <body>
+        <h1>Test</h1>
+        <p foo:bar1="baz" foo:bar2="baz" foo:bar3="baz">custom attribute!</p>
+    </body>
+</html>

--- a/src/test/resources/30/single/xhtml/valid/custom-elements.xhtml
+++ b/src/test/resources/30/single/xhtml/valid/custom-elements.xhtml
@@ -1,0 +1,16 @@
+<!DOCTYPE html>	 
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <head>
+    <title>Test</title>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <h1>Test</h1>
+    <epub-switch>
+      <epub-case required-namespace="https://example.org"> oh my! </epub-case>
+      <epub-default>
+        <p>is this real?</p>
+      </epub-default>
+    </epub-switch>
+  </body>
+</html>

--- a/src/test/resources/30/single/xhtml/valid/custom-ns-attrs.xhtml
+++ b/src/test/resources/30/single/xhtml/valid/custom-ns-attrs.xhtml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:foo="http://www.example.org/2001/10/#" xml:lang="en" lang="en">
-    <head>
-        <title>3.0.1 custom attributes</title>
-    </head>
-    <body>
-        <p foo:bar="baz">custom attribute!</p>
-    </body>
-</html>


### PR DESCRIPTION


## parse boolean/enumerated HTML attributes as case-insensitive
- add an `HTMUtils` facility to get whether an HTML attribute has a
  case-insensitive value (boolean and enumerated attributes)
- pre-process case-insensitive HTML attributes to lower-case their value
- refactor the pre-processing attribute logic for more clarity
- add a test

Fix #941

## basic schema support for HTML custom elements

- add an `isCustomElement` method in `HTMLUtils`.
- pre-process custom elements in `XMLParser` to put them in the
  proprietary namespace used by the Nu Html Checker schemas to treat
  them distinctively.
- add a simple test case.

Fix #932