### PR TITLE
fix: allow `doc-endnote` on `li` children of `ol`

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/mod/html5/block.rnc
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/mod/html5/block.rnc
@@ -167,6 +167,8 @@
 			|	common.attrs.aria.role.treeitem
 			|	common.attrs.aria.role.separator
 			|	common.attrs.aria.role.presentation
+			|	common.attrs.aria.role.doc-biblioentry
+			|	common.attrs.aria.role.doc-endnote
 			)?
 		)
 		oli.attrs.value =

--- a/src/main/resources/com/adobe/epubcheck/schema/30/mod/html5/phrase.rnc
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/mod/html5/phrase.rnc
@@ -37,7 +37,11 @@
 			)?
 		)
 	a.nohref.attrs =
-		( a.attrs
+		( common.attrs.basic
+    & common.attrs.i18n
+    & common.attrs.present
+    & common.attrs.other
+    & a.attrs.name?
 		&	common.attrs.aria?
 		)
 	a.attrs =

--- a/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
@@ -170,6 +170,14 @@ public class OPSCheckerTest
   }
   
   @Test
+  public void testARIARoleDocEndnote()
+  {
+    // test that the `doc-endnote` role is allowed where it should
+    testValidateDocument("xhtml/valid/aria-role-doc-endnote.xhtml", "application/xhtml+xml",
+        EPUBVersion.VERSION_3);
+  }
+  
+  @Test
   public void testValidateXHTMLEdits001()
   {
     testValidateDocument("xhtml/valid/edits-001.xhtml", "application/xhtml+xml",

--- a/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
@@ -962,7 +962,7 @@ public class OPSCheckerTest
   @Test
   public void testValidateXHTML301MDInvalid()
   {
-    Collections.addAll(expectedErrors, MessageId.RSC_005, MessageId.RSC_005);
+    Collections.addAll(expectedErrors, MessageId.RSC_005, MessageId.RSC_005, MessageId.RSC_005);
     testValidateDocument("xhtml/invalid/md.xhtml", "application/xhtml+xml", EPUBVersion.VERSION_3);
   }
 

--- a/src/test/resources/30/single/xhtml/valid/aria-role-doc-endnote.xhtml
+++ b/src/test/resources/30/single/xhtml/valid/aria-role-doc-endnote.xhtml
@@ -1,0 +1,22 @@
+<!DOCTYPE html>	 
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <head>
+    <title>Test</title>
+    <meta charset="UTF-8"/>
+  </head>
+  <body>
+    <h1>Test</h1>
+    <section role="doc-endnotes">
+      <h2>Notes</h2>
+      <ol>
+        <li role="doc-endnote">…</li>
+      </ol>
+    </section>
+    <section role="doc-endnotes">
+      <h2>Notes</h2>
+      <ul>
+        <li role="doc-endnote">…</li>
+      </ul>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
Fix #1041