### PR TITLE
fix: improve reporting of invalid URL host parts

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -326,7 +326,7 @@ RSC_019=EPUBs with Multiple Renditions should contain a META-INF/metadata.xml fi
 RSC_020='%1$s' is not a valid URI.
 RSC_021=A Search Key Map Document must point to Content Documents ('%1$s' was not found in the spine).
 RSC_022=Cannot check image details (requires Java version 7 or higher).
-RSC_023=The URL '%1$s' is missing %2$d slash(es) '/' after the protocol '%3$s:'
+RSC_023=Couldn't parse host of URL '%1$s' (probably due to disallowed characters or missing slashes after the protocol)
 
 #Scripting
 SCP_001=Use of Javascript eval() function in EPUB scripts is a security risk.

--- a/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
@@ -230,7 +230,7 @@ public class OPSCheckerTest
   public void testValidateXHTMLUrlChecksInvalid()
   {
     Collections.addAll(expectedErrors, MessageId.RSC_020);
-    Collections.addAll(expectedWarnings, MessageId.HTM_025, MessageId.RSC_023, MessageId.RSC_023);
+    Collections.addAll(expectedWarnings, MessageId.HTM_025, MessageId.RSC_023, MessageId.RSC_023, MessageId.RSC_023);
     testValidateDocument("xhtml/invalid/url-checks_issue-708.xhtml", "application/xhtml+xml",
         EPUBVersion.VERSION_3);
   }

--- a/src/test/resources/30/single/xhtml/invalid/url-checks_issue-708.xhtml
+++ b/src/test/resources/30/single/xhtml/invalid/url-checks_issue-708.xhtml
@@ -11,7 +11,9 @@
 			<a href="httpf://www.youtube.com/watch?v=xxxxxxxxxxx">Unsupported URI scheme (HTM-025)</a>
 			<a href="https:/www.youtube.com/watch?v=xxxxxxxxxxx">URL is missing slashes after protocol (RSC-023)</a>
 			<a href="https:www.youtube.com/watch?v=xxxxxxxxxxx">URL is missing slashes after protocol (RSC-023)</a>
-
+			<a href="https://w,w.example.com/watch?v=xxxxxxxxxxx">Host contains an invalid character (RSC-023)</a>
+			
+			<a href="https://w_w.example.com">Underscore in hosts are accepted in most browsers</a>
 			<a href="https://www.youtube.com/watch?v=xxxxxxxxxxx">Valid URI</a>
 			<a href="https://youtube.com/watch?v=xxxxxxxxxxx">Valid URI</a>
 			<a href="https://youtube.com/watch?v=xxxxxx%20xxxx">Valid URI</a>


### PR DESCRIPTION
- fix #1034: make the message more genric ("Couldn't parse host…")
- fix #1079: don't report underscores used in the URL host part
- expand test `testValidateXHTMLUrlChecksInvalid`