### PR TITLE
Change css position warnings to usage messages

### DIFF
--- a/src/main/java/com/adobe/epubcheck/ctc/css/EpubCSSCheckCSSHandler.java
+++ b/src/main/java/com/adobe/epubcheck/ctc/css/EpubCSSCheckCSSHandler.java
@@ -506,7 +506,6 @@ public class EpubCSSCheckCSSHandler implements CssContentHandler, CssErrorHandle
   {
     if (!isGlobalFixedFormat || hasIndividualFixedFormatDocuments)
     {
-      MessageId id = hasIndividualFixedFormatDocuments ? MessageId.CSS_027 : MessageId.CSS_017;
       if ("position".compareToIgnoreCase(declaration.getName().get()) == 0)
       {
         for (CssGrammar.CssConstruct construct : declaration.getComponents())
@@ -514,7 +513,7 @@ public class EpubCSSCheckCSSHandler implements CssContentHandler, CssErrorHandle
           if (construct.getType() == CssGrammar.CssConstruct.Type.KEYWORD &&
               "absolute".compareToIgnoreCase(construct.toCssString()) == 0)
           {
-            getReport().message(id, getCorrectedEPUBLocation(path, declaration.getLocation().getLine(), declaration.getLocation().getColumn(), declaration.toCssString()), declaration.getName().get());
+            getReport().message(MessageId.CSS_017, getCorrectedEPUBLocation(path, declaration.getLocation().getLine(), declaration.getLocation().getColumn(), declaration.toCssString()), declaration.getName().get());
             break;
           }
         }

--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -70,7 +70,7 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.CSS_003, Severity.ERROR);
     severities.put(MessageId.CSS_004, Severity.ERROR);
     severities.put(MessageId.CSS_005, Severity.ERROR);
-    severities.put(MessageId.CSS_006, Severity.WARNING);
+    severities.put(MessageId.CSS_006, Severity.USAGE);
     severities.put(MessageId.CSS_007, Severity.INFO);
     severities.put(MessageId.CSS_008, Severity.ERROR);
     severities.put(MessageId.CSS_009, Severity.USAGE);
@@ -80,7 +80,7 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.CSS_013, Severity.USAGE);
     severities.put(MessageId.CSS_015, Severity.ERROR);
     severities.put(MessageId.CSS_016, Severity.SUPPRESSED);
-    severities.put(MessageId.CSS_017, Severity.WARNING);
+    severities.put(MessageId.CSS_017, Severity.USAGE);
     severities.put(MessageId.CSS_019, Severity.WARNING);
     severities.put(MessageId.CSS_020, Severity.ERROR);
     severities.put(MessageId.CSS_021, Severity.USAGE);
@@ -88,7 +88,6 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.CSS_023, Severity.USAGE);
     severities.put(MessageId.CSS_024, Severity.USAGE);
     severities.put(MessageId.CSS_025, Severity.USAGE);
-    severities.put(MessageId.CSS_027, Severity.USAGE);
     severities.put(MessageId.CSS_028, Severity.USAGE);
 
     // HTML

--- a/src/main/java/com/adobe/epubcheck/messages/MessageId.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageId.java
@@ -81,7 +81,6 @@ public enum MessageId implements Comparable<MessageId>
   CSS_023("CSS-023"),
   CSS_024("CSS-024"),
   CSS_025("CSS-025"),
-  CSS_027("CSS-027"),
   CSS_028("CSS-028"),
 
   // Messages relating to xhtml markup

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -40,7 +40,7 @@ CSS_002=Empty or NULL reference found.
 CSS_003=Only UTF-8 and UTF-16 encodings are allowed, detected %1$s.
 CSS_004=Only UTF-8 and UTF-16 encodings are allowed, detected %1$s BOM.
 CSS_005=Conflicting alternate style attributes found: %1$s.
-CSS_006=CSS position:fixed property should not be used in EPUBs.
+CSS_006=CSS selector specifies fixed position.
 CSS_007=Font-face reference %1$s refers to non-standard font type %2$s.
 CSS_008=An error occurred while parsing the CSS: %1$s.
 CSS_009=Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.
@@ -63,7 +63,6 @@ CSS_024=CSS class Selector is not used.
 CSS_024_SUG=Remove unused CSS selectors.
 CSS_025=CSS class Selector could not be found.
 CSS_025_SUG=Check for typos or define a class selector to document the use of the class.
-CSS_027=CSS selector specifies absolute position.
 CSS_028=Use of Font-face declaration.
 
 #HTM - XHTML related messages

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_de.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_de.properties
@@ -63,7 +63,6 @@ CSS_024=CSS-Klasse wird nicht verwendet.
 CSS_024_SUG=Entferne unbenutzte CSS-Selektoren/-Klassen.
 CSS_025=CSS-Klasse wurde nicht gefunden.
 CSS_025_SUG=Überprüfe die Angabe der CSS-Klasse auf Schreibfehler oder definiere einen neuen Klassen-Selektor im CSS.
-CSS_027=CSS-Selektor enthält Anweisungen zu absoluter Positionierung.
 CSS_028=Eine 'font-face'-Deklaration wird genutzt.
 
 #HTM - XHTML related messages

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_es.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_es.properties
@@ -63,7 +63,6 @@ CSS_024=El selector de clase CSS no se utiliza.
 CSS_024_SUG=Elimine los selectores CSS no usados.
 CSS_025=No se encuentra el selector de clase CSS.
 CSS_025_SUG=Compruebe la sintaxis o defina un selector de clase para documentar el uso de la clase.
-CSS_027=El selector CSS especifica una posición absoluta.
 CSS_028=Uso de declaración 'font-face'.
 
 #HTM - XHTML related messages

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_fr.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_fr.properties
@@ -63,7 +63,6 @@ CSS_024=Le sélecteur CSS de classe n'est pas utilisé.
 CSS_024_SUG=Supprimez les sélecteurs CSS inutilisés.
 CSS_025=Le sélecteur CSS de classe est introuvable.
 CSS_025_SUG=Vérifiez les fautes de frappe ou définissez un sélecteur de classe pour attester de l'utilisation de la classe.
-CSS_027=Le sélecteur CSS spécifie une position absolue.
 CSS_028=Utilisation d'une déclaration font-face.
 
 #HTM - XHTML related messages

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_it.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_it.properties
@@ -63,7 +63,6 @@ CSS_024=La regola CSS 'class' non è usata.
 CSS_024_SUG=È consigliabile rimuovere le regole CSS non usate.
 CSS_025=La regola CSS 'class' non è stata trovata.
 CSS_025_SUG=È consigliabile controllare di non aver compiuto un errore nel nome della classe o definire una 'class' effettivamente usata.
-CSS_027=La regola CSS specifica una posizione assoluta.
 CSS_028=La regola CSS specifica una 'font-face'.
 
 #HTM - XHTML related messages

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_ja.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_ja.properties
@@ -63,7 +63,6 @@ CSS_024=CSSクラスセレクタが使われていません.
 CSS_024_SUG=使用していないCSSセレクタを削除してください.
 CSS_025=CSSクラスセレクタが見つけられませんでした.
 CSS_025_SUG=タイプミスをチェックするか、クラスを利用するセレクタを定義してください.
-CSS_027=CSSセレクタでabsolute positionを指定しています.
 CSS_028=Font-face宣言が使われています.
 
 #HTM - XHTML related messages

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_ko_KR.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_ko_KR.properties
@@ -63,7 +63,6 @@ CSS_024=클래스 셀렉터가 사용되지 않습니다.
 CSS_024_SUG=사용하지 않은 선택자를 제거하십시요.
 CSS_025=클래스 선택자를 찾을 수 없습니다.
 CSS_025_SUG=오타가 없는지 확인하거나 사용하려는 클래스 선택자를 추가하십시요.
-CSS_027=선택자가 absolute position 속성을 사용하였습니다.
 CSS_028='font-face' 선언을 사용합니다.
 
 #HTM - XHTML related messages

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_nl.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_nl.properties
@@ -63,7 +63,6 @@ CSS_024=CSS class - bijvoorbeeld .voorbeeld - wordt niet gebruikt.
 CSS_024_SUG=Verwijder ongebruikte CSS selectors.
 CSS_025=De CSS class selector werd niet aangetroffen.
 CSS_025_SUG=Controleer op typefouten of definieer een class selector om het gebruik van de class te documenteren.
-CSS_027=De CSS selector specificeert een absolute positie.
 CSS_028=Gebruik van font-face verklaring.
 
 #HTM - XHTML related messages

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_pt_BR.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle_pt_BR.properties
@@ -63,7 +63,6 @@ CSS_024=O seletor de classe CSS não é utilizado.
 CSS_024_SUG=Remova seletores CSS não utilizados.
 CSS_025=O seletor de classe CSS não foi localizado.
 CSS_025_SUG=Verifique erros de digitação ou defina um seletor de classe para documentar o uso da classe.
-CSS_027=O seletor CSS especifica posição absoluta.
 CSS_028=Uso de declaração Font-face.
 
 #HTM - XHTML related messages

--- a/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
@@ -270,7 +270,6 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   @Test
   public void testValidateEPUB30_CSSURLS_3()
   {
-    Collections.addAll(expectedWarnings, MessageId.CSS_017);
     Collections.addAll(expectedErrors, MessageId.CSS_020, MessageId.CSS_020);
     // 'imgs/table_header_bg_uni.jpg': referenced resource missing in the
     // package

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/failonwarnings/OPS/style_tag_css.xhtml
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/failonwarnings/OPS/style_tag_css.xhtml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-    <title>Transform - Style Tag</title>
+    <!-- <title>Transform - Style Tag</title> -->
     <style type="text/css">
         .rotateY {
             background-color:yellow;

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/failonwarnings_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/failonwarnings_expected_results.json
@@ -40,8 +40,8 @@
     "suggestion" : "Inline styles are not compatible with accessibility settings and display personalization. Use CSS Styles instead."
   }, {
     "ID" : "CSS-006",
-    "severity" : "WARNING",
-    "message" : "CSS position:fixed property should not be used in EPUBs.",
+    "severity" : "USAGE",
+    "message" : "CSS selector specifies fixed position.",
     "additionalLocations" : 0,
     "locations" : [ {
       "path" : "OPS/style.css",
@@ -94,7 +94,32 @@
       "context" : ""
     } ],
     "suggestion" : null
-  } ],
+  }, {
+    "ID" : "HTM-033",
+    "severity" : "USAGE",
+    "message" : "HTML 'head' element does not have a 'title' child element.",
+    "additionalLocations" : 0,
+    "locations" : [ {
+      "path" : "OPS/style_tag_css.xhtml",
+      "line" : 16,
+      "column" : 8,
+      "context" : null
+    } ],
+    "suggestion" : null
+  }, {
+    "ID" : "RSC-017",
+    "severity" : "WARNING",
+    "message" : "Warning while parsing file: The 'head' element should have a 'title' child element.",
+    "additionalLocations" : 0,
+    "locations" : [ {
+      "path" : "OPS/style_tag_css.xhtml",
+      "line" : 3,
+      "column" : 7,
+      "context" : null
+    } ],
+    "suggestion" : null
+  }  
+  ],
   "customMessageFileName" : null,
   "checker" : {
     "path" : "./com/adobe/epubcheck/test/command_line/failonwarnings.epub",
@@ -105,7 +130,7 @@
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 1,
-    "nUsage" : 4
+    "nUsage" : 6
   },
   "publication" : {
     "publisher" : null,
@@ -128,7 +153,7 @@
     "isBackwardCompatible" : true,
     "hasAudio" : false,
     "hasVideo" : false,
-    "charsCount" : 648,
+    "charsCount" : 627,
     "embeddedFonts" : [ ],
     "refFonts" : [ ],
     "hasEncryption" : false,
@@ -249,10 +274,10 @@
     "id" : "page02",
     "fileName" : "OPS/style_tag_css.xhtml",
     "media_type" : "application/xhtml+xml",
-    "compressedSize" : 263,
-    "uncompressedSize" : 563,
+    "compressedSize" : 269,
+    "uncompressedSize" : 572,
     "compressionMethod" : "Deflated",
-    "checkSum" : "a4d45bfbd24ab97ff2bdaa17276c1bc88aa8a5aadbf06f3b28b2f5db91612f6",
+    "checkSum" : "9ade68841fe28761295789b39e412d95cd26316e688f27cbac6ba2fc6f8840",
     "isSpineItem" : true,
     "spineIndex" : 1,
     "isLinear" : true,

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/listSeverities_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/listSeverities_expected_results.txt
@@ -28,7 +28,7 @@ CSS-002	ERROR	Empty or NULL reference found.
 CSS-003	ERROR	Only UTF-8 and UTF-16 encodings are allowed, detected %1$s.	
 CSS-004	ERROR	Only UTF-8 and UTF-16 encodings are allowed, detected %1$s BOM.	
 CSS-005	ERROR	Conflicting alternate style attributes found: %1$s.	
-CSS-006	WARNING	CSS position:fixed property should not be used in EPUBs.	
+CSS-006	WARNING	CSS selector specifies fixed position.	
 CSS-007	WARNING	Font-face reference %1$s refers to non-standard font type %2$s.	
 CSS-008	ERROR	An error occurred while parsing the CSS: %1$s.	
 CSS-009	USAGE	Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.	
@@ -46,7 +46,7 @@ CSS-022	USAGE	CSS selector specifies global margin setting.
 CSS-023	USAGE	CSS selector specifies media query.	
 CSS-024	USAGE	CSS class Selector is not used.	Remove unused CSS selectors.
 CSS-025	USAGE	CSS class Selector could not be found.	Check for typos or define a class selector to document the use of the class.
-CSS-027	USAGE	CSS selector specifies absolute position.	
+CSS-017	USAGE	CSS selector specifies absolute position.	
 CSS-028	USAGE	Use of Font-face declaration.	
 HTM-001	ERROR	Any publication resource that is an XML-based media type must be a valid XML 1.0 document. XML version found: %1$s.	
 HTM-002	WARNING	The installed xml parser doesn't support xml version verification. Xml files must be a valid XML 1.0 document.	

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity/OPS/style_tag_css.xhtml
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity/OPS/style_tag_css.xhtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-    <title>Unused - Style Tag CSS</title>
+	<!-- <title>Unused - Style Tag CSS</title> -->
     <style>
         .used {
             font-style: italic;

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadId_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadId_expected_results.txt
@@ -2,17 +2,19 @@ Start command_line test('severity_overrideBadId')
 ERROR(CHK-002): ./com/adobe/epubcheck/test/command_line/severity(1,0): Unrecognized custom message id BogusID encountered in message overrides file './com/adobe/epubcheck/test/command_line/severity_overrideBadId.txt'.
 Validating using EPUB version 3.0.1 rules.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(27,13): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(38,13): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(38,13): CSS selector specifies fixed position.
+WARNING(RSC-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(4,7): Warning while parsing file: The 'head' element should have a 'title' child element.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,1): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,22): The 'direction' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,1): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,1): CSS selector specifies fixed position.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(55,5): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(56,5): The 'direction' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS selector specifies fixed position.
 USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.xhtml(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(HTM-010): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(2,68): Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(6,62): Document links to multiple CSS files.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(7,66): Document links to multiple CSS files.
+USAGE(HTM-033): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(4,7): HTML 'head' element does not have a 'title' child element.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(2,5): Value of CSS property 'font-size' does not use a relative size: '14px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'line-height' does not use a relative size.
@@ -23,7 +25,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(27,5): Value of CSS property 'line-height' does not use a relative size.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(35,5): Value of CSS property 'font-size' does not use a relative size: 'x-large'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(39,5): Value of CSS property 'font-size' does not use a relative size: 'large'
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(70,5): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(70,5): CSS selector specifies absolute position.
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(79,5): CSS property is declared !Important.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(90,5): Value of CSS property 'font-size' does not use a relative size: 'large'
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(97,1): CSS selector specifies media query.
@@ -35,7 +37,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(38,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(51,5): Value of CSS property 'font-size' does not use a relative size: '11px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(58,5): Value of CSS property 'font-size' does not use a relative size: '10px'
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(2,5): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(2,5): CSS selector specifies absolute position.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(10,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(10,5): Value of CSS property 'line-height' does not use a relative size.
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(15,5): CSS property is declared !Important.
@@ -43,7 +45,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssSty
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(33,1): CSS selector specifies media query.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(35,9): Value of CSS property 'font-size' does not use a relative size: 'large'
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(9,13): CSS property is declared !Important.
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(17,13): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(17,13): CSS selector specifies absolute position.
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(20,9): CSS selector specifies media query.
 USAGE(CSS-025): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(54,24): CSS class Selector could not be found.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(14,9): CSS class Selector is not used.
@@ -72,7 +74,7 @@ USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 
 Check finished with errors
-Messages: 0 fatal / 6 errors / 6 warnings / 0 info / 58 usage
+Messages: 0 fatal / 6 errors / 1 warnings / 0 info / 65 usage
 
 EPUBCheck completed
 Completed command_line test('severity_overrideBadId')

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadMessage_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadMessage_expected_results.txt
@@ -3,17 +3,19 @@ ERROR(CHK-004): ./com/adobe/epubcheck/test/command_line/severity(1,0): The custo
 ERROR(CHK-005): ./com/adobe/epubcheck/test/command_line/severity(2,0): The custom suggestion contains too many parameters in message overrides file './com/adobe/epubcheck/test/command_line/severity_overrideBadMessage.txt'.
 Validating using EPUB version 3.2 rules.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(27,13): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(38,13): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(38,13): CSS selector specifies fixed position.
+WARNING(RSC-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(4,7): Warning while parsing file: The 'head' element should have a 'title' child element.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,1): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,22): The 'direction' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,1): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,1): CSS selector specifies fixed position.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(55,5): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(56,5): The 'direction' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS selector specifies fixed position.
 USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.xhtml(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(HTM-010): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(2,68): Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(6,62): Document links to multiple CSS files.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(7,66): Document links to multiple CSS files.
+USAGE(HTM-033): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(4,7): HTML 'head' element does not have a 'title' child element.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(2,5): Value of CSS property 'font-size' does not use a relative size: '14px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): This is an overridden message.
@@ -24,7 +26,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(27,5): This is an overridden message.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(35,5): Value of CSS property 'font-size' does not use a relative size: 'x-large'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(39,5): Value of CSS property 'font-size' does not use a relative size: 'large'
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(70,5): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(70,5): CSS selector specifies absolute position.
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(79,5): CSS property is declared !Important.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(90,5): Value of CSS property 'font-size' does not use a relative size: 'large'
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(97,1): CSS selector specifies media query.
@@ -36,7 +38,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(38,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(51,5): Value of CSS property 'font-size' does not use a relative size: '11px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(58,5): Value of CSS property 'font-size' does not use a relative size: '10px'
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(2,5): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(2,5): CSS selector specifies absolute position.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(10,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(10,5): This is an overridden message.
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(15,5): CSS property is declared !Important.
@@ -44,7 +46,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssSty
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(33,1): CSS selector specifies media query.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(35,9): Value of CSS property 'font-size' does not use a relative size: 'large'
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(9,13): CSS property is declared !Important.
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(17,13): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(17,13): CSS selector specifies absolute position.
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(20,9): CSS selector specifies media query.
 USAGE(CSS-025): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(54,24): CSS class Selector could not be found.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(14,9): CSS class Selector is not used.
@@ -73,7 +75,7 @@ USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 
 Check finished with errors
-Messages: 0 fatal / 7 errors / 6 warnings / 0 info / 58 usage
+Messages: 0 fatal / 7 errors / 1 warnings / 0 info / 65 usage
 
 EPUBCheck completed
 Completed command_line test('severity_overrideBadMessage')

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadSeverity_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideBadSeverity_expected_results.txt
@@ -2,17 +2,19 @@ Start command_line test('severity_overrideBadSeverity')
 ERROR(CHK-003): ./com/adobe/epubcheck/test/command_line/severity(1,8): Unrecognized custom message severity 'BogusSeverity' encountered in message overrides file './com/adobe/epubcheck/test/command_line/severity_overrideBadSeverity.txt'.
 Validating using EPUB version 3.0.1 rules.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(27,13): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(38,13): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(38,13): CSS selector specifies fixed position.
+WARNING(RSC-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(4,7): Warning while parsing file: The 'head' element should have a 'title' child element.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,1): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,22): The 'direction' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,1): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,1): CSS selector specifies fixed position.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(55,5): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(56,5): The 'direction' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS selector specifies fixed position.
 USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.xhtml(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(HTM-010): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(2,68): Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(6,62): Document links to multiple CSS files.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(7,66): Document links to multiple CSS files.
+USAGE(HTM-033): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(4,7): HTML 'head' element does not have a 'title' child element.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(2,5): Value of CSS property 'font-size' does not use a relative size: '14px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'line-height' does not use a relative size.
@@ -23,7 +25,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(27,5): Value of CSS property 'line-height' does not use a relative size.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(35,5): Value of CSS property 'font-size' does not use a relative size: 'x-large'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(39,5): Value of CSS property 'font-size' does not use a relative size: 'large'
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(70,5): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(70,5): CSS selector specifies absolute position.
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(79,5): CSS property is declared !Important.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(90,5): Value of CSS property 'font-size' does not use a relative size: 'large'
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(97,1): CSS selector specifies media query.
@@ -35,7 +37,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(38,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(51,5): Value of CSS property 'font-size' does not use a relative size: '11px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(58,5): Value of CSS property 'font-size' does not use a relative size: '10px'
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(2,5): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(2,5): CSS selector specifies absolute position.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(10,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(10,5): Value of CSS property 'line-height' does not use a relative size.
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(15,5): CSS property is declared !Important.
@@ -43,7 +45,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssSty
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(33,1): CSS selector specifies media query.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(35,9): Value of CSS property 'font-size' does not use a relative size: 'large'
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(9,13): CSS property is declared !Important.
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(17,13): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(17,13): CSS selector specifies absolute position.
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(20,9): CSS selector specifies media query.
 USAGE(CSS-025): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(54,24): CSS class Selector could not be found.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(14,9): CSS class Selector is not used.
@@ -72,7 +74,7 @@ USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 
 Check finished with errors
-Messages: 0 fatal / 6 errors / 6 warnings / 0 info / 58 usage
+Messages: 0 fatal / 6 errors / 1 warnings / 0 info / 65 usage
 
 EPUBCheck completed
 Completed command_line test('severity_overrideBadSeverity')

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideMissingFile_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideMissingFile_expected_results.txt
@@ -2,17 +2,19 @@ Start command_line test('severity_overrideMissingFile')
 ERROR(CHK-001): ./com/adobe/epubcheck/test/command_line/severity/./com/adobe/epubcheck/test/command_line/severity_overrideMissingFile.txt(-1,-1): The custom message overrides file was not found.
 Validating using EPUB version 3.0.1 rules.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(27,13): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(38,13): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(38,13): CSS selector specifies fixed position.
+WARNING(RSC-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(4,7): Warning while parsing file: The 'head' element should have a 'title' child element.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,1): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,22): The 'direction' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,1): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,1): CSS selector specifies fixed position.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(55,5): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(56,5): The 'direction' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS selector specifies fixed position.
 USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.xhtml(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(HTM-010): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(2,68): Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(6,62): Document links to multiple CSS files.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(7,66): Document links to multiple CSS files.
+USAGE(HTM-033): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(4,7): HTML 'head' element does not have a 'title' child element.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(2,5): Value of CSS property 'font-size' does not use a relative size: '14px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'line-height' does not use a relative size.
@@ -23,7 +25,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(27,5): Value of CSS property 'line-height' does not use a relative size.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(35,5): Value of CSS property 'font-size' does not use a relative size: 'x-large'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(39,5): Value of CSS property 'font-size' does not use a relative size: 'large'
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(70,5): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(70,5): CSS selector specifies absolute position.
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(79,5): CSS property is declared !Important.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(90,5): Value of CSS property 'font-size' does not use a relative size: 'large'
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(97,1): CSS selector specifies media query.
@@ -35,7 +37,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(38,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(51,5): Value of CSS property 'font-size' does not use a relative size: '11px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(58,5): Value of CSS property 'font-size' does not use a relative size: '10px'
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(2,5): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(2,5): CSS selector specifies absolute position.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(10,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(10,5): Value of CSS property 'line-height' does not use a relative size.
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(15,5): CSS property is declared !Important.
@@ -43,7 +45,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssSty
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(33,1): CSS selector specifies media query.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(35,9): Value of CSS property 'font-size' does not use a relative size: 'large'
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(9,13): CSS property is declared !Important.
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(17,13): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(17,13): CSS selector specifies absolute position.
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(20,9): CSS selector specifies media query.
 USAGE(CSS-025): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(54,24): CSS class Selector could not be found.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(14,9): CSS class Selector is not used.
@@ -72,7 +74,7 @@ USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 
 Check finished with errors
-Messages: 0 fatal / 6 errors / 6 warnings / 0 info / 58 usage
+Messages: 0 fatal / 6 errors / 1 warnings / 0 info / 65 usage
 
 EPUBCheck completed
 Completed command_line test('severity_overrideMissingFile')

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideOk_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_overrideOk_expected_results.txt
@@ -1,17 +1,19 @@
 Start command_line test('severity_overrideOk')
 Validating using EPUB version 3.0.1 rules.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(27,13): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(38,13): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(38,13): CSS selector specifies fixed position.
+WARNING(RSC-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(4,7): Warning while parsing file: The 'head' element should have a 'title' child element.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,1): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,22): The 'direction' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,1): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,1): CSS selector specifies fixed position.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(55,5): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(56,5): The 'direction' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS selector specifies fixed position.
 USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.xhtml(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(HTM-010): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(2,68): Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.
 ERROR(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(6,62):  (severity overridden from USAGE) This is an overridden message
 ERROR(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(7,66):  (severity overridden from USAGE) This is an overridden message
+USAGE(HTM-033): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(4,7): HTML 'head' element does not have a 'title' child element.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(2,5): Value of CSS property 'font-size' does not use a relative size: '14px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'line-height' does not use a relative size.
@@ -21,7 +23,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(27,5): Value of CSS property 'line-height' does not use a relative size.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(35,5): Value of CSS property 'font-size' does not use a relative size: 'x-large'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(39,5): Value of CSS property 'font-size' does not use a relative size: 'large'
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(70,5): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(70,5): CSS selector specifies absolute position.
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(79,5): CSS property is declared !Important.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(90,5): Value of CSS property 'font-size' does not use a relative size: 'large'
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(97,1): CSS selector specifies media query.
@@ -33,7 +35,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(38,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(51,5): Value of CSS property 'font-size' does not use a relative size: '11px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(58,5): Value of CSS property 'font-size' does not use a relative size: '10px'
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(2,5): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(2,5): CSS selector specifies absolute position.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(10,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(10,5): Value of CSS property 'line-height' does not use a relative size.
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(15,5): CSS property is declared !Important.
@@ -41,7 +43,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssSty
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(33,1): CSS selector specifies media query.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(35,9): Value of CSS property 'font-size' does not use a relative size: 'large'
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(9,13): CSS property is declared !Important.
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(17,13): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(17,13): CSS selector specifies absolute position.
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(20,9): CSS selector specifies media query.
 USAGE(CSS-025): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(54,24): CSS class Selector could not be found.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(14,9): CSS class Selector is not used.
@@ -70,7 +72,7 @@ USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 
 Check finished with errors
-Messages: 0 fatal / 7 errors / 6 warnings / 0 info / 55 usage
+Messages: 0 fatal / 7 errors / 1 warnings / 0 info / 62 usage
 
 EPUBCheck completed
 Completed command_line test('severity_overrideOk')

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_usage_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_usage_expected_results.txt
@@ -1,17 +1,19 @@
 Start command_line test('severity_usage')
 Validating using EPUB version 3.0.1 rules.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(27,13): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(38,13): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(38,13): CSS selector specifies fixed position.
+WARNING(RSC-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(4,7): Warning while parsing file: The 'head' element should have a 'title' child element.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,1): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,22): The 'direction' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,1): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,1): CSS selector specifies fixed position.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(55,5): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(56,5): The 'direction' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS position:fixed property should not be used in EPUBs.
+USAGE(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS selector specifies fixed position.
 USAGE(ACC-008): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.xhtml(-1,-1): Navigation Document has no 'landmarks nav' element.
 USAGE(HTM-010): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/toc.ncx(2,68): Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(6,62): Document links to multiple CSS files.
 USAGE(CSS-012): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/external_css.xhtml(7,66): Document links to multiple CSS files.
+USAGE(HTM-033): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(4,7): HTML 'head' element does not have a 'title' child element.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(2,5): Value of CSS property 'font-size' does not use a relative size: '14px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(7,5): Value of CSS property 'line-height' does not use a relative size.
@@ -22,7 +24,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(27,5): Value of CSS property 'line-height' does not use a relative size.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(35,5): Value of CSS property 'font-size' does not use a relative size: 'x-large'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(39,5): Value of CSS property 'font-size' does not use a relative size: 'large'
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(70,5): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(70,5): CSS selector specifies absolute position.
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(79,5): CSS property is declared !Important.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(90,5): Value of CSS property 'font-size' does not use a relative size: 'large'
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(97,1): CSS selector specifies media query.
@@ -34,7 +36,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(38,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(51,5): Value of CSS property 'font-size' does not use a relative size: '11px'
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(58,5): Value of CSS property 'font-size' does not use a relative size: '10px'
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(2,5): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(2,5): CSS selector specifies absolute position.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(10,5): Value of CSS property 'font-size' does not use a relative size: '12px'
 USAGE(ACC-015): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(10,5): Value of CSS property 'line-height' does not use a relative size.
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(15,5): CSS property is declared !Important.
@@ -42,7 +44,7 @@ USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssSty
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(33,1): CSS selector specifies media query.
 USAGE(ACC-014): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(35,9): Value of CSS property 'font-size' does not use a relative size: 'large'
 USAGE(CSS-013): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(9,13): CSS property is declared !Important.
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(17,13): CSS selector specifies absolute position.
+USAGE(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(17,13): CSS selector specifies absolute position.
 USAGE(CSS-023): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(20,9): CSS selector specifies media query.
 USAGE(CSS-025): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(54,24): CSS class Selector could not be found.
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(14,9): CSS class Selector is not used.
@@ -71,7 +73,7 @@ USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused
 USAGE(CSS-024): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/unused.css(66,3): CSS class Selector is not used.
 
 Check finished with errors
-Messages: 0 fatal / 5 errors / 6 warnings / 0 info / 58 usage
+Messages: 0 fatal / 5 errors / 1 warnings / 0 info / 65 usage
 
 EPUBCheck completed
 Completed command_line test('severity_usage')

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/severity_warning_expected_results.txt
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/severity_warning_expected_results.txt
@@ -1,18 +1,13 @@
 Start command_line test('severity_warning')
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(27,13): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(38,13): CSS position:fixed property should not be used in EPUBs.
+WARNING(RSC-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(4,7): Warning while parsing file: The 'head' element should have a 'title' child element.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,1): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(14,22): The 'direction' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/inline_css.xhtml(15,1): CSS position:fixed property should not be used in EPUBs.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(55,5): The 'unicode-bidi' property must not be included in an EPUB Style Sheet.
 ERROR(CSS-001): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(56,5): The 'direction' property must not be included in an EPUB Style Sheet.
-WARNING(CSS-006): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(66,5): CSS position:fixed property should not be used in EPUBs.
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style.css(70,5): CSS selector specifies absolute position.
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/cssStyles.css(2,5): CSS selector specifies absolute position.
-WARNING(CSS-017): ./com/adobe/epubcheck/test/command_line/severity.epub/OPS/style_tag_css.xhtml(17,13): CSS selector specifies absolute position.
 
 Check finished with errors
-Messages: 0 fatal / 5 errors / 6 warnings
+Messages: 0 fatal / 5 errors / 1 warnings
 
 EPUBCheck completed
 Completed command_line test('severity_warning')

--- a/src/test/resources/com/adobe/epubcheck/test/css/discouraged_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/discouraged_expected_results.json
@@ -252,8 +252,8 @@
     "suggestion" : null
   }, {
     "ID" : "CSS-006",
-    "severity" : "WARNING",
-    "message" : "CSS position:fixed property should not be used in EPUBs.",
+    "severity" : "USAGE",
+    "message" : "CSS selector specifies fixed position.",
     "additionalLocations" : 0,
     "locations" : [ {
       "path" : "OPS/inline_css.xhtml",
@@ -313,7 +313,7 @@
     "suggestion" : null
   }, {
     "ID" : "CSS-017",
-    "severity" : "WARNING",
+    "severity" : "USAGE",
     "message" : "CSS selector specifies absolute position.",
     "additionalLocations" : 0,
     "locations" : [ {
@@ -508,8 +508,8 @@
     "elapsedTime" : 48,
     "nFatal" : 0,
     "nError" : 2,
-    "nWarning" : 2,
-    "nUsage" : 18
+    "nWarning" : 0,
+    "nUsage" : 20
   },
   "publication" : {
     "publisher" : null,

--- a/src/test/resources/com/adobe/epubcheck/test/css/discouraged_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/css/discouraged_expected_results.xml
@@ -18,12 +18,12 @@
          <message severity="error" subMessage="CSS-001">CSS-001, ERROR, [The 'unicode-bidi' property must not be included in an EPUB Style Sheet.], OPS/style.css (55-5)</message>
          <message severity="error" subMessage="CSS-001">CSS-001, ERROR, [The 'direction' property must not be included in an EPUB Style Sheet.], OPS/inline_css.xhtml (14-22)</message>
          <message severity="error" subMessage="CSS-001">CSS-001, ERROR, [The 'direction' property must not be included in an EPUB Style Sheet.], OPS/style.css (56-5)</message>
-         <message severity="error" subMessage="CSS-006">CSS-006, WARN, [CSS position:fixed property should not be used in EPUBs.], OPS/style_tag_css.xhtml (38-13)</message>
-         <message severity="error" subMessage="CSS-006">CSS-006, WARN, [CSS position:fixed property should not be used in EPUBs.], OPS/inline_css.xhtml (15-1)</message>
-         <message severity="error" subMessage="CSS-006">CSS-006, WARN, [CSS position:fixed property should not be used in EPUBs.], OPS/style.css (66-5)</message>
-         <message severity="error" subMessage="CSS-017">CSS-017, WARN, [CSS selector specifies absolute position.], OPS/style.css (70-5)</message>
-         <message severity="error" subMessage="CSS-017">CSS-017, WARN, [CSS selector specifies absolute position.], OPS/cssStyles.css (2-5)</message>
-         <message severity="error" subMessage="CSS-017">CSS-017, WARN, [CSS selector specifies absolute position.], OPS/style_tag_css.xhtml (17-13)</message>
+         <message severity="info" subMessage="CSS-006">CSS-006, HINT, [CSS position:fixed property should not be used in EPUBs.], OPS/style_tag_css.xhtml (38-13)</message>
+         <message severity="info" subMessage="CSS-006">CSS-006, HINT, [CSS position:fixed property should not be used in EPUBs.], OPS/inline_css.xhtml (15-1)</message>
+         <message severity="info" subMessage="CSS-006">CSS-006, HINT, [CSS position:fixed property should not be used in EPUBs.], OPS/style.css (66-5)</message>
+         <message severity="info" subMessage="CSS-017">CSS-017, HINT, [CSS selector specifies absolute position.], OPS/style.css (70-5)</message>
+         <message severity="info" subMessage="CSS-017">CSS-017, HINT, [CSS selector specifies absolute position.], OPS/cssStyles.css (2-5)</message>
+         <message severity="info" subMessage="CSS-017">CSS-017, HINT, [CSS selector specifies absolute position.], OPS/style_tag_css.xhtml (17-13)</message>
          <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS/toc.xhtml</message>
          <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
          <message severity="info" subMessage="CSS-012">CSS-012, HINT, [Document links to multiple CSS files.], OPS/external_css.xhtml (6-62)</message>


### PR DESCRIPTION
This PR addresses #899 in the following ways:

- lowers CSS-006 and CSS-017 from WARNING to USAGE
- deletes CSS-027 as it becomes redundant with -017

Making these changes resulted in no warnings in the command line tests, though, so to add one back I deleted the title from one of the XHTML content documents. We don't have any CSS warnings in the specification, and my limited imagination couldn't come up with any other warnings for HTML.