### PR TITLE
chore: set Travis to build on trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - openjdk11


### PR DESCRIPTION
Travis JDK downloads is quite brittle. See for instance the following community thread:
https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/6

Building on `trusty` is allegedly more stable (for JDK downloads) than building on `xenial`.