### PR TITLE
feat: report empty `title` elements in XHTML Content Documents

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/epub-xhtml-30.sch
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/epub-xhtml-30.sch
@@ -28,6 +28,13 @@
       </rule>
     </pattern>
     
+    <pattern id="title.non-empty">
+        <rule context="h:title">
+            <assert test="normalize-space(.)"
+                >Element "title" must not be empty.</assert>
+        </rule>
+    </pattern>
+    
     <pattern id="epub.switch.deprecated">
         <rule context="epub:switch">
             <report test="true()"

--- a/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/ops/OPSCheckerTest.java
@@ -1392,4 +1392,12 @@ public class OPSCheckerTest
         EPUBVersion.VERSION_3);
   }
 
+  @Test
+  public void testTitleEmpty()
+  {
+    Collections.addAll(expectedErrors, MessageId.RSC_005);
+    testValidateDocument("xhtml/invalid/title-empty.xhtml", "application/xhtml+xml",
+        EPUBVersion.VERSION_3);
+  }
+
 }

--- a/src/test/resources/30/single/xhtml/invalid/issue153.xhtml
+++ b/src/test/resources/30/single/xhtml/invalid/issue153.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title></title>
+        <title>Test</title>
     </head>
     <body>
         <math xmlns="http://www.w3.org/1998/Math/MathML">

--- a/src/test/resources/30/single/xhtml/invalid/title-empty.xhtml
+++ b/src/test/resources/30/single/xhtml/invalid/title-empty.xhtml
@@ -1,0 +1,10 @@
+<!DOCTYPE html>	 
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+  <head>
+    <title></title>
+    <meta charset="UTF-8"/>
+  </head>
+  <body>
+    <h1>Test</h1>
+  </body>
+</html>


### PR DESCRIPTION
Empty or whitespace-only `title` elements are disallowed in HTML:
  https://html.spec.whatwg.org/#the-title-element

Nu HTML Checker checks this with Java Code, so it’s not exposed in
EPUBCheck (which only uses the Checkr’s schemas).
This change re-implements the check in Schematron.

Fixes #1093