### PR TITLE
fix: allow `epub:type` on all HTML elements

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/epub-nav-30.rnc
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/epub-nav-30.rnc
@@ -7,9 +7,13 @@
    }
 
    ## "reset" the definition of nav.attrs to what it was
-   ## before epub:type was set to augment common.attrs
+   ## before epub:type was set to augment common.attrs.basic
    nav.attrs.noepubtype = 
-     ( common.attrs.basic
+     ( common.attrs.id?
+     & common.attrs.class?
+     & common.attrs.title?
+     & common.attrs.base?
+     & common.attrs.space?
      & common.attrs.i18n
      & common.attrs.present
      & common.attrs.other

--- a/src/main/resources/com/adobe/epubcheck/schema/30/mod/epub-type-attr.rnc
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/mod/epub-type-attr.rnc
@@ -8,8 +8,6 @@
    ## common.attrs.other is augmented by other schemas.
    ## We therefore augment common.attrs (and also attrobute
    ## lists that are not based on common.attrs) 
-   common.attrs &= epub.type.attr?
-   a.attrs &= epub.type.attr?
-   area.attrs &= epub.type.attr?
+   common.attrs.basic &= epub.type.attr?
 
    epub.type.attr = attribute epub:type { datatype.properties }

--- a/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
@@ -454,6 +454,13 @@ public class OPSCheckerTest
     testValidateDocument("xhtml/valid/epubtype.xhtml", "application/xhtml+xml",
         EPUBVersion.VERSION_3);
   }
+  
+  @Test
+  public void testEPUBTypeInHead()
+  {
+    testValidateDocument("xhtml/valid/epubtype-in-head.xhtml", "application/xhtml+xml",
+        EPUBVersion.VERSION_3);
+  }
 
   @Test
   public void testEPUBTypeFromReservedVocab()

--- a/src/test/resources/30/single/xhtml/valid/epubtype-in-head.xhtml
+++ b/src/test/resources/30/single/xhtml/valid/epubtype-in-head.xhtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>	 
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops"
+  epub:prefix="my: https://example.org/vocab/#" lang="en">
+  <head>
+    <title>Test</title>
+    <meta name="creator" content="Herman Melville" epub:type="my:creator" />
+  </head>
+  <body>
+    <h1>Test</h1>
+  </body>
+</html>


### PR DESCRIPTION
Fix #986