### PR TITLE
add doc-dedication to aside roles

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/mod/html5/structural.rnc
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/mod/html5/structural.rnc
@@ -115,6 +115,7 @@
 			|	common.attrs.aria.role.feed
 			|	common.attrs.aria.role.region
 			|	common.attrs.aria.role.presentation
+			|	common.attrs.aria.role.doc-dedication
 			|	common.attrs.aria.role.doc-example
 			|	common.attrs.aria.role.doc-footnote
 			|	common.attrs.aria.role.doc-pullquote


### PR DESCRIPTION
This should fully match us up with the ARIA in HTML doc again.