### PR TITLE
fix: report duplicate landmarks nav entries as ERROR

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/epub-nav-30.sch
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/epub-nav-30.sch
@@ -38,7 +38,7 @@
                 count(ancestor::html:nav//html:ol//html:a[
                     tokenize(lower-case(@epub:type),'\s+') = $current_type_normalized and
                     normalize-space(lower-case(@href)) = $current_href_normalized
-                    ]) le 1">WARNING: Duplicate 'a' elements with the same 'epub:type' and 'href' attributes inside 'landmarks' nav element</assert>
+                    ]) le 1">Another landmark was found with the same epub:type and same reference to '<value-of select="$current_href_normalized"/>'</assert>
         </rule>
     </pattern>
 

--- a/src/test/java/com/adobe/epubcheck/nav/NavCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/nav/NavCheckerTest.java
@@ -187,7 +187,7 @@ public class NavCheckerTest
   public void testValidateDocumentNavLandmarksDuplicates()
   {
     // Multiple occurrences of the 'landmarks' nav element
-    Collections.addAll(expectedWarnings, MessageId.RSC_017, MessageId.RSC_017);
+    Collections.addAll(expectedErrors, MessageId.RSC_005, MessageId.RSC_005);
     testValidateDocument("invalid/nav-landmarks-duplicates.xhtml");
   }
   


### PR DESCRIPTION
They were previously reported as WARNING.

Close #298