### PR TITLE
Support global ARIA attributes in SVG

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/mod/epub-svg11.rnc
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/mod/epub-svg11.rnc
@@ -23,6 +23,7 @@ SVG.foreignObject.content |=
 	|	common.inner.flow
 	)
 
+SVG.Core.attrib &= aria.global?
 SVG.Core.extra.attrib &= epub.type.attr?
 
 # augment MathML annotation-xml content model

--- a/src/main/resources/com/adobe/epubcheck/schema/30/mod/epub-xhtml-svg11.rnc
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/mod/epub-xhtml-svg11.rnc
@@ -9,6 +9,7 @@ include "svg11/inkscape.rnc"
 
 common.elem.phrasing |= svg
 
+SVG.Core.attrib &= aria.global?
 SVG.Core.extra.attrib &= epub.type.attr?
 
 SVG.foreignObject.content |= common.inner.flow

--- a/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
@@ -693,6 +693,12 @@ public class OPSCheckerTest
   }
 
   @Test
+  public void testValidateSVG_WithARIAAttributes()
+  {
+    testValidateDocument("svg/valid/aria-attributes.svg", "image/svg+xml", EPUBVersion.VERSION_3);
+  }
+  
+  @Test
   public void testValidateSVG_WithDataAttribute()
   {
     testValidateDocument("svg/valid/data-attribute.svg", "image/svg+xml", EPUBVersion.VERSION_3);

--- a/src/test/resources/30/single/svg/valid/aria-attributes.svg
+++ b/src/test/resources/30/single/svg/valid/aria-attributes.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 1200 400" xmlns="http://www.w3.org/2000/svg" version="1.1"
+	xmlns:xlink="http://www.w3.org/1999/xlink">
+	<title>Test</title>
+	<desc>Cover</desc>
+	<image height="857" width="500" xlink:href="../images/cover.jpg" role="doc-cover"
+		aria-label="Cover"/>
+</svg>


### PR DESCRIPTION
Add `aria.global` attributes to `SVG.Core.attrib`, in both SVG and XHTML
integration schemas.

Fix #846

Thanks @mattgarrish for the schema spelunking!