### PR TITLE
Allow font/* as blessed media types

### DIFF
--- a/src/main/java/com/adobe/epubcheck/opf/OPFChecker30.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFChecker30.java
@@ -491,7 +491,13 @@ public class OPFChecker30 extends OPFChecker implements DocumentValidator
 
   public static boolean isBlessedFontType(String type)
   {
-    return type.equals("application/vnd.ms-opentype") || type.equals("application/font-woff")
+    return type.equals("font/otf")
+        || type.equals("font/ttf")
+        || type.equals("font/woff")
+        || type.equals("font/woff2")
+        || type.equals("application/font-sfnt")
+        || type.equals("application/font-woff")
+        || type.equals("application/vnd.ms-opentype")
         || type.equals("image/svg+xml");
   }
   

--- a/src/test/resources/30/single/opf/valid/cmt.opf
+++ b/src/test/resources/30/single/opf/valid/cmt.opf
@@ -13,6 +13,7 @@
 	<item id="font_001"  href="font_001.otf" media-type="application/vnd.ms-opentype"/>
 	<item id="font_002"  href="font_002.woff" media-type="application/font-woff"/>
 	<item id="font_003"  href="font_003.svg" media-type="image/svg+xml"/>
+	<item id="font_004"  href="font_004.woff2" media-type="font/woff2"/>
 	<item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml"/>
 	<item id="audio_001"  href="audio_001.mpg" media-type="audio/mpeg"/>
 	<item id="audio_002"  href="audio_002.mp4" media-type="audio/mp4"/>


### PR DESCRIPTION
This PR fixes #872 by allowing resources declared as font/* to be recognized as core media types, since fonts don't require fallbacks.