### PR TITLE
fix: allow 'a11y:certifierCredential' as a link

### DIFF
--- a/src/main/java/com/adobe/epubcheck/vocab/AccessibilityVocab.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/AccessibilityVocab.java
@@ -19,6 +19,7 @@ public final class AccessibilityVocab
 
   public static enum LINKREL_PROPERTIES
   {
+    CERTIFIER_CREDENTIAL,
     CERTIFIER_REPORT;
   }
 

--- a/src/test/java/com/adobe/epubcheck/opf/OPFCheckerTest.java
+++ b/src/test/java/com/adobe/epubcheck/opf/OPFCheckerTest.java
@@ -1313,6 +1313,12 @@ public class OPFCheckerTest
     // tests that the a11y vocb and known properties are allowed
     testValidateDocument("valid/vocab-a11y-declared.opf", EPUBVersion.VERSION_3);
   }
+
+  @Test
+  public void testVocabA11yCredientialsInLink() {
+    // tests that the a11y:certifierCredential property can be defined as a link
+    testValidateDocument("valid/vocab-a11y-credentials-in-link.opf", EPUBVersion.VERSION_3);
+  }
   
   @Test
   public void testVocabA11yUndeclared() {

--- a/src/test/resources/30/single/opf/valid/vocab-a11y-credentials-in-link.opf
+++ b/src/test/resources/30/single/opf/valid/vocab-a11y-credentials-in-link.opf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    prefix="a11y: http://www.idpf.org/epub/vocab/package/a11y/#">
+    <metadata>
+        <dc:identifier id="uid">uid</dc:identifier>
+        <dc:title>Test</dc:title>
+        <dc:language>en</dc:language>
+        <meta property="dcterms:modified">2011-08-19T12:00:00Z</meta>
+        <meta property="a11y:certifiedBy">Accessibility Testers Group</meta>
+        <link rel="a11y:certifierReport" href="http://example.org/report"/>
+        <link rel="a11y:certifierCredential" href="https://example.com/a11y/credential"/>
+    </metadata>
+    <manifest>
+        <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>
+    </manifest>
+    <spine>
+        <itemref idref="t001"/>
+    </spine>
+</package>


### PR DESCRIPTION
Fixes #1140