### PR TITLE
Add DPUB-ARIA role tests

### DIFF
--- a/src/test/resources/epub3/content-document-xhtml.feature
+++ b/src/test/resources/epub3/content-document-xhtml.feature
@@ -33,8 +33,44 @@ Feature: EPUB 3 XHTML Content Document
     And the message contains 'attribute "aria-describedat" not allowed here'
     And no other errors or warnings are reported
     
-  Scenario: Verify the `doc-endnote` role is allowed on list items
-    When checking document 'aria-role-doc-endnote-valid.xhtml'
+  Scenario: Verify the DPUB-ARIA roles allowed on `a`
+    When checking document 'aria-roles-img-valid.xhtml'
+    Then no errors or warnings are reported
+
+  Scenario: Verify the DPUB-ARIA roles allowed on `aside`
+    When checking document 'aria-roles-img-valid.xhtml'
+    Then no errors or warnings are reported
+
+  Scenario: Verify the DPUB-ARIA roles allowed on `footer`
+    When checking document 'aria-roles-footer-valid.xhtml'
+    Then no errors or warnings are reported
+
+  Scenario: Verify the DPUB-ARIA roles allowed on `h1`-'h6`
+    When checking document 'aria-roles-h1-h6-valid.xhtml'
+    Then no errors or warnings are reported
+
+  Scenario: Verify the DPUB-ARIA roles allowed on `header`
+    When checking document 'aria-roles-header-valid.xhtml'
+    Then no errors or warnings are reported
+
+  Scenario: Verify the DPUB-ARIA roles allowed on `hr`
+    When checking document 'aria-roles-header-valid.xhtml'
+    Then no errors or warnings are reported
+
+  Scenario: Verify the DPUB-ARIA roles allowed on `img`
+    When checking document 'aria-roles-img-valid.xhtml'
+    Then no errors or warnings are reported
+
+  Scenario: Verify the DPUB-ARIA roles allowed on `li`
+    When checking document 'aria-roles-li-valid.xhtml'
+    Then no errors or warnings are reported
+
+  Scenario: Verify the DPUB-ARIA roles allowed on `nav`
+    When checking document 'aria-roles-nav-valid.xhtml'
+    Then no errors or warnings are reported
+
+  Scenario: Verify the DPUB-ARIA roles allowed on `section`
+    When checking document 'aria-roles-section-valid.xhtml'
     Then no errors or warnings are reported
 
   Scenario: Verify ARIA attributes allowed on SVG elements

--- a/src/test/resources/epub3/files/content-document-xhtml/aria-roles-a-valid.xhtml
+++ b/src/test/resources/epub3/files/content-document-xhtml/aria-roles-a-valid.xhtml
@@ -1,0 +1,15 @@
+<!DOCTYPE html>	 
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>DPUB-ARIA roles allowed on a</title>
+	</head>
+	<body>
+		<a role="doc-backlink" href="#test">Back link</a>
+		<a role="doc-biblioref" href="#test">Bibliography reference</a>
+		<a role="doc-glossref" href="#test">Glossary reference</a>
+		<a role="doc-noteref" href="#test">Note reference</a>
+		
+		<p id="test">Test destination</p>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/content-document-xhtml/aria-roles-aside-valid.xhtml
+++ b/src/test/resources/epub3/files/content-document-xhtml/aria-roles-aside-valid.xhtml
@@ -1,0 +1,24 @@
+<!DOCTYPE html>	 
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>DPUB-ARIA roles allowed on aside</title>
+	</head>
+	<body>
+		<aside role="doc-dedication">
+			<p>Dedication</p>
+		</aside>
+		<aside role="doc-example">
+			<p>Example</p>
+		</aside>
+		<aside role="doc-footnote">
+			<p>Footnote</p>
+		</aside>
+		<aside role="doc-pullquote">
+			<p>Pull Quote</p>
+		</aside>
+		<aside role="doc-tip">
+			<p>Tip</p>
+		</aside>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/content-document-xhtml/aria-roles-footer-valid.xhtml
+++ b/src/test/resources/epub3/files/content-document-xhtml/aria-roles-footer-valid.xhtml
@@ -1,0 +1,12 @@
+<!DOCTYPE html>	 
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>DPUB-ARIA roles allowed on footer</title>
+	</head>
+	<body>
+		<footer role="doc-footnote">
+			<p>Footer footnote?</p>
+		</footer>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/content-document-xhtml/aria-roles-h1-h6-valid.xhtml
+++ b/src/test/resources/epub3/files/content-document-xhtml/aria-roles-h1-h6-valid.xhtml
@@ -1,0 +1,15 @@
+<!DOCTYPE html>	 
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>DPUB-ARIA roles allowed on h1 to h6</title>
+	</head>
+	<body>
+		<h1 role="doc-subtitle">H1 Subtitle</h1>
+		<h2 role="doc-subtitle">H2 Subtitle</h2>
+		<h3 role="doc-subtitle">H3 Subtitle</h3>
+		<h4 role="doc-subtitle">H4 Subtitle</h4>
+		<h5 role="doc-subtitle">H5 Subtitle</h5>
+		<h6 role="doc-subtitle">H6 Subtitle</h6>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/content-document-xhtml/aria-roles-header-valid.xhtml
+++ b/src/test/resources/epub3/files/content-document-xhtml/aria-roles-header-valid.xhtml
@@ -1,0 +1,12 @@
+<!DOCTYPE html>	 
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>DPUB-ARIA roles allowed on header</title>
+	</head>
+	<body>
+		<header role="doc-footnote">
+			<p>Header footnote?</p>
+		</header>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/content-document-xhtml/aria-roles-hr-valid.xhtml
+++ b/src/test/resources/epub3/files/content-document-xhtml/aria-roles-hr-valid.xhtml
@@ -1,0 +1,10 @@
+<!DOCTYPE html>	 
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>DPUB-ARIA roles allowed on hr</title>
+	</head>
+	<body>
+		<hr role="doc-pagebreak" aria-label="page 45" id="p45"/>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/content-document-xhtml/aria-roles-img-valid.xhtml
+++ b/src/test/resources/epub3/files/content-document-xhtml/aria-roles-img-valid.xhtml
@@ -1,0 +1,10 @@
+<!DOCTYPE html>	 
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>DPUB-ARIA roles allowed on img</title>
+	</head>
+	<body>
+		<img role="doc-cover" src="test.jpg" alt="okay"/>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/content-document-xhtml/aria-roles-li-valid.xhtml
+++ b/src/test/resources/epub3/files/content-document-xhtml/aria-roles-li-valid.xhtml
@@ -6,13 +6,13 @@
 	</head>
 	<body>
 		<h1>Test</h1>
-		<section>
+		<section role="doc-endnotes">
 			<h2>Notes</h2>
 			<ol>
 				<li role="doc-endnote">…</li>
 			</ol>
 		</section>
-		<section>
+		<section role="doc-bibliography">
 			<h2>Bibliography</h2>
 			<ul>
 				<li role="doc-biblioentry">…</li>

--- a/src/test/resources/epub3/files/content-document-xhtml/aria-roles-li-valid.xhtml
+++ b/src/test/resources/epub3/files/content-document-xhtml/aria-roles-li-valid.xhtml
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<title>Allow doc-endnote on list items</title>
+		<title>DPUB-ARIA roles allowed on li</title>
 	</head>
 	<body>
 		<h1>Test</h1>
@@ -13,9 +13,9 @@
 			</ol>
 		</section>
 		<section>
-			<h2>Notes</h2>
+			<h2>Bibliography</h2>
 			<ul>
-				<li role="doc-endnote">…</li>
+				<li role="doc-biblioentry">…</li>
 			</ul>
 		</section>
 	</body>

--- a/src/test/resources/epub3/files/content-document-xhtml/aria-roles-nav-valid.xhtml
+++ b/src/test/resources/epub3/files/content-document-xhtml/aria-roles-nav-valid.xhtml
@@ -1,0 +1,18 @@
+<!DOCTYPE html>	 
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>DPUB-ARIA roles allowed on nav</title>
+	</head>
+	<body>
+		<nav role="doc-index">
+			<h2>Index</h2>
+		</nav>
+		<nav role="doc-pagelist">
+			<h2>Page List</h2>
+		</nav>
+		<nav role="doc-toc">
+			<h2>Table of Contents</h2>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/content-document-xhtml/aria-roles-section-valid.xhtml
+++ b/src/test/resources/epub3/files/content-document-xhtml/aria-roles-section-valid.xhtml
@@ -1,0 +1,93 @@
+<!DOCTYPE html>	 
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>DPUB-ARIA roles allowed on section</title>
+	</head>
+	<body>
+		<section role="doc-abstract">
+			<p>doc-abstract</p>
+		</section>
+		<section role="doc-acknowledgments">
+			<p>doc-acknowledgments</p>
+		</section>
+		<section role="doc-afterword">
+			<p>doc-afterword</p>
+		</section>
+		<section role="doc-appendix">
+			<p>doc-appendix</p>
+		</section>
+		<section role="doc-bibliography">
+			<p>doc-bibliography</p>
+		</section>
+		<section role="doc-chapter">
+			<p>doc-chapter</p>
+		</section>
+		<section role="doc-colophon">
+			<p>doc-colophon</p>
+		</section>
+		<section role="doc-conclusion">
+			<p>doc-conclusion</p>
+		</section>
+		<section role="doc-credit">
+			<p>doc-credit</p>
+		</section>
+		<section role="doc-credits">
+			<p>doc-credits</p>
+		</section>
+		<section role="doc-dedication">
+			<p>doc-dedication</p>
+		</section>
+		<section role="doc-endnotes">
+			<p>doc-endnotes</p>
+		</section>
+		<section role="doc-epigraph">
+			<p>doc-epigraph</p>
+		</section>
+		<section role="doc-epilogue">
+			<p>doc-epilogue</p>
+		</section>
+		<section role="doc-errata">
+			<p>doc-errata</p>
+		</section>
+		<section role="doc-example">
+			<p>doc-example</p>
+		</section>
+		<section role="doc-foreword">
+			<p>doc-foreword</p>
+		</section>
+		<section role="doc-glossary">
+			<p>doc-glossary</p>
+		</section>
+		<section role="doc-index">
+			<p>doc-index</p>
+		</section>
+		<section role="doc-introduction">
+			<p>doc-introduction</p>
+		</section>
+		<section role="doc-notice">
+			<p>doc-notice</p>
+		</section>
+		<section role="doc-pagelist">
+			<p>doc-pagelist</p>
+		</section>
+		<section role="doc-part">
+			<p>doc-part</p>
+		</section>
+		<section role="doc-preface">
+			<p>doc-preface</p>
+		</section>
+		<section role="doc-prologue">
+			<p>doc-prologue</p>
+		</section>
+		<section role="doc-pullquote">
+			<p>doc-pullquote</p>
+		</section>
+		<section role="doc-qna">
+			<p>doc-qna</p>
+		</section>
+		<section role="doc-toc">
+			<p>doc-toc</p>
+		</section>
+	</body>
+</html>


### PR DESCRIPTION
Adds tests for each element in the ARIA in HTML doc that has a restricted set of allowed DPUB-ARIA roles.

Setting this up as a separate PR from #1112 as the test for doc-epigraph will fail until merged with the new code base.