### PR TITLE
remove 'ERROR' in the informative "under review" message

### DIFF
--- a/src/main/java/com/adobe/epubcheck/opf/XRefChecker.java
+++ b/src/main/java/com/adobe/epubcheck/opf/XRefChecker.java
@@ -549,7 +549,7 @@ public class XRefChecker
           EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber),
           (ref.type == Type.NAV_TOC_LINK) ? "toc" : "page-list", ref.value, orderContext);
       report.message(MessageId.INF_001,
-          EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber), "ERROR", "https://github.com/w3c/publ-epub-revision/issues/1283");
+          EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber), "https://github.com/w3c/publ-epub-revision/issues/1283");
       lastSpinePosition = targetSpinePosition;
       lastAnchorPosition = -1;
     }
@@ -573,7 +573,7 @@ public class XRefChecker
             EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber),
             (ref.type == Type.NAV_TOC_LINK) ? "toc" : "page-list", ref.value, orderContext);
         report.message(MessageId.INF_001,
-            EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber), "ERROR", "https://github.com/w3c/publ-epub-revision/issues/1283");
+            EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber), "https://github.com/w3c/publ-epub-revision/issues/1283");
       }
       lastAnchorPosition = targetAnchorPosition;
     }

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -1,7 +1,7 @@
 # This is the default MessageBundle.properties file
 
 #Info
-INF_001=The previous rule is under review and may change to an '%1$s' in a future release. See the discussion at %2$s
+INF_001=The previous rule is under review and its severity may change in a future release. See the discussion at %1$s
 
 #Accessibility
 ACC_001='img' or 'area' HTML element has no 'alt' attribute.


### PR DESCRIPTION
This addresses the concern raised by @ShinyaTakami in #1056.

@ShinyaTakami can you please review?