### PR TITLE
feat: report use of non-preferred Core Media Types

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -262,6 +262,7 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.OPF_087, Severity.ERROR);
     severities.put(MessageId.OPF_088, Severity.USAGE);
     severities.put(MessageId.OPF_089, Severity.ERROR);
+    severities.put(MessageId.OPF_090, Severity.USAGE);
 
     // PKG
     severities.put(MessageId.PKG_001, Severity.WARNING);

--- a/src/main/java/com/adobe/epubcheck/messages/MessageId.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageId.java
@@ -255,6 +255,7 @@ public enum MessageId implements Comparable<MessageId>
   OPF_087("OPF-087"),
   OPF_088("OPF-088"),
   OPF_089("OPF-089"),
+  OPF_090("OPF-090"),
 
   // Messages relating to the entire package
   PKG_001("PKG-001"),

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -270,6 +270,7 @@ OPF_086_SUG.xmp-record=the 'record' keyword with the properties attribute value 
 OPF_087=Property '%1$s' is not allowed on documents of type '%2$s'.
 OPF_088=Unrecognized property '%1$s'.
 OPF_089=The 'alternate' link rel keyword cannot be paired with other keywords.
+OPF_090=It is encouraged to use MIME media type '%1$s' instead of '%2$s'.  
 
 #Package
 PKG_001=Validating the EPUB against version %1$s but detected version %2$s.

--- a/src/test/resources/30/single/opf/valid/cmt-preferred.opf
+++ b/src/test/resources/30/single/opf/valid/cmt-preferred.opf
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="q">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+</metadata>
+<manifest>
+	<item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+	<item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml"/>
+	<!-- the following items should use preferred media types -->
+	<item id="js_001"  href="script_001.js" media-type="text/javascript"/>
+	<item id="font_001"  href="font_001.otf" media-type="application/vnd.ms-opentype"/>
+	<item id="font_002"  href="font_002.woff" media-type="application/font-woff"/>
+	<item id="font_003"  href="font_003.ttf" media-type="application/font-sfnt"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/src/test/resources/com/adobe/epubcheck/test/css/font-face_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font-face_expected_results.json
@@ -320,6 +320,30 @@
     } ],
     "suggestion" : null
   }, {
+    "ID" : "OPF-090",
+    "severity" : "USAGE",
+    "message" : "It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ",
+    "additionalLocations" : 0,
+    "locations" : [ {
+      "path" : "OPS/content.opf",
+      "line" : 17,
+      "column" : 89,
+      "context" : null
+    } ],
+    "suggestion" : null
+  }, {
+    "ID" : "OPF-090",
+    "severity" : "USAGE",
+    "message" : "It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ",
+    "additionalLocations" : 0,
+    "locations" : [ {
+      "path" : "OPS/content.opf",
+      "line" : 18,
+      "column" : 84,
+      "context" : null
+    } ],
+    "suggestion" : null
+  }, {
     "ID" : "RSC-006",
     "severity" : "ERROR",
     "message" : "Remote resource reference not allowed; resource must be placed in the OCF.",
@@ -387,15 +411,15 @@
   } ],
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/css/font-face.epub",
+    "path" : "./test-classes/com/adobe/epubcheck/test/css/font-face.epub",
     "filename" : "font-face.epub",
     "checkerVersion" : "4.2.0-rc-SNAPSHOT",
-    "checkDate" : "02-28-2019 23:57:14",
-    "elapsedTime" : 122,
+    "checkDate" : "03-16-2019 02:28:42",
+    "elapsedTime" : 53,
     "nFatal" : 0,
     "nError" : 9,
     "nWarning" : 1,
-    "nUsage" : 9
+    "nUsage" : 11
   },
   "publication" : {
     "publisher" : null,

--- a/src/test/resources/com/adobe/epubcheck/test/css/font-face_expected_results.xmp
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font-face_expected_results.xmp
@@ -12,7 +12,7 @@
                        dc:language="en"
                        extended-properties:Characters="2205"
                        rdf:about=""
-                       xmp:CreateDate="2019-02-28T23:57:02Z">
+                       xmp:CreateDate="2019-03-16T02:38:56Z">
          <dc:title>
             <rdf:Alt>
                <rdf:li xml:lang="x-default">Font Face Sample Book</rdf:li>
@@ -31,7 +31,7 @@
             </rdf:Bag>
          </xmpTPg:Fonts>
          <premis:hasEvent rdf:parseType="Resource">
-            <premis:hasEventDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-28T23:57:14+01:00</premis:hasEventDateTime>
+            <premis:hasEventDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-16T02:44:44+01:00</premis:hasEventDateTime>
             <premis:hasEventType rdf:resource="http://id.loc.gov/vocabulary/preservation/eventType/val"/>
             <premis:hasEventDetail>Not well-formed</premis:hasEventDetail>
             <premis:hasEventOutcomeInformation>
@@ -115,6 +115,22 @@
                      <premis:hasEventOutcomeDetail>
                         <rdf:Seq>
                            <rdf:li premis:hasEventOutcomeDetailNote="OPS/styles/style.css (31-1)"/>
+                        </rdf:Seq>
+                     </premis:hasEventOutcomeDetail>
+                  </rdf:li>
+                  <rdf:li rdf:parseType="Resource">
+                     <premis:hasEventOutcome>OPF-090, HINT, It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.</premis:hasEventOutcome>
+                     <premis:hasEventOutcomeDetail>
+                        <rdf:Seq>
+                           <rdf:li premis:hasEventOutcomeDetailNote="OPS/content.opf (17-89)"/>
+                        </rdf:Seq>
+                     </premis:hasEventOutcomeDetail>
+                  </rdf:li>
+                  <rdf:li rdf:parseType="Resource">
+                     <premis:hasEventOutcome>OPF-090, HINT, It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.</premis:hasEventOutcome>
+                     <premis:hasEventOutcomeDetail>
+                        <rdf:Seq>
+                           <rdf:li premis:hasEventOutcomeDetailNote="OPS/content.opf (18-84)"/>
                         </rdf:Seq>
                      </premis:hasEventOutcomeDetail>
                   </rdf:li>

--- a/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.json
@@ -242,18 +242,92 @@
       "context" : null
     } ],
     "suggestion" : null
+  }, {
+    "ID" : "OPF-090",
+    "severity" : "USAGE",
+    "message" : "It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ",
+    "additionalLocations" : 0,
+    "locations" : [ {
+      "path" : "Css-fontface/package.opf",
+      "line" : 23,
+      "column" : 121,
+      "context" : null
+    }, {
+      "path" : "Css-fontface/package.opf",
+      "line" : 24,
+      "column" : 119,
+      "context" : null
+    }, {
+      "path" : "Css-fontface/package.opf",
+      "line" : 25,
+      "column" : 115,
+      "context" : null
+    }, {
+      "path" : "Css-fontface/package.opf",
+      "line" : 27,
+      "column" : 125,
+      "context" : null
+    }, {
+      "path" : "Css-fontface/package.opf",
+      "line" : 28,
+      "column" : 123,
+      "context" : null
+    }, {
+      "path" : "Css-fontface/package.opf",
+      "line" : 29,
+      "column" : 119,
+      "context" : null
+    } ],
+    "suggestion" : null
+  }, {
+    "ID" : "OPF-090",
+    "severity" : "USAGE",
+    "message" : "It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ",
+    "additionalLocations" : 0,
+    "locations" : [ {
+      "path" : "Css-fontface/package.opf",
+      "line" : 19,
+      "column" : 119,
+      "context" : null
+    }, {
+      "path" : "Css-fontface/package.opf",
+      "line" : 20,
+      "column" : 117,
+      "context" : null
+    }, {
+      "path" : "Css-fontface/package.opf",
+      "line" : 21,
+      "column" : 113,
+      "context" : null
+    }, {
+      "path" : "Css-fontface/package.opf",
+      "line" : 31,
+      "column" : 116,
+      "context" : null
+    }, {
+      "path" : "Css-fontface/package.opf",
+      "line" : 32,
+      "column" : 114,
+      "context" : null
+    }, {
+      "path" : "Css-fontface/package.opf",
+      "line" : 33,
+      "column" : 110,
+      "context" : null
+    } ],
+    "suggestion" : null
   } ],
   "customMessageFileName" : null,
   "checker" : {
     "path" : "./test-classes/com/adobe/epubcheck/test/css/font_encryption_idpf.epub",
     "filename" : "font_encryption_idpf.epub",
-    "checkerVersion" : "4.2.0-beta-SNAPSHOT",
-    "checkDate" : "02-05-2019 16:01:02",
-    "elapsedTime" : 441,
+    "checkerVersion" : "4.2.0-rc-SNAPSHOT",
+    "checkDate" : "03-16-2019 02:28:43",
+    "elapsedTime" : 383,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
-    "nUsage" : 4
+    "nUsage" : 6
   },
   "publication" : {
     "publisher" : "Epub3 Team",

--- a/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.xml
@@ -1,18 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       date="2019-02-05"
+       date="2019-03-13"
        name="epubcheck"
-       release="4.2.0-beta-SNAPSHOT"
+       release="4.2.0-rc-SNAPSHOT"
        xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove http://hul.harvard.edu/ois/xml/xsd/jhove/jhove.xsd">
-   <date>2019-02-05T16:01:03+01:00</date>
+   <date>2019-03-16T02:28:44+01:00</date>
    <repInfo uri="/Users/Romain/Work/epubcheck/epubcheck/target/test-classes/com/adobe/epubcheck/test/css/font_encryption_idpf.epub">
-      <created>2019-02-05T15:38:16Z</created>
+      <created>2019-03-16T02:26:38Z</created>
       <lastModified>2012-01-20T12:47:00Z</lastModified>
       <format>application/epub+zip</format>
-      <version>3.0.1</version>
+      <version>3.2</version>
       <status>Well-formed</status>
       <messages>
+         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (19-119)</message>
+         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (20-117)</message>
+         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (21-113)</message>
+         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (31-116)</message>
+         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (32-114)</message>
+         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (33-110)</message>
+         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (23-121)</message>
+         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (24-119)</message>
+         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (25-115)</message>
+         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (27-125)</message>
+         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (28-123)</message>
+         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (29-119)</message>
          <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (2-5)</message>
          <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (3-5)</message>
          <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (4-5)</message>
@@ -88,7 +100,7 @@
                <property>
                   <name>CreationDate</name>
                   <values arity="Scalar" type="Date">
-                     <value>2019-02-05T15:38:16Z</value>
+                     <value>2019-03-16T02:26:38Z</value>
                   </values>
                </property>
                <property>

--- a/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.xmp
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.xmp
@@ -13,7 +13,7 @@
                        dc:publisher="Epub3 Team"
                        extended-properties:Characters="2790"
                        rdf:about=""
-                       xmp:CreateDate="2019-02-05T15:38:16Z">
+                       xmp:CreateDate="2019-03-16T02:26:38Z">
          <dc:creator>
             <rdf:Seq>
                <rdf:li>David</rdf:li>
@@ -41,11 +41,37 @@
             </rdf:Bag>
          </xmpTPg:Fonts>
          <premis:hasEvent rdf:parseType="Resource">
-            <premis:hasEventDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-02-05T16:01:03+01:00</premis:hasEventDateTime>
+            <premis:hasEventDateTime rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-03-16T02:28:44+01:00</premis:hasEventDateTime>
             <premis:hasEventType rdf:resource="http://id.loc.gov/vocabulary/preservation/eventType/val"/>
             <premis:hasEventDetail>Well-formed</premis:hasEventDetail>
             <premis:hasEventOutcomeInformation>
                <rdf:Seq>
+                  <rdf:li rdf:parseType="Resource">
+                     <premis:hasEventOutcome>OPF-090, HINT, It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.</premis:hasEventOutcome>
+                     <premis:hasEventOutcomeDetail>
+                        <rdf:Seq>
+                           <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/package.opf (19-119)"/>
+                           <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/package.opf (20-117)"/>
+                           <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/package.opf (21-113)"/>
+                           <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/package.opf (31-116)"/>
+                           <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/package.opf (32-114)"/>
+                           <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/package.opf (33-110)"/>
+                        </rdf:Seq>
+                     </premis:hasEventOutcomeDetail>
+                  </rdf:li>
+                  <rdf:li rdf:parseType="Resource">
+                     <premis:hasEventOutcome>OPF-090, HINT, It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.</premis:hasEventOutcome>
+                     <premis:hasEventOutcomeDetail>
+                        <rdf:Seq>
+                           <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/package.opf (23-121)"/>
+                           <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/package.opf (24-119)"/>
+                           <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/package.opf (25-115)"/>
+                           <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/package.opf (27-125)"/>
+                           <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/package.opf (28-123)"/>
+                           <rdf:li premis:hasEventOutcomeDetailNote="Css-fontface/package.opf (29-119)"/>
+                        </rdf:Seq>
+                     </premis:hasEventOutcomeDetail>
+                  </rdf:li>
                   <rdf:li rdf:parseType="Resource">
                      <premis:hasEventOutcome>CSS-028, HINT, Use of Font-face declaration.</premis:hasEventOutcome>
                      <premis:hasEventOutcomeDetail>
@@ -113,7 +139,7 @@
             </premis:hasEventOutcomeInformation>
             <premis:hasEventRelatedAgent rdf:parseType="Resource">
                <premis:hasAgentType rdf:resource="http://id.loc.gov/vocabulary/preservation/agentType/sof"/>
-               <premis:hasAgentName>epubcheck 4.2.0-beta-SNAPSHOT</premis:hasAgentName>
+               <premis:hasAgentName>epubcheck 4.2.0-rc-SNAPSHOT</premis:hasAgentName>
             </premis:hasEventRelatedAgent>
          </premis:hasEvent>
          <premis:hasSignificantProperties>

--- a/src/test/resources/com/adobe/epubcheck/test/scripts/XMLHttpRequest_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/scripts/XMLHttpRequest_expected_results.json
@@ -48,6 +48,18 @@
     } ],
     "suggestion" : null
   }, {
+    "ID" : "OPF-090",
+    "severity" : "USAGE",
+    "message" : "It is encouraged to use MIME media type 'application/javascript' instead of 'text/javascript'.  ",
+    "additionalLocations" : 0,
+    "locations" : [ {
+      "path" : "OPS/content.opf",
+      "line" : 15,
+      "column" : 77,
+      "context" : null
+    } ],
+    "suggestion" : null
+  }, {
     "ID" : "SCP-002",
     "severity" : "USAGE",
     "message" : "Use of XMLHttpRequest in EPUB scripts is a security risk.",
@@ -147,15 +159,15 @@
   } ],
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/scripts/XMLHttpRequest.epub",
+    "path" : "./test-classes/com/adobe/epubcheck/test/scripts/XMLHttpRequest.epub",
     "filename" : "XMLHttpRequest.epub",
-    "checkerVersion" : "4.2.0-beta-SNAPSHOT",
-    "checkDate" : "02-24-2019 02:17:07",
-    "elapsedTime" : 104,
+    "checkerVersion" : "4.2.0-rc-SNAPSHOT",
+    "checkDate" : "03-16-2019 02:28:29",
+    "elapsedTime" : 93,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
-    "nUsage" : 10
+    "nUsage" : 11
   },
   "publication" : {
     "publisher" : null,

--- a/src/test/resources/com/adobe/epubcheck/test/scripts/eval_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/scripts/eval_expected_results.json
@@ -73,6 +73,18 @@
     } ],
     "suggestion" : null
   }, {
+    "ID" : "OPF-090",
+    "severity" : "USAGE",
+    "message" : "It is encouraged to use MIME media type 'application/javascript' instead of 'text/javascript'.  ",
+    "additionalLocations" : 0,
+    "locations" : [ {
+      "path" : "OPS/content.opf",
+      "line" : 15,
+      "column" : 77,
+      "context" : null
+    } ],
+    "suggestion" : null
+  }, {
     "ID" : "SCP-001",
     "severity" : "USAGE",
     "message" : "Use of Javascript eval() function in EPUB scripts is a security risk.",
@@ -158,15 +170,15 @@
   } ],
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/scripts/eval.epub",
+    "path" : "./test-classes/com/adobe/epubcheck/test/scripts/eval.epub",
     "filename" : "eval.epub",
-    "checkerVersion" : "4.2.0-beta-SNAPSHOT",
-    "checkDate" : "02-24-2019 02:17:07",
-    "elapsedTime" : 126,
+    "checkerVersion" : "4.2.0-rc-SNAPSHOT",
+    "checkDate" : "03-16-2019 02:28:29",
+    "elapsedTime" : 90,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
-    "nUsage" : 8
+    "nUsage" : 9
   },
   "publication" : {
     "publisher" : null,

--- a/src/test/resources/com/adobe/epubcheck/test/scripts/properties_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/scripts/properties_expected_results.json
@@ -87,6 +87,18 @@
     } ],
     "suggestion" : null
   }, {
+    "ID" : "OPF-090",
+    "severity" : "USAGE",
+    "message" : "It is encouraged to use MIME media type 'application/javascript' instead of 'text/javascript'.  ",
+    "additionalLocations" : 0,
+    "locations" : [ {
+      "path" : "OPS/content.opf",
+      "line" : 18,
+      "column" : 77,
+      "context" : null
+    } ],
+    "suggestion" : null
+  }, {
     "ID" : "RSC-005",
     "severity" : "ERROR",
     "message" : "Error while parsing file: The for attribute does not refer to an allowed target element (expecting: button|meter|output|progress|select|textarea|input[not(@type='hidden')]).",
@@ -197,15 +209,15 @@
   } ],
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/scripts/properties.epub",
+    "path" : "./test-classes/com/adobe/epubcheck/test/scripts/properties.epub",
     "filename" : "properties.epub",
-    "checkerVersion" : "4.2.0-beta-SNAPSHOT",
-    "checkDate" : "02-24-2019 02:17:01",
-    "elapsedTime" : 5782,
+    "checkerVersion" : "4.2.0-rc-SNAPSHOT",
+    "checkDate" : "03-16-2019 02:28:28",
+    "elapsedTime" : 429,
     "nFatal" : 0,
     "nError" : 2,
     "nWarning" : 0,
-    "nUsage" : 8
+    "nUsage" : 9
   },
   "publication" : {
     "publisher" : null,

--- a/src/test/resources/com/adobe/epubcheck/test/scripts/storage_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/scripts/storage_expected_results.json
@@ -41,6 +41,18 @@
     } ],
     "suggestion" : null
   }, {
+    "ID" : "OPF-090",
+    "severity" : "USAGE",
+    "message" : "It is encouraged to use MIME media type 'application/javascript' instead of 'text/javascript'.  ",
+    "additionalLocations" : 0,
+    "locations" : [ {
+      "path" : "OPS/content.opf",
+      "line" : 15,
+      "column" : 77,
+      "context" : null
+    } ],
+    "suggestion" : null
+  }, {
     "ID" : "SCP-003",
     "severity" : "USAGE",
     "message" : "Local and Session Storage is not currently supported.",
@@ -183,15 +195,15 @@
   } ],
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/scripts/storage.epub",
+    "path" : "./test-classes/com/adobe/epubcheck/test/scripts/storage.epub",
     "filename" : "storage.epub",
-    "checkerVersion" : "4.2.0-beta-SNAPSHOT",
-    "checkDate" : "02-24-2019 02:17:07",
-    "elapsedTime" : 95,
+    "checkerVersion" : "4.2.0-rc-SNAPSHOT",
+    "checkDate" : "03-16-2019 02:28:29",
+    "elapsedTime" : 82,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
-    "nUsage" : 8
+    "nUsage" : 9
   },
   "publication" : {
     "publisher" : null,

--- a/src/test/resources/com/adobe/epubcheck/test/scripts/unused_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/scripts/unused_expected_results.json
@@ -41,6 +41,23 @@
     } ],
     "suggestion" : null
   }, {
+    "ID" : "OPF-090",
+    "severity" : "USAGE",
+    "message" : "It is encouraged to use MIME media type 'application/javascript' instead of 'text/javascript'.  ",
+    "additionalLocations" : 0,
+    "locations" : [ {
+      "path" : "OPS/content.opf",
+      "line" : 15,
+      "column" : 77,
+      "context" : null
+    }, {
+      "path" : "OPS/content.opf",
+      "line" : 16,
+      "column" : 77,
+      "context" : null
+    } ],
+    "suggestion" : null
+  }, {
     "ID" : "SCP-006",
     "severity" : "USAGE",
     "message" : "Inline scripts found.",
@@ -109,15 +126,15 @@
   } ],
   "customMessageFileName" : null,
   "checker" : {
-    "path" : "./target/test-classes/com/adobe/epubcheck/test/scripts/unused.epub",
+    "path" : "./test-classes/com/adobe/epubcheck/test/scripts/unused.epub",
     "filename" : "unused.epub",
-    "checkerVersion" : "4.2.0-beta-SNAPSHOT",
-    "checkDate" : "02-24-2019 02:17:07",
-    "elapsedTime" : 140,
+    "checkerVersion" : "4.2.0-rc-SNAPSHOT",
+    "checkDate" : "03-16-2019 02:28:29",
+    "elapsedTime" : 98,
     "nFatal" : 0,
     "nError" : 0,
     "nWarning" : 0,
-    "nUsage" : 6
+    "nUsage" : 7
   },
   "publication" : {
     "publisher" : null,

--- a/src/test/resources/com/adobe/epubcheck/test/xhtml/media_overlays_expected_results.json
+++ b/src/test/resources/com/adobe/epubcheck/test/xhtml/media_overlays_expected_results.json
@@ -316,6 +316,33 @@
     } ],
     "suggestion" : null
   }, {
+    "ID" : "OPF-090",
+    "severity" : "USAGE",
+    "message" : "It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ",
+    "additionalLocations" : 0,
+    "locations" : [ {
+      "path" : "OPS/content.opf",
+      "line" : 21,
+      "column" : 116,
+      "context" : null
+    }, {
+      "path" : "OPS/content.opf",
+      "line" : 22,
+      "column" : 114,
+      "context" : null
+    }, {
+      "path" : "OPS/content.opf",
+      "line" : 23,
+      "column" : 110,
+      "context" : null
+    }, {
+      "path" : "OPS/content.opf",
+      "line" : 24,
+      "column" : 123,
+      "context" : null
+    } ],
+    "suggestion" : null
+  }, {
     "ID" : "RSC-005",
     "severity" : "ERROR",
     "message" : "Error while parsing file: global media:duration meta element not set",
@@ -344,13 +371,13 @@
   "checker" : {
     "path" : "./test-classes/com/adobe/epubcheck/test/xhtml/media_overlays.epub",
     "filename" : "media_overlays.epub",
-    "checkerVersion" : "4.2.0-beta-SNAPSHOT",
-    "checkDate" : "02-05-2019 15:52:58",
-    "elapsedTime" : 718,
+    "checkerVersion" : "4.2.0-rc-SNAPSHOT",
+    "checkDate" : "03-16-2019 02:39:43",
+    "elapsedTime" : 568,
     "nFatal" : 0,
     "nError" : 3,
     "nWarning" : 0,
-    "nUsage" : 7
+    "nUsage" : 8
   },
   "publication" : {
     "publisher" : null,


### PR DESCRIPTION
Report a new `USAGE` message, `OPF-090`, when a Package Doc item is
declared with a Core Media Type which has an alternative preferred media
type.

Fix #873