### PR TITLE
Add l10n contributors to the dist README

### DIFF
--- a/src/main/assembly/README-dist.txt
+++ b/src/main/assembly/README-dist.txt
@@ -62,6 +62,7 @@ Previous contributors include:
 - Alexander Walters
 - Andrew Neitsch
 - Arwen Pond
+- Bobby Tung
 - Bogdan Iordache
 - Dave Cramer
 - dilbirligi

--- a/src/main/assembly/README-dist.txt
+++ b/src/main/assembly/README-dist.txt
@@ -71,6 +71,7 @@ Previous contributors include:
 - Francisco Sanchez
 - Garth Conboy
 - George Bina
+- Gregorio Pellegrino (Fondazione LIA)
 - Ionut-Maxim Margelatu
 - Jessica Hekman
 - Jostein Austvik Jacobsen

--- a/src/main/assembly/README-dist.txt
+++ b/src/main/assembly/README-dist.txt
@@ -76,7 +76,7 @@ Previous contributors include:
 - Jessica Hekman
 - Jostein Austvik Jacobsen
 - Liza Daly
-- Marianne Gulstad
+- Marianne Gulstad (Publizon)
 - Markus Gylling
 - Martin Kraetke
 - Masayoshi Takahashi

--- a/src/main/assembly/README-dist.txt
+++ b/src/main/assembly/README-dist.txt
@@ -73,6 +73,7 @@ Previous contributors include:
 - Jessica Hekman
 - Jostein Austvik Jacobsen
 - Liza Daly
+- Marianne Gulstad
 - Markus Gylling
 - Martin Kraetke
 - Masayoshi Takahashi

--- a/src/main/assembly/README-dist.txt
+++ b/src/main/assembly/README-dist.txt
@@ -67,6 +67,7 @@ Previous contributors include:
 - Dave Cramer
 - dilbirligi
 - Emiliano Molina
+- Elisa Molinari (Fondazione LIA)
 - Francisco Sanchez
 - Garth Conboy
 - George Bina


### PR DESCRIPTION
I just added new translations from Transifex:
* **Chinese (Taiwan)** 46195adc2a88ef45ef6341bb424804980f3857db
* **Danish** 28ef69bea729073186890117611c616672e64fc7

I just updated existing translations from Transifex:
* **Italian** 864282a6245007a6b08d3c1d57c2da6db2da5fa0 and d954ae7b9b90d373378e3c6622ba40bb7d42f5d0

However, Transifex does not show who translated the messages, who contributed.

Dear contributors, we highly value your efforts in translation EPUBCheck and would like to add your name to the list of contributors in the README file. 🙏 

Please leave me a comment  here if you contributed to one of the languages above and I will add you to the list. Thanks.