### PR TITLE
Avoid usage of BufferedImage to avoid OutOfMemoryError

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -1,0 +1,3 @@
+@Library('cmh-pipeline-shared-library') _
+
+commonPipeline([runIt: false, customVersionIncrement: true, openJdk: true])

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     </developers>
 
     <properties>
-        <java.version>1.7</java.version>
+        <java.version>8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,9 @@
         <version>7</version>
     </parent>
 
-    <groupId>org.w3c</groupId>
+    <groupId>com.wiley</groupId>
     <artifactId>epubcheck</artifactId>
-    <version>4.2.3-SNAPSHOT</version>
+    <version>4.2.3</version>
 
     <packaging>jar</packaging>
 
@@ -126,29 +126,6 @@
             <email>skoji@mac.com</email>
         </developer>
     </developers>
-    <mailingLists>
-        <mailingList>
-            <name>EPUBCheck discussion</name>
-            <subscribe>mailto:public-epubcheck-request@w3.org?subject=subscribe</subscribe>
-            <unsubscribe>mailto:public-epubcheck-request@w3.org?subject=unsubscribe</unsubscribe>
-            <post>public-epubcheck@w3.org</post>
-            <archive>https://lists.w3.org/Archives/Public/public-epubcheck/</archive>
-        </mailingList>
-        <mailingList>
-            <name>ARCHIVE: epubcheck discussion</name>
-            <archive>https://groups.google.com/forum/#!forum/epubcheck</archive>
-        </mailingList>
-    </mailingLists>
-    <scm>
-        <connection>scm:git:ssh://git@github.com:w3c/epubcheck.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com:w3c/epubcheckgit</developerConnection>
-        <url>https://github.com/w3c/epubcheck</url>
-        <tag>HEAD</tag>
-    </scm>
-    <issueManagement>
-        <system>Github</system>
-        <url>https://github.com/w3c/epubcheck/issues</url>
-    </issueManagement>
 
     <properties>
         <java.version>1.7</java.version>
@@ -558,4 +535,38 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>wiley-releases</id>
+            <name>Wiley Releases</name>
+            <url>http://nexus.aws.wiley.com:8081/nexus/content/groups/public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <repositories>
+        <repository>
+            <id>wiley</id>
+            <url>http://nexus.aws.wiley.com:8081/nexus/content/groups/public/</url>
+        </repository>
+        <!-- For epublib-->
+        <repository>
+            <id>psiegman-repo</id>
+            <url>https://github.com/psiegman/mvn-repo/raw/master/releases</url>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>cmh</id>
+            <name>Wiley Releases</name>
+            <url>http://nexus.aws.wiley.com:8081/nexus/content/repositories/releases</url>
+        </repository>
+    </distributionManagement>
 </project>

--- a/src/main/java/com/adobe/epubcheck/bitmap/BitmapChecker.java
+++ b/src/main/java/com/adobe/epubcheck/bitmap/BitmapChecker.java
@@ -142,8 +142,7 @@ public class BitmapChecker implements ContentChecker
       if (formatFromSuffix != null && formatFromSuffix.equals(formatFromInputStream)) {
       // file format and file extension matches; read image file
       
-      try {
-        ImageInputStream stream = new FileImageInputStream(tempFile);
+      try (ImageInputStream stream = new FileImageInputStream(tempFile)) {
         reader.setInput(stream);
         int width = reader.getWidth(reader.getMinIndex());
         int height = reader.getHeight(reader.getMinIndex());

--- a/src/main/java/com/adobe/epubcheck/bitmap/BitmapChecker.java
+++ b/src/main/java/com/adobe/epubcheck/bitmap/BitmapChecker.java
@@ -22,7 +22,6 @@
 
 package com.adobe.epubcheck.bitmap;
 
-import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -31,6 +30,7 @@ import java.util.Iterator;
 
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
+import javax.imageio.stream.FileImageInputStream;
 import javax.imageio.stream.ImageInputStream;
 
 import com.adobe.epubcheck.api.EPUBLocation;
@@ -119,6 +119,7 @@ public class BitmapChecker implements ContentChecker
     tempFile = getImageFile(ocf, imgFileName);
     String formatFromInputStream = null;
     String formatFromSuffix = null;
+    ImageReader reader = null;
     ImageInputStream imageInputStream = ImageIO.createImageInputStream(tempFile);
     Iterator<ImageReader> imageReaderIteratorFromInputStream = ImageIO.getImageReaders(imageInputStream);
     while (imageReaderIteratorFromInputStream.hasNext()) {
@@ -127,7 +128,7 @@ public class BitmapChecker implements ContentChecker
         
       Iterator<ImageReader> imageReaderIteratorFromSuffix = ImageIO.getImageReadersBySuffix(suffix);
         while (imageReaderIteratorFromSuffix.hasNext()) {
-          ImageReader reader = imageReaderIteratorFromSuffix.next();
+          reader = imageReaderIteratorFromSuffix.next();
           formatFromSuffix = reader.getFormatName();
           
           if (formatFromSuffix != null && formatFromSuffix.equals(formatFromInputStream)) break;
@@ -142,16 +143,11 @@ public class BitmapChecker implements ContentChecker
       // file format and file extension matches; read image file
       
       try {
-        BufferedImage image = ImageIO.read(tempFile);
-        if (image == null) {
-          report.message(MessageId.PKG_021, EPUBLocation.create(imgFileName));
-          return null;
-          
-        } else {
-          int width          = image.getWidth();
-          int height         = image.getHeight();
-          return new ImageHeuristics(width, height, tempFile.length());
-        }
+        ImageInputStream stream = new FileImageInputStream(tempFile);
+        reader.setInput(stream);
+        int width = reader.getWidth(reader.getMinIndex());
+        int height = reader.getHeight(reader.getMinIndex());
+        return new ImageHeuristics(width, height, tempFile.length());
       }
       catch (IOException e)
       {


### PR DESCRIPTION
In some cases, 700KB .jpg can be about 8500x6000 pixels and BufferedImage consumes about 100MB.
So if you have a lot of such images you easily can get OOM. Do not sure why, but GC does not collect old BufferedImage during single validation.