### PR TITLE
fix: upgrade commons-compress to v1.20 to remediate CVE-2019-12402

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.18</version>
+            <version>1.20</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.tukaani</groupId>


### PR DESCRIPTION
CVE-2019-12402:

- Library: org.apache.commons:commons-compress
- Vulnerable versions: >= 1.15, < 1.19
- Patched version: 1.19

The file name encoding algorithm used internally in Apache Commons
Compress 1.15 to 1.18 can get into an infinite loop when faced with
specially crafted inputs. This can lead to a denial of service attack if
an attacker can choose the file names inside of an archive created by
Compress.

Fixes #1078