### PR TITLE
fix: script data blocks don't need to be declared

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -319,7 +319,7 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.SCP_002, Severity.USAGE);
     severities.put(MessageId.SCP_003, Severity.USAGE);
     severities.put(MessageId.SCP_004, Severity.ERROR);
-    severities.put(MessageId.SCP_005, Severity.ERROR);
+    severities.put(MessageId.SCP_005, Severity.SUPPRESSED);
     severities.put(MessageId.SCP_006, Severity.USAGE);
     severities.put(MessageId.SCP_007, Severity.USAGE);
     severities.put(MessageId.SCP_008, Severity.USAGE);

--- a/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
@@ -1339,5 +1339,21 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   public void testBaseURI()
   {
     testValidateDocument("valid/base-uri");
+  } 
+
+  @Test
+  public void testScript_DataBlock()
+  {
+    // test that script data blocks are allowed, and do not require the 'scripted'
+    // property to be defined on the Content Document item
+    testValidateDocument("valid/script-data-block");
+  }
+  
+  @Test
+  public void testScript_PropertyUndeclared()
+  {
+    // test that scripted resource must be declared in the Package Document
+    expectedErrors.add(MessageId.OPF_014);
+    testValidateDocument("invalid/script-property-undeclared");
   }
 }

--- a/src/test/resources/30/expanded/invalid/script-property-undeclared/META-INF/container.xml
+++ b/src/test/resources/30/expanded/invalid/script-property-undeclared/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+   <rootfiles>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+   </rootfiles>
+</container>

--- a/src/test/resources/30/expanded/invalid/script-property-undeclared/OPS/content_001.xhtml
+++ b/src/test/resources/30/expanded/invalid/script-property-undeclared/OPS/content_001.xhtml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<title>Minimal EPUB</title>
+		<script>
+			alert('hi');
+		</script>
+	</head>
+	<body epub:type="bodymatter">
+		<h1>Loomings</h1>
+		<p>Call me Ishmael.</p>
+	</body>
+</html>

--- a/src/test/resources/30/expanded/invalid/script-property-undeclared/OPS/nav.xhtml
+++ b/src/test/resources/30/expanded/invalid/script-property-undeclared/OPS/nav.xhtml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+		<nav epub:type="landmarks">
+			<ol>
+				<li><a href="content_001.xhtml" epub:type="bodymatter">Start Reading</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/30/expanded/invalid/script-property-undeclared/OPS/package.opf
+++ b/src/test/resources/30/expanded/invalid/script-property-undeclared/OPS/package.opf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title id="title">Minimal EPUB 3.0</dc:title>
+    <dc:language>en</dc:language>
+    <dc:identifier id="q">NOID</dc:identifier>
+    <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+  </metadata>
+  <manifest>
+    <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  </manifest>
+  <spine>
+    <itemref idref="content_001"/>
+  </spine>
+</package>

--- a/src/test/resources/30/expanded/invalid/script-property-undeclared/mimetype
+++ b/src/test/resources/30/expanded/invalid/script-property-undeclared/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/src/test/resources/30/expanded/valid/script-data-block/META-INF/container.xml
+++ b/src/test/resources/30/expanded/valid/script-data-block/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+   <rootfiles>
+      <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
+   </rootfiles>
+</container>

--- a/src/test/resources/30/expanded/valid/script-data-block/OPS/content_001.xhtml
+++ b/src/test/resources/30/expanded/valid/script-data-block/OPS/content_001.xhtml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<title>Minimal EPUB</title>
+		<script type="application/vnd.xyz">
+			xyz
+		</script>
+	</head>
+	<body epub:type="bodymatter">
+		<h1>Loomings</h1>
+		<p>Call me Ishmael.</p>
+	</body>
+</html>

--- a/src/test/resources/30/expanded/valid/script-data-block/OPS/nav.xhtml
+++ b/src/test/resources/30/expanded/valid/script-data-block/OPS/nav.xhtml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+		<nav epub:type="landmarks">
+			<ol>
+				<li><a href="content_001.xhtml" epub:type="bodymatter">Start Reading</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/30/expanded/valid/script-data-block/OPS/package.opf
+++ b/src/test/resources/30/expanded/valid/script-data-block/OPS/package.opf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title id="title">Minimal EPUB 3.0</dc:title>
+    <dc:language>en</dc:language>
+    <dc:identifier id="q">NOID</dc:identifier>
+    <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+  </metadata>
+  <manifest>
+    <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  </manifest>
+  <spine>
+    <itemref idref="content_001"/>
+  </spine>
+</package>

--- a/src/test/resources/30/expanded/valid/script-data-block/mimetype
+++ b/src/test/resources/30/expanded/valid/script-data-block/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/src/test/resources/com/adobe/epubcheck/test/scripts/properties_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/scripts/properties_expected_results.json
@@ -99,28 +99,6 @@
     } ],
     "suggestion" : null
   }, {
-    "ID" : "SCP-005",
-    "severity" : "ERROR",
-    "message" : "Content file contains script but it is not marked as scripted.",
-    "additionalLocations" : 0,
-    "locations" : [ {
-      "path" : "OPS/external_script_not_marked.xhtml",
-      "line" : -1,
-      "column" : -1,
-      "context" : null
-    }, {
-      "path" : "OPS/inline_script_not_marked.xhtml",
-      "line" : -1,
-      "column" : -1,
-      "context" : null
-    }, {
-      "path" : "OPS/script_tag_not_marked.xhtml",
-      "line" : -1,
-      "column" : -1,
-      "context" : null
-    } ],
-    "suggestion" : null
-  }, {
     "ID" : "SCP-006",
     "severity" : "USAGE",
     "message" : "Inline scripts found.",
@@ -225,7 +203,7 @@
     "checkDate" : "02-24-2019 02:17:01",
     "elapsedTime" : 5782,
     "nFatal" : 0,
-    "nError" : 3,
+    "nError" : 2,
     "nWarning" : 0,
     "nUsage" : 8
   },


### PR DESCRIPTION
Content Documents with script data blocks (`script` elements with inline
data that isn't Javascript) should not need to be declared as `scripted`
in the Package Document.

`OPF_014` reports missing item properties, and already only reports a
missing `scipted` property when Javascript-typed `script` is found.

But `SCP_005` was also raised as `ERROR`, duplicating `OPF_014`, and
incorrectly _not_ depending on the script type.

This PR fixes that by suppressing message `SCP_005`.