### PR TITLE
fix: allow any role on `a` elem with no `href`

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/mod/html5/phrase.rnc
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/mod/html5/phrase.rnc
@@ -5,24 +5,19 @@
 
 ## Contextual Hyperlink: <a>
 
-	a.elem.phrasing =
-		element a { a.inner.phrasing & a.attrs }
-	a.elem.flow =
-		element a { a.inner.flow & a.attrs }
-	a.attrs =
-		(	common.attrs.basic
-		&	common.attrs.i18n
-		&	common.attrs.present
-		&	common.attrs.other
-		&	a.attrs.name?
-		&	shared-hyperlink.attrs.download?
-		&	shared-hyperlink.attrs.href?
-		&	shared-hyperlink.attrs.target?
-		&	shared-hyperlink.attrs.rel?
-		&	shared-hyperlink.attrs.hreflang?
-		&	shared-hyperlink.attrs.type?
-		&	shared-hyperlink.attrs.ping?
-		&	referrerpolicy?
+	a.elem.phrasing = a.href.elem.phrasing | a.nohref.elem.phrasing
+	a.elem.flow = a.href.elem.flow | a.nohref.elem.flow
+	a.href.elem.phrasing =
+		element a { a.inner.phrasing & a.href.attrs }
+	a.href.elem.flow =
+		element a { a.inner.flow & a.href.attrs }
+	a.nohref.elem.phrasing =
+		element a { a.inner.phrasing & a.nohref.attrs }
+	a.nohref.elem.flow =
+		element a { a.inner.flow & a.nohref.attrs }
+	a.href.attrs =
+		( a.attrs
+		& shared-hyperlink.attrs.href
 		&	(	common.attrs.aria.implicit.link
 			|	common.attrs.aria.role.button
 			|	common.attrs.aria.role.checkbox
@@ -40,6 +35,24 @@
 			|	common.attrs.aria.role.doc-glossref
 			|	common.attrs.aria.role.doc-noteref
 			)?
+		)
+	a.nohref.attrs =
+		( a.attrs
+		&	common.attrs.aria?
+		)
+	a.attrs =
+		(	common.attrs.basic
+		&	common.attrs.i18n
+		&	common.attrs.present
+		&	common.attrs.other
+		&	a.attrs.name?
+		&	shared-hyperlink.attrs.download?
+		&	shared-hyperlink.attrs.target?
+		&	shared-hyperlink.attrs.rel?
+		&	shared-hyperlink.attrs.hreflang?
+		&	shared-hyperlink.attrs.type?
+		&	shared-hyperlink.attrs.ping?
+		&	referrerpolicy?
 		)
 		a.attrs.name =
 		  attribute name {

--- a/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
@@ -161,6 +161,15 @@ public class OPSCheckerTest
   }
   
   @Test
+  public void testARIARoleOnAElemWithNoHref()
+  {
+    // test that any role is allowed on `a` elem with no `href` attribute.
+    // the test case specifically tests the `doc-pagebreak` role.
+    testValidateDocument("xhtml/valid/aria-role-a-nohref.xhtml", "application/xhtml+xml",
+        EPUBVersion.VERSION_3);
+  }
+  
+  @Test
   public void testValidateXHTMLEdits001()
   {
     testValidateDocument("xhtml/valid/edits-001.xhtml", "application/xhtml+xml",

--- a/src/test/resources/30/single/xhtml/valid/aria-role-a-nohref.xhtml
+++ b/src/test/resources/30/single/xhtml/valid/aria-role-a-nohref.xhtml
@@ -1,0 +1,12 @@
+<!DOCTYPE html>	 
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <head>
+    <title>Test</title>
+    <meta charset="UTF-8"/>
+  </head>
+  <body>
+    <h1>Test</h1>
+    <!-- this is allowed by ARIA in HTML, but not a good practice -->
+    <a role="doc-pagebreak">1</a>
+  </body>
+</html>


### PR DESCRIPTION
Any role is allowed according to ARIA in HTML:
https://www.w3.org/TR/html-aria/#anohref

Ported from validator/validator#774
Fix #1022