### PR TITLE
feat: revert the spine/toc nav order check to a WARNING

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -34,6 +34,8 @@ class DefaultSeverities implements Severities
     {
       return;
     }
+    // Info
+    severities.put(MessageId.INF_001, Severity.INFO);
 
     // Accessibility
     severities.put(MessageId.ACC_001, Severity.USAGE);

--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -154,7 +154,7 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.NAV_008, Severity.USAGE);
     severities.put(MessageId.NAV_009, Severity.ERROR);
     severities.put(MessageId.NAV_010, Severity.ERROR);
-    severities.put(MessageId.NAV_011, Severity.ERROR);
+    severities.put(MessageId.NAV_011, Severity.WARNING);
 
     // NCX
     severities.put(MessageId.NCX_001, Severity.ERROR);

--- a/src/main/java/com/adobe/epubcheck/messages/MessageId.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageId.java
@@ -28,6 +28,9 @@ import java.util.NoSuchElementException;
 
 public enum MessageId implements Comparable<MessageId>
 {
+  // General info messages
+  INF_001("INF-001"),
+  
   // Messages relating to accessibility
   ACC_001("ACC-001"),
   ACC_002("ACC-002"),

--- a/src/main/java/com/adobe/epubcheck/opf/XRefChecker.java
+++ b/src/main/java/com/adobe/epubcheck/opf/XRefChecker.java
@@ -548,6 +548,8 @@ public class XRefChecker
       report.message(MessageId.NAV_011,
           EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber),
           (ref.type == Type.NAV_TOC_LINK) ? "toc" : "page-list", ref.value, orderContext);
+      report.message(MessageId.INF_001,
+          EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber), "ERROR", "https://github.com/w3c/publ-epub-revision/issues/1283");
       lastSpinePosition = targetSpinePosition;
       lastAnchorPosition = -1;
     }
@@ -570,6 +572,8 @@ public class XRefChecker
         report.message(MessageId.NAV_011,
             EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber),
             (ref.type == Type.NAV_TOC_LINK) ? "toc" : "page-list", ref.value, orderContext);
+        report.message(MessageId.INF_001,
+            EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber), "ERROR", "https://github.com/w3c/publ-epub-revision/issues/1283");
       }
       lastAnchorPosition = targetAnchorPosition;
     }

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -1,5 +1,8 @@
 # This is the default MessageBundle.properties file
 
+#Info
+INF_001=The previous rule is under review and may change to an '%1$s' in a future release. See the discussion at %2$s
+
 #Accessibility
 ACC_001='img' or 'area' HTML element has no 'alt' attribute.
 ACC_002='input' HTML element is not referenced by a corresponding label element.

--- a/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
@@ -213,7 +213,7 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   public void testValidateNav_TocWrongOrderInSpine()
   {
     // test that toc nav links MUST be in spine order 
-    expectedErrors.add(MessageId.NAV_011);
+    expectedWarnings.add(MessageId.NAV_011);
     testValidateDocument("invalid/nav-toc-unordered-spine");
   }
 
@@ -221,7 +221,7 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   public void testValidateNav_TocWrongOrderOfFragments()
   {
     // test that toc nav links MUST be in document order
-    expectedErrors.addAll(Collections.nCopies(2, MessageId.NAV_011));
+    expectedWarnings.addAll(Collections.nCopies(2, MessageId.NAV_011));
     testValidateDocument("invalid/nav-toc-unordered-fragments");
   }
   
@@ -236,7 +236,7 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   public void testValidateNav_PageListWrongOrderInSpine()
   {
     // test that page-list nav links MUST be in spine order 
-    expectedErrors.add(MessageId.NAV_011);
+    expectedWarnings.add(MessageId.NAV_011);
     testValidateDocument("invalid/nav-page-list-unordered-spine");
   }
   
@@ -244,7 +244,7 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   public void testValidateNav_PageListWrongOrderOfFragments()
   {
     // test that page-list nav links MUST be in document order
-    expectedErrors.add(MessageId.NAV_011);
+    expectedWarnings.add(MessageId.NAV_011);
     testValidateDocument("invalid/nav-page-list-unordered-fragments");
   }
 

--- a/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
+++ b/src/test/java/com/adobe/epubcheck/api/Epub30CheckExpandedTest.java
@@ -214,6 +214,7 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   {
     // test that toc nav links MUST be in spine order 
     expectedWarnings.add(MessageId.NAV_011);
+    expectedInfos.add(MessageId.INF_001);
     testValidateDocument("invalid/nav-toc-unordered-spine");
   }
 
@@ -222,6 +223,7 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   {
     // test that toc nav links MUST be in document order
     expectedWarnings.addAll(Collections.nCopies(2, MessageId.NAV_011));
+    expectedInfos.add(MessageId.INF_001);
     testValidateDocument("invalid/nav-toc-unordered-fragments");
   }
   
@@ -237,6 +239,7 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   {
     // test that page-list nav links MUST be in spine order 
     expectedWarnings.add(MessageId.NAV_011);
+    expectedInfos.add(MessageId.INF_001);
     testValidateDocument("invalid/nav-page-list-unordered-spine");
   }
   
@@ -245,6 +248,7 @@ public class Epub30CheckExpandedTest extends AbstractEpubCheckTest
   {
     // test that page-list nav links MUST be in document order
     expectedWarnings.add(MessageId.NAV_011);
+    expectedInfos.add(MessageId.INF_001);
     testValidateDocument("invalid/nav-page-list-unordered-fragments");
   }
 


### PR DESCRIPTION
As agreed on the 2019-07-11 EPUB CG call:
https://www.w3.org/2019/07/11-epub3cg-minutes.html

Changes the behavior introduced in #999

Fixes #1036