### PR TITLE
Allow foreign namespaced elements and attributes in EPUB 2 SVGs

### DIFF
--- a/src/main/java/com/adobe/epubcheck/ops/OPSChecker.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSChecker.java
@@ -56,7 +56,7 @@ public class OPSChecker implements ContentChecker, DocumentValidator
       .putAll(Predicates.and(mimetype("application/xhtml+xml"), version(EPUBVersion.VERSION_3)),
           XMLValidators.XHTML_30_RNC, XMLValidators.XHTML_30_SCH)
       .putAll(Predicates.and(mimetype("image/svg+xml"), version(EPUBVersion.VERSION_2)),
-          XMLValidators.SVG_20_RNG, XMLValidators.IDUNIQUE_20_SCH)
+          XMLValidators.SVG_20_NVDL, XMLValidators.IDUNIQUE_20_SCH)
       .putAll(Predicates.and(mimetype("image/svg+xml"), version(EPUBVersion.VERSION_3)),
           XMLValidators.SVG_30_NVDL)
       .putAll(

--- a/src/main/java/com/adobe/epubcheck/xml/XMLValidators.java
+++ b/src/main/java/com/adobe/epubcheck/xml/XMLValidators.java
@@ -36,7 +36,7 @@ public enum XMLValidators
   SEARCH_KEY_MAP_RNC("schema/30/dict/search-key-map.rnc"),
   SIG_20_RNG("schema/20/rng/signatures.rng"),
   SIG_30_RNC("schema/30/ocf-signatures-30.rnc"),
-  SVG_20_RNG("schema/20/rng/svg11.rng"),
+  SVG_20_NVDL("schema/20/rng/ops20-svg.nvdl"),
   SVG_30_RNC("schema/30/epub-svg-30.rnc"),
   SVG_30_NVDL("schema/30/epub-svg-30.nvdl"),
   SVG_30_SCH("schema/30/epub-svg-30.sch"),

--- a/src/main/resources/com/adobe/epubcheck/schema/20/rng/ops20-svg.nvdl
+++ b/src/main/resources/com/adobe/epubcheck/schema/20/rng/ops20-svg.nvdl
@@ -4,7 +4,6 @@
 		<namespace ns="http://www.w3.org/2000/svg">
 			<validate schema="svg11.rng" schemaType="application/relax-ng"
 				useMode="allowForeignNS">
-				<context path="foreignObject" useMode="allowHTMLOnly"/>
 			</validate>
 		</namespace>
 	</mode>
@@ -26,28 +25,6 @@
 		</namespace>
 		<anyNamespace match="elements attributes">
 			<allow/>
-		</anyNamespace>
-	</mode>
-	<mode name="allowHTMLOnly">
-		<namespace ns="http://www.w3.org/1999/xhtml">
-			<attach/>
-		</namespace>
-		<namespace ns="http://www.idpf.org/2007/ops" match="attributes">
-			<attach/>
-		</namespace>
-		<namespace ns="http://www.w3.org/1999/xlink" match="attributes">
-			<attach/>
-		</namespace>
-		<namespace ns="http://www.w3.org/XML/1998/namespace" match="attributes">
-			<attach/>
-		</namespace>
-		<namespace ns="" match="attributes">
-			<attach/>
-		</namespace>
-	</mode>
-	<mode name="attachAnyNS">
-		<anyNamespace>
-			<attach/>
 		</anyNamespace>
 	</mode>
 </rules>

--- a/src/main/resources/com/adobe/epubcheck/schema/20/rng/ops20-svg.nvdl
+++ b/src/main/resources/com/adobe/epubcheck/schema/20/rng/ops20-svg.nvdl
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rules xmlns="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0" startMode="svg">
+	<mode name="svg">
+		<namespace ns="http://www.w3.org/2000/svg">
+			<validate schema="svg11.rng" schemaType="application/relax-ng"
+				useMode="allowForeignNS">
+				<context path="foreignObject" useMode="allowHTMLOnly"/>
+			</validate>
+		</namespace>
+	</mode>
+	<mode name="allowForeignNS">
+		<namespace ns="http://www.w3.org/1999/xhtml">
+			<attach/>
+		</namespace>
+		<namespace ns="http://www.idpf.org/2007/ops" match="attributes">
+			<attach/>
+		</namespace>
+		<namespace ns="http://www.w3.org/1999/xlink" match="attributes">
+			<attach/>
+		</namespace>
+		<namespace ns="http://www.w3.org/XML/1998/namespace" match="attributes">
+			<attach/>
+		</namespace>
+		<namespace ns="" match="attributes">
+			<attach/>
+		</namespace>
+		<anyNamespace match="elements attributes">
+			<allow/>
+		</anyNamespace>
+	</mode>
+	<mode name="allowHTMLOnly">
+		<namespace ns="http://www.w3.org/1999/xhtml">
+			<attach/>
+		</namespace>
+		<namespace ns="http://www.idpf.org/2007/ops" match="attributes">
+			<attach/>
+		</namespace>
+		<namespace ns="http://www.w3.org/1999/xlink" match="attributes">
+			<attach/>
+		</namespace>
+		<namespace ns="http://www.w3.org/XML/1998/namespace" match="attributes">
+			<attach/>
+		</namespace>
+		<namespace ns="" match="attributes">
+			<attach/>
+		</namespace>
+	</mode>
+	<mode name="attachAnyNS">
+		<anyNamespace>
+			<attach/>
+		</anyNamespace>
+	</mode>
+</rules>

--- a/src/main/resources/com/adobe/epubcheck/schema/20/rng/ops20.nvdl
+++ b/src/main/resources/com/adobe/epubcheck/schema/20/rng/ops20.nvdl
@@ -12,7 +12,7 @@
 <!-- mode that allows arbitrary XHTML or SVG fragment -->
 <mode name="blessed-xhtml-svg">
    <namespace ns="http://www.w3.org/2000/svg">
-      <allow/>
+      <allow useMode="allowForeignNS"/>
    </namespace>
    <namespace ns="http://www.w3.org/1999/xhtml">
       <allow/>
@@ -27,7 +27,7 @@
       <attach/>
    </namespace>
    <namespace ns="http://www.w3.org/2000/svg">
-	  <attach/>
+   	<attach useMode="allowForeignNS"/>
    </namespace>
    <anyNamespace>
       <allow/>
@@ -46,7 +46,7 @@
 <!-- mode that validates SVG and OPS islands inside XHTML -->
 <mode name="xhtml-content">
    <namespace ns="http://www.w3.org/2000/svg">
-      <attach/>
+   	<attach useMode="allowForeignNS"/>
    </namespace>
    <namespace ns="http://www.w3.org/1999/xhtml">
       <attach/>
@@ -67,4 +67,24 @@
    </namespace>
 </mode>
 
+	<mode name="allowForeignNS">
+		<namespace ns="http://www.w3.org/1999/xhtml">
+			<attach/>
+		</namespace>
+		<namespace ns="http://www.idpf.org/2007/ops" match="attributes">
+			<attach/>
+		</namespace>
+		<namespace ns="http://www.w3.org/1999/xlink" match="attributes">
+			<attach/>
+		</namespace>
+		<namespace ns="http://www.w3.org/XML/1998/namespace" match="attributes">
+			<attach/>
+		</namespace>
+		<namespace ns="" match="attributes">
+			<attach/>
+		</namespace>
+		<anyNamespace match="elements attributes">
+			<allow/>
+		</anyNamespace>
+	</mode>
 </rules>


### PR DESCRIPTION
Fixes #1147 by adding an NVDL script similar to the EPUB 3 version to remove foreign namespaced elements and attributes before dispatching to the SVG 1.1 RNG.

I also copied the allowForeignNS mode into the XHTML NVDL schema to do the same for embedded SVGs.

I haven't added any tests to this PR as I don't want to write them using the old format. I'll open a separate PR later with some tests using the new. I did test against the second file in issue #1147, modified to also embed an SVG, and didn't get the reported errors anymore.