### PR TITLE
fix: parse CSS custom properties

### DIFF
--- a/src/main/java/org/idpf/epubcheck/util/css/CssScanner.java
+++ b/src/main/java/org/idpf/epubcheck/util/css/CssScanner.java
@@ -134,9 +134,10 @@ final class CssScanner
       {
         _urange();
       }
-      else if (NMSTART.matches(cur) || cur == '-'
-          && matches(next, NMSTART) || escapes.get(0).isPresent()
-          || (cur == '-' && escapes.get(1).isPresent()))
+      else if (NMSTART.matches(cur) 
+          || cur == '-'  && 
+             (matches(next, NMSTART) || reader.peek() == '-' || escapes.get(1).isPresent())
+          || escapes.get(0).isPresent())
       {
         _ident();
         if (reader.peek() == '(')
@@ -406,7 +407,7 @@ final class CssScanner
   }
 
   /**
-   * IDENT [-]?{nmstart}{nmchar}*
+   * IDENT ([-]?{nmstart}|[--]){nmchar}*
    */
   private void _ident() throws
       IOException,

--- a/src/test/java/org/idpf/epubcheck/util/css/CssParserTest.java
+++ b/src/test/java/org/idpf/epubcheck/util/css/CssParserTest.java
@@ -171,6 +171,13 @@ public class CssParserTest {
       assertTrue(((CssQuantity)cc).subType != CssQuantity.Unit.LENGTH); // '1m' is invalid length
     }
   }
+  
+  @Test
+  public void testParser015() throws Exception {
+    String s = "E { --my-property: 16px; } ";
+    HandlerImpl handler = checkBasics(exec(s));
+    assertEquals(0, handler.errors.size());
+  }
 			
 	@Test
 	public void testParserAtRule001() throws Exception {
@@ -884,6 +891,11 @@ public class CssParserTest {
 		checkBasics(execFile("counter-styles.css", false));								
 	}
 	
+	@Test
+	public void testParserFile005() throws Exception {
+	  checkBasics(execFile("custom-properties.css", false));
+	}
+
 	@Test
 	public void testGrammarToCssString001() throws Exception {				
 		String s = "E {color:black}";

--- a/src/test/java/org/idpf/epubcheck/util/css/CssScannerTest.java
+++ b/src/test/java/org/idpf/epubcheck/util/css/CssScannerTest.java
@@ -455,6 +455,17 @@ public class CssScannerTest {
 	}
 	
 	@Test
+	public void testLexerIdent_30() throws Exception {
+	  String s = "--a";
+
+	  List<CssToken> tokens = execScan(s);
+	  assertEquals(1, tokens.size());
+	  assertEquals(0, exceptions.size());
+	  assertEquals(CssToken.Type.IDENT, tokens.get(0).getType());
+	  assertEquals("--a", tokens.get(0).getChars());
+	}
+
+	@Test
 	public void testLexerAtKeyword_10() throws Exception {
 		String s = "@ident";
 		

--- a/src/test/resources/css/custom-properties.css
+++ b/src/test/resources/css/custom-properties.css
@@ -1,0 +1,37 @@
+/*Examples taken from MDN "Using custom properties"*/
+
+/* Basics */
+
+:root {
+  --main-bg-color: brown;
+}
+
+.one {
+  color: white;
+  background-color: var(--main-bg-color);
+  margin: 10px;
+  width: 50px;
+  height: 50px;
+  display: inline-block;
+}
+
+
+/* Fallbacks */ 
+
+.two {
+  color: var(--my-var, red); /* Red if --my-var is not defined */
+}
+
+.three {
+  background-color: var(--my-var, var(--my-background, pink)); /* pink if my-var and --my-background are not defined */
+}
+
+.three {
+  background-color: var(--my-var, --my-background, pink); /* Invalid: "--my-background, pink" */
+}
+
+/* Invalid variable */
+
+:root { --text-color: 16px; } 
+p { color: blue; } 
+p { color: var(--text-color); }


### PR DESCRIPTION
This change only fixes the `CssScanner` to parse CSS custom properties
as IDENT tokens.

Additional work may be needed to actually make the built-in CSS Grammar
aware of custom properties, but at this time this is not needed to
prevent EPUBCheck from reporting custom properties as errors.

Fix #790