### PR TITLE
Add an Automatic-Module-Name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,7 @@
                             net.sf.saxon.*;version="[9.8.0,9.8.1)",
                             *
                         </Import-Package>
+                        <Automatic-Module-Name>org.w3c.epubcheck</Automatic-Module-Name>
                         <_removeheaders>Include-Resource,Private-Package, Bnd-LastModified, Build-Jdk, Built-By</_removeheaders>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
This adds an Automatic-Module-Name manifest entry in order to allow
epubcheck to be used in a modular context without having to depend
on an unstable generated module name.

Fix: https://github.com/w3c/epubcheck/issues/1128