### PR TITLE
Add doc-glossary to section

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/mod/html5/structural.rnc
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/mod/html5/structural.rnc
@@ -42,6 +42,7 @@
 			|	common.attrs.aria.role.doc-errata
 			|	common.attrs.aria.role.doc-example
 			|	common.attrs.aria.role.doc-foreword
+			|	common.attrs.aria.role.doc-glossary
 			|	common.attrs.aria.role.doc-index
 			|	common.attrs.aria.role.doc-introduction
 			|	common.attrs.aria.role.doc-notice


### PR DESCRIPTION
This PR fixes #997 by allowing doc-glossary on section element.

Probably should include some tests, but we don't test any of the roles so figuring we can deal with that at a later time.