### PR TITLE
[fix #789] use the new jhove schema

### DIFF
--- a/src/main/java/com/adobe/epubcheck/util/XmlReportImpl.java
+++ b/src/main/java/com/adobe/epubcheck/util/XmlReportImpl.java
@@ -26,13 +26,13 @@ public class XmlReportImpl extends XmlReportAbstract
     generationDate = fromTime(System.currentTimeMillis());
     try
     {
-      setNamespace("http://hul.harvard.edu/ois/xml/ns/jhove");
+      setNamespace("http://schema.openpreservation.org/ois/xml/ns/jhove");
       addPrefixNamespace("xsi","http://www.w3.org/2001/XMLSchema-instance");
 	  List<KeyValue<String, String>> attrs = new ArrayList<KeyValue<String, String>>();
 	  attrs.add(KeyValue.with("name", epubCheckName));
 	  attrs.add(KeyValue.with("release", epubCheckVersion)); 
 	  attrs.add(KeyValue.with("date", epubCheckDate));
-	  attrs.add(KeyValue.with("xsi:schemaLocation", "http://hul.harvard.edu/ois/xml/ns/jhove http://hul.harvard.edu/ois/xml/xsd/jhove/jhove.xsd"));
+	  attrs.add(KeyValue.with("xsi:schemaLocation", "http://schema.openpreservation.org/ois/xml/ns/jhove https://schema.openpreservation.org/ois/xml/xsd/jhove/jhove.xsd"));
 	  startElement("jhove", attrs);
 
 	  generateElement("date", generationDate);
@@ -69,7 +69,7 @@ public class XmlReportImpl extends XmlReportAbstract
 				loc = " (" + ml.getLine() + "-" + ml.getColumn() + ")";
 			  }
               generateElement("message", m + PathUtil.removeWorkingDirectory(ml.getPath()) + loc,
-            		  KeyValue.with("subMessage", c.getID()), KeyValue.with("severity", "error"));
+            		  KeyValue.with("id", c.getID()), KeyValue.with("severity", "error"));
         	}
         }
         for (CheckMessage c : errors) {
@@ -80,7 +80,7 @@ public class XmlReportImpl extends XmlReportAbstract
 				loc = " (" + ml.getLine() + "-" + ml.getColumn() + ")";
 			  }
               generateElement("message", m + PathUtil.removeWorkingDirectory(ml.getPath()) + loc,
-            		  KeyValue.with("subMessage", c.getID()), KeyValue.with("severity", "error"));
+            		  KeyValue.with("id", c.getID()), KeyValue.with("severity", "error"));
         	}
         }
         for (CheckMessage c : warns) {
@@ -91,7 +91,7 @@ public class XmlReportImpl extends XmlReportAbstract
 				loc = " (" + ml.getLine() + "-" + ml.getColumn() + ")";
 			  }
               generateElement("message", m + PathUtil.removeWorkingDirectory(ml.getPath()) + loc,
-            		  KeyValue.with("subMessage", c.getID()), KeyValue.with("severity", "error"));
+            		  KeyValue.with("id", c.getID()), KeyValue.with("severity", "warning"));
         	}
         }
         for (CheckMessage c : hints) {
@@ -102,7 +102,7 @@ public class XmlReportImpl extends XmlReportAbstract
 				loc = " (" + ml.getLine() + "-" + ml.getColumn() + ")";
 			  }
               generateElement("message", m + PathUtil.removeWorkingDirectory(ml.getPath()) + loc,
-            		  KeyValue.with("subMessage", c.getID()), KeyValue.with("severity", "info"));
+            		  KeyValue.with("id", c.getID()), KeyValue.with("severity", "info"));
         	}
         }
         endElement("messages");

--- a/src/test/resources/com/adobe/epubcheck/test/DTBook/Basic_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/DTBook/Basic_expected_results.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+<jhove xmlns="http://schema.openpreservation.org/ois/xml/ns/jhove"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        date="2017-01-02"
        name="epubcheck"
        release="4.0.3-SNAPSHOT"
-       xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove http://hul.harvard.edu/ois/xml/xsd/jhove/jhove.xsd">
+       xsi:schemaLocation="http://schema.openpreservation.org/ois/xml/ns/jhove https://schema.openpreservation.org/ois/xml/xsd/jhove/jhove.xsd">
  <date>2017-01-02T18:40:30+01:00</date>
  <repInfo uri="/Users/tofi/dev/epubcheck/target/test-classes/com/adobe/epubcheck/test/DTBook/Basic.epub">
   <created>2017-01-02T18:34:14Z</created>
@@ -12,8 +12,8 @@
   <version>2.0.1</version>
   <status>Well-formed</status>
   <messages>
-   <message severity="error" subMessage="OPF-021">OPF-021, WARN, [Use of non-registered URI scheme type in href: 'waka://barnesandnoble.com'.], OPS/AreYouReadyV3.xml (25-69)</message>
-   <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
+   <message severity="warning" id="OPF-021">OPF-021, WARN, [Use of non-registered URI scheme type in href: 'waka://barnesandnoble.com'.], OPS/AreYouReadyV3.xml (25-69)</message>
+   <message severity="info" id="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>

--- a/src/test/resources/com/adobe/epubcheck/test/command_line/xmlfile_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/command_line/xmlfile_expected_results.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+<jhove xmlns="http://schema.openpreservation.org/ois/xml/ns/jhove"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        date="2019-02-05"
        name="epubcheck"
        release="4.2.0-beta-SNAPSHOT"
-       xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove http://hul.harvard.edu/ois/xml/xsd/jhove/jhove.xsd">
+       xsi:schemaLocation="http://schema.openpreservation.org/ois/xml/ns/jhove https://schema.openpreservation.org/ois/xml/xsd/jhove/jhove.xsd">
    <date>2019-02-05T15:38:26+01:00</date>
    <repInfo uri="/Users/Romain/Work/epubcheck/epubcheck/target/test-classes/com/adobe/epubcheck/test/command_line/xmlfile.epub">
       <created>2019-02-05T15:38:16Z</created>
@@ -13,17 +13,17 @@
       <version>3.0.1</version>
       <status>Well-formed</status>
       <messages>
-         <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS/toc.xhtml</message>
-         <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
-         <message severity="info" subMessage="CSS-009">CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style.css (3-23)</message>
-         <message severity="info" subMessage="CSS-009">CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style.css (8-23)</message>
-         <message severity="info" subMessage="CSS-009">CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style_tag_css.xhtml (8-31)</message>
-         <message severity="info" subMessage="CSS-009">CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style_tag_css.xhtml (13-31)</message>
-         <message severity="info" subMessage="CSS-009">CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style_tag_css.xhtml (5-28)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (10-119)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (11-115)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (14-116)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (15-114)</message>
+         <message severity="info" id="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS/toc.xhtml</message>
+         <message severity="info" id="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
+         <message severity="info" id="CSS-009">CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style.css (3-23)</message>
+         <message severity="info" id="CSS-009">CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style.css (8-23)</message>
+         <message severity="info" id="CSS-009">CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style_tag_css.xhtml (8-31)</message>
+         <message severity="info" id="CSS-009">CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style_tag_css.xhtml (13-31)</message>
+         <message severity="info" id="CSS-009">CSS-009, HINT, [Use of certain CSS such as Columns, Transforms, Transitions, box-sizing or KeyFrames can cause pagination issues.], OPS/style_tag_css.xhtml (5-28)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (10-119)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (11-115)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (14-116)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (15-114)</message>
       </messages>
       <mimeType>application/epub+zip</mimeType>
       <properties>

--- a/src/test/resources/com/adobe/epubcheck/test/css/discouraged_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/css/discouraged_expected_results.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+<jhove xmlns="http://schema.openpreservation.org/ois/xml/ns/jhove"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        date="2019-02-05"
        name="epubcheck"
        release="4.2.0-beta-SNAPSHOT"
-       xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove http://hul.harvard.edu/ois/xml/xsd/jhove/jhove.xsd">
+       xsi:schemaLocation="http://schema.openpreservation.org/ois/xml/ns/jhove https://schema.openpreservation.org/ois/xml/xsd/jhove/jhove.xsd">
    <date>2019-02-05T15:52:56+01:00</date>
    <repInfo uri="/Users/Romain/Work/epubcheck/epubcheck/target/test-classes/com/adobe/epubcheck/test/css/discouraged.epub">
       <created>2019-02-05T15:38:16Z</created>
@@ -13,75 +13,75 @@
       <version>3.0.1</version>
       <status>Not well-formed</status>
       <messages>
-         <message severity="error" subMessage="CSS-001">CSS-001, ERROR, [The 'unicode-bidi' property must not be included in an EPUB Style Sheet.], OPS/style_tag_css.xhtml (27-13)</message>
-         <message severity="error" subMessage="CSS-001">CSS-001, ERROR, [The 'unicode-bidi' property must not be included in an EPUB Style Sheet.], OPS/inline_css.xhtml (14-1)</message>
-         <message severity="error" subMessage="CSS-001">CSS-001, ERROR, [The 'unicode-bidi' property must not be included in an EPUB Style Sheet.], OPS/style.css (55-5)</message>
-         <message severity="error" subMessage="CSS-001">CSS-001, ERROR, [The 'direction' property must not be included in an EPUB Style Sheet.], OPS/inline_css.xhtml (14-22)</message>
-         <message severity="error" subMessage="CSS-001">CSS-001, ERROR, [The 'direction' property must not be included in an EPUB Style Sheet.], OPS/style.css (56-5)</message>
-         <message severity="info" subMessage="CSS-006">CSS-006, HINT, [CSS position:fixed property should not be used in EPUBs.], OPS/style_tag_css.xhtml (38-13)</message>
-         <message severity="info" subMessage="CSS-006">CSS-006, HINT, [CSS position:fixed property should not be used in EPUBs.], OPS/inline_css.xhtml (15-1)</message>
-         <message severity="info" subMessage="CSS-006">CSS-006, HINT, [CSS position:fixed property should not be used in EPUBs.], OPS/style.css (66-5)</message>
-         <message severity="info" subMessage="CSS-017">CSS-017, HINT, [CSS selector specifies absolute position.], OPS/style.css (70-5)</message>
-         <message severity="info" subMessage="CSS-017">CSS-017, HINT, [CSS selector specifies absolute position.], OPS/cssStyles.css (2-5)</message>
-         <message severity="info" subMessage="CSS-017">CSS-017, HINT, [CSS selector specifies absolute position.], OPS/style_tag_css.xhtml (17-13)</message>
-         <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS/toc.xhtml</message>
-         <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
-         <message severity="info" subMessage="CSS-012">CSS-012, HINT, [Document links to multiple CSS files.], OPS/external_css.xhtml (6-62)</message>
-         <message severity="info" subMessage="CSS-012">CSS-012, HINT, [Document links to multiple CSS files.], OPS/external_css.xhtml (7-66)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '14px'], OPS/style.css (2-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '14px'], OPS/unused.css (23-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '12px'], OPS/style.css (7-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '12px'], OPS/style.css (27-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '12px'], OPS/unused.css (8-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '12px'], OPS/unused.css (32-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '12px'], OPS/unused.css (38-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '12px'], OPS/cssStyles.css (10-5)</message>
-         <message severity="info" subMessage="ACC-015">ACC-015, HINT, [Value of CSS property 'line-height' does not use a relative size.], OPS/style.css (7-5)</message>
-         <message severity="info" subMessage="ACC-015">ACC-015, HINT, [Value of CSS property 'line-height' does not use a relative size.], OPS/style.css (27-5)</message>
-         <message severity="info" subMessage="ACC-015">ACC-015, HINT, [Value of CSS property 'line-height' does not use a relative size.], OPS/cssStyles.css (10-5)</message>
-         <message severity="info" subMessage="CSS-021">CSS-021, HINT, [Shorthand CSS property 'font-family' specifies an invalid System Font.], OPS/style.css (11-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '18px'], OPS/style.css (15-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '18px'], OPS/style.css (19-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'x-large'], OPS/style.css (35-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'large'], OPS/style.css (39-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'large'], OPS/style.css (90-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'large'], OPS/style.css (99-9)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'large'], OPS/cssStyles.css (27-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'large'], OPS/cssStyles.css (35-9)</message>
-         <message severity="info" subMessage="CSS-013">CSS-013, HINT, [CSS property is declared !Important.], OPS/style.css (79-5)</message>
-         <message severity="info" subMessage="CSS-013">CSS-013, HINT, [CSS property is declared !Important.], OPS/cssStyles.css (15-5)</message>
-         <message severity="info" subMessage="CSS-013">CSS-013, HINT, [CSS property is declared !Important.], OPS/style_tag_css.xhtml (9-13)</message>
-         <message severity="info" subMessage="CSS-023">CSS-023, HINT, [CSS selector specifies media query.], OPS/style.css (97-1)</message>
-         <message severity="info" subMessage="CSS-023">CSS-023, HINT, [CSS selector specifies media query.], OPS/cssStyles.css (33-1)</message>
-         <message severity="info" subMessage="CSS-023">CSS-023, HINT, [CSS selector specifies media query.], OPS/style_tag_css.xhtml (20-9)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '22px'], OPS/unused.css (14-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '11px'], OPS/unused.css (51-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '10px'], OPS/unused.css (58-5)</message>
-         <message severity="info" subMessage="CSS-025">CSS-025, HINT, [CSS class Selector could not be found.], OPS/style_tag_css.xhtml (54-24)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style_tag_css.xhtml (14-9)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (6-1)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (10-1)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (14-1)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (18-1)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (22-1)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (30-1)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (34-1)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (38-1)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (42-1)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (46-1)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (82-1)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (98-5)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (1-1)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (30-1)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (36-1)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (49-1)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (56-1)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (62-1)</message>
-         <message severity="info" subMessage="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (66-3)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (10-54)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (11-97)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (14-50)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (15-41)</message>
+         <message severity="error" id="CSS-001">CSS-001, ERROR, [The 'unicode-bidi' property must not be included in an EPUB Style Sheet.], OPS/style_tag_css.xhtml (27-13)</message>
+         <message severity="error" id="CSS-001">CSS-001, ERROR, [The 'unicode-bidi' property must not be included in an EPUB Style Sheet.], OPS/inline_css.xhtml (14-1)</message>
+         <message severity="error" id="CSS-001">CSS-001, ERROR, [The 'unicode-bidi' property must not be included in an EPUB Style Sheet.], OPS/style.css (55-5)</message>
+         <message severity="error" id="CSS-001">CSS-001, ERROR, [The 'direction' property must not be included in an EPUB Style Sheet.], OPS/inline_css.xhtml (14-22)</message>
+         <message severity="error" id="CSS-001">CSS-001, ERROR, [The 'direction' property must not be included in an EPUB Style Sheet.], OPS/style.css (56-5)</message>
+         <message severity="info" id="CSS-006">CSS-006, HINT, [CSS position:fixed property should not be used in EPUBs.], OPS/style_tag_css.xhtml (38-13)</message>
+         <message severity="info" id="CSS-006">CSS-006, HINT, [CSS position:fixed property should not be used in EPUBs.], OPS/inline_css.xhtml (15-1)</message>
+         <message severity="info" id="CSS-006">CSS-006, HINT, [CSS position:fixed property should not be used in EPUBs.], OPS/style.css (66-5)</message>
+         <message severity="info" id="CSS-017">CSS-017, HINT, [CSS selector specifies absolute position.], OPS/style.css (70-5)</message>
+         <message severity="info" id="CSS-017">CSS-017, HINT, [CSS selector specifies absolute position.], OPS/cssStyles.css (2-5)</message>
+         <message severity="info" id="CSS-017">CSS-017, HINT, [CSS selector specifies absolute position.], OPS/style_tag_css.xhtml (17-13)</message>
+         <message severity="info" id="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS/toc.xhtml</message>
+         <message severity="info" id="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
+         <message severity="info" id="CSS-012">CSS-012, HINT, [Document links to multiple CSS files.], OPS/external_css.xhtml (6-62)</message>
+         <message severity="info" id="CSS-012">CSS-012, HINT, [Document links to multiple CSS files.], OPS/external_css.xhtml (7-66)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '14px'], OPS/style.css (2-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '14px'], OPS/unused.css (23-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '12px'], OPS/style.css (7-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '12px'], OPS/style.css (27-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '12px'], OPS/unused.css (8-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '12px'], OPS/unused.css (32-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '12px'], OPS/unused.css (38-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '12px'], OPS/cssStyles.css (10-5)</message>
+         <message severity="info" id="ACC-015">ACC-015, HINT, [Value of CSS property 'line-height' does not use a relative size.], OPS/style.css (7-5)</message>
+         <message severity="info" id="ACC-015">ACC-015, HINT, [Value of CSS property 'line-height' does not use a relative size.], OPS/style.css (27-5)</message>
+         <message severity="info" id="ACC-015">ACC-015, HINT, [Value of CSS property 'line-height' does not use a relative size.], OPS/cssStyles.css (10-5)</message>
+         <message severity="info" id="CSS-021">CSS-021, HINT, [Shorthand CSS property 'font-family' specifies an invalid System Font.], OPS/style.css (11-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '18px'], OPS/style.css (15-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '18px'], OPS/style.css (19-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'x-large'], OPS/style.css (35-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'large'], OPS/style.css (39-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'large'], OPS/style.css (90-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'large'], OPS/style.css (99-9)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'large'], OPS/cssStyles.css (27-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'large'], OPS/cssStyles.css (35-9)</message>
+         <message severity="info" id="CSS-013">CSS-013, HINT, [CSS property is declared !Important.], OPS/style.css (79-5)</message>
+         <message severity="info" id="CSS-013">CSS-013, HINT, [CSS property is declared !Important.], OPS/cssStyles.css (15-5)</message>
+         <message severity="info" id="CSS-013">CSS-013, HINT, [CSS property is declared !Important.], OPS/style_tag_css.xhtml (9-13)</message>
+         <message severity="info" id="CSS-023">CSS-023, HINT, [CSS selector specifies media query.], OPS/style.css (97-1)</message>
+         <message severity="info" id="CSS-023">CSS-023, HINT, [CSS selector specifies media query.], OPS/cssStyles.css (33-1)</message>
+         <message severity="info" id="CSS-023">CSS-023, HINT, [CSS selector specifies media query.], OPS/style_tag_css.xhtml (20-9)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '22px'], OPS/unused.css (14-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '11px'], OPS/unused.css (51-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: '10px'], OPS/unused.css (58-5)</message>
+         <message severity="info" id="CSS-025">CSS-025, HINT, [CSS class Selector could not be found.], OPS/style_tag_css.xhtml (54-24)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style_tag_css.xhtml (14-9)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (6-1)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (10-1)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (14-1)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (18-1)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (22-1)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (30-1)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (34-1)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (38-1)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (42-1)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (46-1)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (82-1)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/style.css (98-5)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (1-1)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (30-1)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (36-1)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (49-1)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (56-1)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (62-1)</message>
+         <message severity="info" id="CSS-024">CSS-024, HINT, [CSS class Selector is not used.], OPS/unused.css (66-3)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (10-54)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (11-97)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (14-50)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], OPS/inline_css.xhtml (15-41)</message>
       </messages>
       <mimeType>application/epub+zip</mimeType>
       <properties>

--- a/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font-family-no-src_expected_results.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+<jhove xmlns="http://schema.openpreservation.org/ois/xml/ns/jhove"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        date="2019-02-05"
        name="epubcheck"
        release="4.2.0-beta-SNAPSHOT"
-       xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove http://hul.harvard.edu/ois/xml/xsd/jhove/jhove.xsd">
+       xsi:schemaLocation="http://schema.openpreservation.org/ois/xml/ns/jhove https://schema.openpreservation.org/ois/xml/xsd/jhove/jhove.xsd">
    <date>2019-02-05T15:52:56+01:00</date>
    <repInfo uri="/Users/Romain/Work/epubcheck/epubcheck/target/test-classes/com/adobe/epubcheck/test/css/font-family-no-src.epub">
       <created>2019-02-05T15:38:16Z</created>
@@ -13,25 +13,25 @@
       <version>3.0.1</version>
       <status>Not well-formed</status>
       <messages>
-         <message severity="error" subMessage="RSC-007">RSC-007, ERROR, [Referenced resource 'OPS/fonts/bloody.woff' could not be found in the EPUB.], OPS/style_tag_css.xhtml (9-13)</message>
-         <message severity="error" subMessage="RSC-007">RSC-007, ERROR, [Referenced resource 'OPS/fonts/badaboom.woff' could not be found in the EPUB.], OPS/style_tag_css.xhtml (14-13)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/style_tag_css.xhtml (8-13)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/style_tag_css.xhtml (9-13)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/style_tag_css.xhtml (13-13)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/style_tag_css.xhtml (14-13)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/styles/style.css (2-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/styles/style.css (6-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/styles/style.css (10-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/styles/style.css (14-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/styles/style.css (18-5)</message>
-         <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS/toc.xhtml</message>
-         <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'xx-large'], OPS/styles/style.css (26-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'xx-large'], OPS/styles/style.css (32-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'xx-large'], OPS/styles/style.css (38-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'xx-large'], OPS/styles/style.css (44-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'xx-large'], OPS/styles/style.css (50-5)</message>
-         <message severity="info" subMessage="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'xx-large'], OPS/styles/style.css (56-5)</message>
+         <message severity="error" id="RSC-007">RSC-007, ERROR, [Referenced resource 'OPS/fonts/bloody.woff' could not be found in the EPUB.], OPS/style_tag_css.xhtml (9-13)</message>
+         <message severity="error" id="RSC-007">RSC-007, ERROR, [Referenced resource 'OPS/fonts/badaboom.woff' could not be found in the EPUB.], OPS/style_tag_css.xhtml (14-13)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/style_tag_css.xhtml (8-13)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/style_tag_css.xhtml (9-13)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/style_tag_css.xhtml (13-13)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/style_tag_css.xhtml (14-13)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/styles/style.css (2-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/styles/style.css (6-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/styles/style.css (10-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/styles/style.css (14-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], OPS/styles/style.css (18-5)</message>
+         <message severity="info" id="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS/toc.xhtml</message>
+         <message severity="info" id="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'xx-large'], OPS/styles/style.css (26-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'xx-large'], OPS/styles/style.css (32-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'xx-large'], OPS/styles/style.css (38-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'xx-large'], OPS/styles/style.css (44-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'xx-large'], OPS/styles/style.css (50-5)</message>
+         <message severity="info" id="ACC-014">ACC-014, HINT, [Value of CSS property 'font-size' does not use a relative size: 'xx-large'], OPS/styles/style.css (56-5)</message>
       </messages>
       <mimeType>application/epub+zip</mimeType>
       <properties>

--- a/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/css/font_encryption_idpf_expected_results.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+<jhove xmlns="http://schema.openpreservation.org/ois/xml/ns/jhove"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        date="2019-03-13"
        name="epubcheck"
        release="4.2.0-rc-SNAPSHOT"
-       xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove http://hul.harvard.edu/ois/xml/xsd/jhove/jhove.xsd">
+       xsi:schemaLocation="http://schema.openpreservation.org/ois/xml/ns/jhove https://schema.openpreservation.org/ois/xml/xsd/jhove/jhove.xsd">
    <date>2019-03-16T02:28:44+01:00</date>
    <repInfo uri="/Users/Romain/Work/epubcheck/epubcheck/target/test-classes/com/adobe/epubcheck/test/css/font_encryption_idpf.epub">
       <created>2019-03-16T02:26:38Z</created>
@@ -13,60 +13,60 @@
       <version>3.2</version>
       <status>Well-formed</status>
       <messages>
-         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (19-119)</message>
-         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (20-117)</message>
-         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (21-113)</message>
-         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (31-116)</message>
-         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (32-114)</message>
-         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (33-110)</message>
-         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (23-121)</message>
-         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (24-119)</message>
-         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (25-115)</message>
-         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (27-125)</message>
-         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (28-123)</message>
-         <message severity="info" subMessage="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (29-119)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (2-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (3-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (4-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (5-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (9-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (10-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (11-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (12-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (16-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (17-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (18-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (19-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (23-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (24-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (25-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (26-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (30-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (31-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (32-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (33-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (37-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (38-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (39-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (40-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (43-5)</message>
-         <message severity="info" subMessage="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], There are 23 additional locations for this message.</message>
-         <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], Css-fontface/pages/toc.xhtml</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (11-51)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (15-52)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (19-55)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (23-56)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (33-44)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (11-68)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (15-69)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (19-72)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (23-73)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (35-61)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (11-69)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (15-70)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (19-73)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (23-74)</message>
-         <message severity="info" subMessage="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (35-62)</message>
+         <message severity="info" id="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (19-119)</message>
+         <message severity="info" id="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (20-117)</message>
+         <message severity="info" id="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (21-113)</message>
+         <message severity="info" id="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (31-116)</message>
+         <message severity="info" id="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (32-114)</message>
+         <message severity="info" id="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/woff' instead of 'application/font-woff'.  ], Css-fontface/package.opf (33-110)</message>
+         <message severity="info" id="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (23-121)</message>
+         <message severity="info" id="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (24-119)</message>
+         <message severity="info" id="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (25-115)</message>
+         <message severity="info" id="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (27-125)</message>
+         <message severity="info" id="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (28-123)</message>
+         <message severity="info" id="OPF-090">OPF-090, HINT, [It is encouraged to use MIME media type 'font/otf' instead of 'application/vnd.ms-opentype'.  ], Css-fontface/package.opf (29-119)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (2-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (3-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (4-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (5-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (9-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (10-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (11-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (12-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (16-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (17-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (18-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (19-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (23-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (24-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (25-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (26-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (30-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (31-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (32-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (33-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (37-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (38-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (39-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (40-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], Css-fontface/css/fonts.css (43-5)</message>
+         <message severity="info" id="CSS-028">CSS-028, HINT, [Use of Font-face declaration.], There are 23 additional locations for this message.</message>
+         <message severity="info" id="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], Css-fontface/pages/toc.xhtml</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (11-51)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (15-52)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (19-55)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (23-56)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg1.xhtml (33-44)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (11-68)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (15-69)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (19-72)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (23-73)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg2.xhtml (35-61)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (11-69)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (15-70)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (19-73)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (23-74)</message>
+         <message severity="info" id="ACC-013">ACC-013, HINT, [Content file contains at least one inline style declaration.], Css-fontface/pages/pg3.xhtml (35-62)</message>
       </messages>
       <mimeType>application/epub+zip</mimeType>
       <properties>

--- a/src/test/resources/com/adobe/epubcheck/test/encryption/epub20_encryption_binary_content.epub_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/encryption/epub20_encryption_binary_content.epub_expected_results.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+<jhove xmlns="http://schema.openpreservation.org/ois/xml/ns/jhove"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  date="2019-01-20"
  name="epubcheck"
  release="4.1.1-SNAPSHOT"
- xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove http://hul.harvard.edu/ois/xml/xsd/jhove/jhove.xsd">
+ xsi:schemaLocation="http://schema.openpreservation.org/ois/xml/ns/jhove https://schema.openpreservation.org/ois/xml/xsd/jhove/jhove.xsd">
  <date>2019-01-21T09:52:50+01:00</date>
  <repInfo uri="./test-classes/com/adobe/epubcheck/test/encryption/epub20_encryption_binary_content.epub">
   <created>2015-06-02T16:34:06Z</created>
@@ -12,12 +12,12 @@
   <version>2.0.1</version>
   <status>Not well-formed</status>
   <messages>
-   <message severity="error" subMessage="RSC-004">RSC-004, ERROR, [File 'OEBPS/Text/pdfMigration.html' could not be decrypted.], epub20_encryption_binary_content.epub</message>
-   <message severity="error" subMessage="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (24-67)</message>
-   <message severity="error" subMessage="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (30-82)</message>
-   <message severity="error" subMessage="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (36-81)</message>
-   <message severity="error" subMessage="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (42-75)</message>
-   <message severity="error" subMessage="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (48-61)</message>
+   <message severity="error" id="RSC-004">RSC-004, ERROR, [File 'OEBPS/Text/pdfMigration.html' could not be decrypted.], epub20_encryption_binary_content.epub</message>
+   <message severity="error" id="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (24-67)</message>
+   <message severity="error" id="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (30-82)</message>
+   <message severity="error" id="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (36-81)</message>
+   <message severity="error" id="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (42-75)</message>
+   <message severity="error" id="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (48-61)</message>
   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>

--- a/src/test/resources/com/adobe/epubcheck/test/encryption/epub20_minimal_encryption.epub_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/encryption/epub20_minimal_encryption.epub_expected_results.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+<jhove xmlns="http://schema.openpreservation.org/ois/xml/ns/jhove"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        date="2017-01-02"
        name="epubcheck"
        release="4.0.3-SNAPSHOT"
-       xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove http://hul.harvard.edu/ois/xml/xsd/jhove/jhove.xsd">
+       xsi:schemaLocation="http://schema.openpreservation.org/ois/xml/ns/jhove https://schema.openpreservation.org/ois/xml/xsd/jhove/jhove.xsd">
  <date>2017-01-02T18:40:30+01:00</date>
  <repInfo uri="./com/adobe/epubcheck/test/encryption/epub20_minimal_encryption.epub">
   <created>2015-03-03T17:12:58Z</created>
@@ -12,12 +12,12 @@
   <version>2.0.1</version>
   <status>Not well-formed</status>
   <messages>
-   <message severity="error" subMessage="RSC-004">RSC-004, ERROR, [File 'OEBPS/Text/pdfMigration.html' could not be decrypted.], epub20_minimal_encryption.epub</message>
-   <message severity="error" subMessage="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (24-67)</message>
-   <message severity="error" subMessage="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (30-82)</message>
-   <message severity="error" subMessage="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (36-81)</message>
-   <message severity="error" subMessage="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (42-75)</message>
-   <message severity="error" subMessage="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (48-61)</message>
+   <message severity="error" id="RSC-004">RSC-004, ERROR, [File 'OEBPS/Text/pdfMigration.html' could not be decrypted.], epub20_minimal_encryption.epub</message>
+   <message severity="error" id="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (24-67)</message>
+   <message severity="error" id="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (30-82)</message>
+   <message severity="error" id="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (36-81)</message>
+   <message severity="error" id="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (42-75)</message>
+   <message severity="error" id="RSC-012">RSC-012, ERROR, [Fragment identifier is not defined.], OEBPS/toc.ncx (48-61)</message>
   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>

--- a/src/test/resources/com/adobe/epubcheck/test/encryption/epub30_font_obfuscation.epub_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/encryption/epub30_font_obfuscation.epub_expected_results.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+<jhove xmlns="http://schema.openpreservation.org/ois/xml/ns/jhove"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        date="2017-01-02"
        name="epubcheck"
        release="4.0.3-SNAPSHOT"
-       xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove http://hul.harvard.edu/ois/xml/xsd/jhove/jhove.xsd">
+       xsi:schemaLocation="http://schema.openpreservation.org/ois/xml/ns/jhove https://schema.openpreservation.org/ois/xml/xsd/jhove/jhove.xsd">
  <date>2017-01-02T18:40:30+01:00</date>
  <repInfo uri="./com/adobe/epubcheck/test/encryption/epub30_font_obfuscation.epub">
   <created>2012-01-08T21:51:18Z</created>

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Epub2_marked_v3_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Epub2_marked_v3_expected_results.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+<jhove xmlns="http://schema.openpreservation.org/ois/xml/ns/jhove"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        date="2019-02-05"
        name="epubcheck"
        release="4.2.0-beta-SNAPSHOT"
-       xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove http://hul.harvard.edu/ois/xml/xsd/jhove/jhove.xsd">
+       xsi:schemaLocation="http://schema.openpreservation.org/ois/xml/ns/jhove https://schema.openpreservation.org/ois/xml/xsd/jhove/jhove.xsd">
    <date>2019-02-05T22:24:42+01:00</date>
    <repInfo uri="/Users/Romain/Work/epubcheck/epubcheck/target/test-classes/com/adobe/epubcheck/test/opf/Epub2_marked_v3.epub">
       <created>2019-02-05T15:38:16Z</created>
@@ -12,10 +12,10 @@
       <version>3.0.1</version>
       <status>Not well-formed</status>
       <messages>
-         <message severity="error" subMessage="RSC-005">RSC-005, ERROR, [Error while parsing file: package dcterms:modified meta element must occur exactly once], OPS/content.opf (3-57)</message>
-         <message severity="error" subMessage="RSC-005">RSC-005, ERROR, [Error while parsing file: Exactly one manifest item must declare the 'nav' property (number of 'nav' items: 0).], OPS/content.opf (8-13)</message>
-         <message severity="error" subMessage="HTM-004">HTM-004, ERROR, [Irregular DOCTYPE: found '-//W3C//DTD XHTML 1.1//EN', expected '&lt;!DOCTYPE html&gt;'.], OPS/page01.xhtml</message>
-         <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
+         <message severity="error" id="RSC-005">RSC-005, ERROR, [Error while parsing file: package dcterms:modified meta element must occur exactly once], OPS/content.opf (3-57)</message>
+         <message severity="error" id="RSC-005">RSC-005, ERROR, [Error while parsing file: Exactly one manifest item must declare the 'nav' property (number of 'nav' items: 0).], OPS/content.opf (8-13)</message>
+         <message severity="error" id="HTM-004">HTM-004, ERROR, [Irregular DOCTYPE: found '-//W3C//DTD XHTML 1.1//EN', expected '&lt;!DOCTYPE html&gt;'.], OPS/page01.xhtml</message>
+         <message severity="info" id="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
       </messages>
       <mimeType>application/epub+zip</mimeType>
       <properties>

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Epub3_marked_v2_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Epub3_marked_v2_expected_results.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+<jhove xmlns="http://schema.openpreservation.org/ois/xml/ns/jhove"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        date="2017-01-02"
        name="epubcheck"
        release="4.0.3-SNAPSHOT"
-       xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove http://hul.harvard.edu/ois/xml/xsd/jhove/jhove.xsd">
+       xsi:schemaLocation="http://schema.openpreservation.org/ois/xml/ns/jhove https://schema.openpreservation.org/ois/xml/xsd/jhove/jhove.xsd">
  <date>2017-01-02T18:40:31+01:00</date>
  <repInfo uri="/Users/tofi/dev/epubcheck/target/test-classes/com/adobe/epubcheck/test/opf/Epub3_marked_v2.epub">
   <created>2017-01-02T18:34:14Z</created>
@@ -13,16 +13,16 @@
   <version>2.0.1</version>
   <status>Not well-formed</status>
   <messages>
-   <message severity="error" subMessage="RSC-005">RSC-005, ERROR, [Error while parsing file: attribute "property" not allowed here; expected attribute "content", "id", "name", "scheme" or "xml:lang"], OPS/content.opf (7-39)</message>
-   <message severity="error" subMessage="RSC-005">RSC-005, ERROR, [Error while parsing file: element "meta" missing required attributes "content" and "name"], OPS/content.opf (7-39)</message>
-   <message severity="error" subMessage="RSC-005">RSC-005, ERROR, [Error while parsing file: text not allowed here; expected the element end-tag], OPS/content.opf (7-61)</message>
-   <message severity="error" subMessage="RSC-005">RSC-005, ERROR, [Error while parsing file: attribute "properties" not allowed here; expected attribute "fallback", "fallback-style", "href", "media-type", "required-modules" or "required-namespace"], OPS/content.opf (12-90)</message>
-   <message severity="error" subMessage="HTM-004">HTM-004, ERROR, [Irregular DOCTYPE: found '', expected '&lt;!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" 
+   <message severity="error" id="RSC-005">RSC-005, ERROR, [Error while parsing file: attribute "property" not allowed here; expected attribute "content", "id", "name", "scheme" or "xml:lang"], OPS/content.opf (7-39)</message>
+   <message severity="error" id="RSC-005">RSC-005, ERROR, [Error while parsing file: element "meta" missing required attributes "content" and "name"], OPS/content.opf (7-39)</message>
+   <message severity="error" id="RSC-005">RSC-005, ERROR, [Error while parsing file: text not allowed here; expected the element end-tag], OPS/content.opf (7-61)</message>
+   <message severity="error" id="RSC-005">RSC-005, ERROR, [Error while parsing file: attribute "properties" not allowed here; expected attribute "fallback", "fallback-style", "href", "media-type", "required-modules" or "required-namespace"], OPS/content.opf (12-90)</message>
+   <message severity="error" id="HTM-004">HTM-004, ERROR, [Irregular DOCTYPE: found '', expected '&lt;!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" 
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"&gt;'.], OPS/toc.xhtml</message>
-   <message severity="error" subMessage="RSC-005">RSC-005, ERROR, [Error while parsing file: element "nav" not allowed anywhere; expected element "address", "blockquote", "del", "div", "dl", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "ins", "noscript", "ns:svg", "ol", "p", "pre", "script", "table" or "ul" (with xmlns:ns="http://www.w3.org/2000/svg")], OPS/toc.xhtml (9-22)</message>
-   <message severity="error" subMessage="RSC-005">RSC-005, ERROR, [Error while parsing file: element "nav" not allowed anywhere; expected element "address", "blockquote", "del", "div", "dl", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "ins", "noscript", "ns:svg", "ol", "p", "pre", "script", "table" or "ul" (with xmlns:ns="http://www.w3.org/2000/svg")], OPS/toc.xhtml (12-10)</message>
-   <message severity="error" subMessage="RSC-005">RSC-005, ERROR, [Error while parsing file: element "body" incomplete; expected element "address", "blockquote", "del", "div", "dl", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "ins", "noscript", "ns:svg", "ol", "p", "pre", "script", "table" or "ul" (with xmlns:ns="http://www.w3.org/2000/svg")], OPS/toc.xhtml (14-8)</message>
-   <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
+   <message severity="error" id="RSC-005">RSC-005, ERROR, [Error while parsing file: element "nav" not allowed anywhere; expected element "address", "blockquote", "del", "div", "dl", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "ins", "noscript", "ns:svg", "ol", "p", "pre", "script", "table" or "ul" (with xmlns:ns="http://www.w3.org/2000/svg")], OPS/toc.xhtml (9-22)</message>
+   <message severity="error" id="RSC-005">RSC-005, ERROR, [Error while parsing file: element "nav" not allowed anywhere; expected element "address", "blockquote", "del", "div", "dl", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "ins", "noscript", "ns:svg", "ol", "p", "pre", "script", "table" or "ul" (with xmlns:ns="http://www.w3.org/2000/svg")], OPS/toc.xhtml (12-10)</message>
+   <message severity="error" id="RSC-005">RSC-005, ERROR, [Error while parsing file: element "body" incomplete; expected element "address", "blockquote", "del", "div", "dl", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "ins", "noscript", "ns:svg", "ol", "p", "pre", "script", "table" or "ul" (with xmlns:ns="http://www.w3.org/2000/svg")], OPS/toc.xhtml (14-8)</message>
+   <message severity="info" id="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Missing_Spine_epub3_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Missing_Spine_epub3_expected_results.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+<jhove xmlns="http://schema.openpreservation.org/ois/xml/ns/jhove"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        date="2019-02-05"
        name="epubcheck"
        release="4.2.0-beta-SNAPSHOT"
-       xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove http://hul.harvard.edu/ois/xml/xsd/jhove/jhove.xsd">
+       xsi:schemaLocation="http://schema.openpreservation.org/ois/xml/ns/jhove https://schema.openpreservation.org/ois/xml/xsd/jhove/jhove.xsd">
    <date>2019-02-05T22:24:42+01:00</date>
    <repInfo uri="/Users/Romain/Work/epubcheck/epubcheck/target/test-classes/com/adobe/epubcheck/test/opf/Missing_Spine_epub3.epub">
       <created>2019-02-05T15:38:16Z</created>
@@ -13,10 +13,10 @@
       <version>3.0.1</version>
       <status>Not well-formed</status>
       <messages>
-         <message severity="error" subMessage="OPF-019">OPF-019, FATAL, [Spine tag was not found in the OPF file.], OPS/content.opf</message>
-         <message severity="error" subMessage="RSC-005">RSC-005, ERROR, [Error while parsing file: element "package" incomplete; missing required element "spine"], OPS/content.opf (13-11)</message>
-         <message severity="error" subMessage="RSC-011">RSC-011, ERROR, [Found a reference to a resource that is not a spine item.], OPS/toc.xhtml (11-36)</message>
-         <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS/toc.xhtml</message>
+         <message severity="error" id="OPF-019">OPF-019, FATAL, [Spine tag was not found in the OPF file.], OPS/content.opf</message>
+         <message severity="error" id="RSC-005">RSC-005, ERROR, [Error while parsing file: element "package" incomplete; missing required element "spine"], OPS/content.opf (13-11)</message>
+         <message severity="error" id="RSC-011">RSC-011, ERROR, [Found a reference to a resource that is not a spine item.], OPS/toc.xhtml (11-36)</message>
+         <message severity="info" id="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS/toc.xhtml</message>
       </messages>
       <mimeType>application/epub+zip</mimeType>
       <properties>

--- a/src/test/resources/com/adobe/epubcheck/test/opf/Publication_Metadata_epub3_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/opf/Publication_Metadata_epub3_expected_results.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+<jhove xmlns="http://schema.openpreservation.org/ois/xml/ns/jhove"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        date="2019-02-05"
        name="epubcheck"
        release="4.2.0-beta-SNAPSHOT"
-       xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove http://hul.harvard.edu/ois/xml/xsd/jhove/jhove.xsd">
+       xsi:schemaLocation="http://schema.openpreservation.org/ois/xml/ns/jhove https://schema.openpreservation.org/ois/xml/xsd/jhove/jhove.xsd">
    <date>2019-02-05T22:24:45+01:00</date>
    <repInfo uri="/Users/Romain/Work/epubcheck/epubcheck/target/test-classes/com/adobe/epubcheck/test/opf/Publication_Metadata_epub3.epub">
       <created>2019-02-05T15:38:16Z</created>
@@ -13,8 +13,8 @@
       <version>3.0.1</version>
       <status>Well-formed</status>
       <messages>
-         <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS/toc.xhtml</message>
-         <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
+         <message severity="info" id="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS/toc.xhtml</message>
+         <message severity="info" id="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS/toc.ncx (2-68)</message>
       </messages>
       <mimeType>application/epub+zip</mimeType>
       <properties>

--- a/src/test/resources/com/adobe/epubcheck/test/package/interesting_paths_epub2_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/package/interesting_paths_epub2_expected_results.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+<jhove xmlns="http://schema.openpreservation.org/ois/xml/ns/jhove"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        date="2017-01-02"
        name="epubcheck"
        release="4.0.3-SNAPSHOT"
-       xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove http://hul.harvard.edu/ois/xml/xsd/jhove/jhove.xsd">
+       xsi:schemaLocation="http://schema.openpreservation.org/ois/xml/ns/jhove https://schema.openpreservation.org/ois/xml/xsd/jhove/jhove.xsd">
   <date>2017-01-02T18:40:35+01:00</date>
   <repInfo uri="/Users/tofi/dev/epubcheck/target/test-classes/com/adobe/epubcheck/test/package/interesting_paths_epub2.epub">
   <created>2017-01-02T18:34:16Z</created>
@@ -12,11 +12,11 @@
   <version>2.0.1</version>
   <status>Well-formed</status>
   <messages>
-    <message severity="error" subMessage="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/More XHTML Content/page01.xhtml</message>
-    <message severity="error" subMessage="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/content.opf</message>
-    <message severity="error" subMessage="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/toc.ncx</message>
-    <message severity="error" subMessage="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], XHTML Content/page02.xhtml</message>
-    <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS Content/toc.ncx (2-68)</message>
+    <message severity="warning" id="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/More XHTML Content/page01.xhtml</message>
+    <message severity="warning" id="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/content.opf</message>
+    <message severity="warning" id="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/toc.ncx</message>
+    <message severity="warning" id="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], XHTML Content/page02.xhtml</message>
+    <message severity="info" id="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS Content/toc.ncx (2-68)</message>
   </messages>
   <mimeType>application/epub+zip</mimeType>
   <properties>

--- a/src/test/resources/com/adobe/epubcheck/test/package/interesting_paths_epub3_expected_results.xml
+++ b/src/test/resources/com/adobe/epubcheck/test/package/interesting_paths_epub3_expected_results.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jhove xmlns="http://hul.harvard.edu/ois/xml/ns/jhove"
+<jhove xmlns="http://schema.openpreservation.org/ois/xml/ns/jhove"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        date="2019-02-05"
        name="epubcheck"
        release="4.2.0-beta-SNAPSHOT"
-       xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/jhove http://hul.harvard.edu/ois/xml/xsd/jhove/jhove.xsd">
+       xsi:schemaLocation="http://schema.openpreservation.org/ois/xml/ns/jhove https://schema.openpreservation.org/ois/xml/xsd/jhove/jhove.xsd">
    <date>2019-02-05T15:52:54+01:00</date>
    <repInfo uri="/Users/Romain/Work/epubcheck/epubcheck/target/test-classes/com/adobe/epubcheck/test/package/interesting_paths_epub3.epub">
       <created>2019-02-05T15:38:16Z</created>
@@ -13,20 +13,20 @@
       <version>3.0.1</version>
       <status>Not well-formed</status>
       <messages>
-         <message severity="error" subMessage="RSC-001">RSC-001, ERROR, [File 'OPS Content/style.' could not be found.], interesting_paths_epub3.epub</message>
-         <message severity="error" subMessage="RSC-007">RSC-007, ERROR, [Referenced resource 'style.' could not be found in the EPUB.], OPS Content/Cyrillic_Ф.xhtml (6-62)</message>
-         <message severity="error" subMessage="RSC-007">RSC-007, ERROR, [Referenced resource '../XHTML Content/page 02.xhtml' could not be found in the EPUB.], OPS Content/Cyrillic_Ф.xhtml (13-53)</message>
-         <message severity="error" subMessage="PKG-009">PKG-009, ERROR, [File name contains characters that are not allowed in OCF file names: '"{","}"'.], OPS Content/page{03}.xhtml</message>
-         <message severity="error" subMessage="PKG-012">PKG-012, WARN, [File name contains the following non-ascii characters: Ф. Consider changing the filename.], OPS Content/Cyrillic_Ф.xhtml</message>
-         <message severity="error" subMessage="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/Cyrillic_Ф.xhtml</message>
-         <message severity="error" subMessage="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/More XHTML Content/page01.xhtml</message>
-         <message severity="error" subMessage="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/content.opf</message>
-         <message severity="error" subMessage="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/page{03}.xhtml</message>
-         <message severity="error" subMessage="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/toc.ncx</message>
-         <message severity="error" subMessage="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/toc.xhtml</message>
-         <message severity="error" subMessage="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], XHTML Content/page 02.xhtml</message>
-         <message severity="info" subMessage="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS Content/toc.xhtml</message>
-         <message severity="info" subMessage="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS Content/toc.ncx (2-68)</message>
+         <message severity="error" id="RSC-001">RSC-001, ERROR, [File 'OPS Content/style.' could not be found.], interesting_paths_epub3.epub</message>
+         <message severity="error" id="RSC-007">RSC-007, ERROR, [Referenced resource 'style.' could not be found in the EPUB.], OPS Content/Cyrillic_Ф.xhtml (6-62)</message>
+         <message severity="error" id="RSC-007">RSC-007, ERROR, [Referenced resource '../XHTML Content/page 02.xhtml' could not be found in the EPUB.], OPS Content/Cyrillic_Ф.xhtml (13-53)</message>
+         <message severity="error" id="PKG-009">PKG-009, ERROR, [File name contains characters that are not allowed in OCF file names: '"{","}"'.], OPS Content/page{03}.xhtml</message>
+         <message severity="warning" id="PKG-012">PKG-012, WARN, [File name contains the following non-ascii characters: Ф. Consider changing the filename.], OPS Content/Cyrillic_Ф.xhtml</message>
+         <message severity="warning" id="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/Cyrillic_Ф.xhtml</message>
+         <message severity="warning" id="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/More XHTML Content/page01.xhtml</message>
+         <message severity="warning" id="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/content.opf</message>
+         <message severity="warning" id="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/page{03}.xhtml</message>
+         <message severity="warning" id="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/toc.ncx</message>
+         <message severity="warning" id="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], OPS Content/toc.xhtml</message>
+         <message severity="warning" id="PKG-010">PKG-010, WARN, [Filename contains spaces, therefore URI escaping is necessary. Consider removing spaces from filename.], XHTML Content/page 02.xhtml</message>
+         <message severity="info" id="ACC-008">ACC-008, HINT, [Navigation Document has no 'landmarks nav' element.], OPS Content/toc.xhtml</message>
+         <message severity="info" id="HTM-010">HTM-010, HINT, [Namespace uri 'http://www.daisy.org/z3986/2005/ncx/' was found.], OPS Content/toc.ncx (2-68)</message>
       </messages>
       <mimeType>application/epub+zip</mimeType>
       <properties>


### PR DESCRIPTION
In order to fix the issue #789, the new jhove schema is implemented.

Indeed, this new schema has been published and includes an 'id' attribute as well as a 'warning' level. So the alignment between the severity attribute and the level is now straightforward.

EpubCheck level | severity attribute
----------------| ------------------
fatal error     | error
error           | error
warn            | warning
hint            | info