### PR TITLE
Test and check playback classes do not have refines attribute

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/package-30.sch
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/package-30.sch
@@ -99,36 +99,6 @@
         </rule>
     </pattern>
 
-    <pattern id="opf.media.overlay">
-        <rule context="opf:item[@media-overlay]">
-            <let name="ref" value="./normalize-space(@media-overlay)"/>
-            <let name="item" value="//opf:manifest/opf:item[normalize-space(@id) = $ref]"/>
-        	<let name="item-media-type" value="normalize-space($item/@media-type)"/>
-            <assert test="$item-media-type = 'application/smil+xml'">media overlay items must be of
-                the "application/smil+xml" type (given type was "<value-of select="$item-media-type"
-                />")</assert>
-        </rule>
-    </pattern>
-
-    <pattern id="opf.media.overlay.metadata.global">
-        <rule context="opf:manifest[opf:item[@media-overlay]]">
-        	<assert test="//opf:meta[normalize-space(@property)='media:duration' and not (@refines)]">global
-                media:duration meta element not set</assert>
-        </rule>
-    </pattern>
-
-    <pattern id="opf.media.overlay.metadata.item">
-        <rule context="opf:manifest/opf:item[@media-overlay]">
-            <let name="mo-idref" value="normalize-space(@media-overlay)"/>
-            <let name="mo-item" value="//opf:item[normalize-space(@id) = $mo-idref]"/>
-            <let name="mo-item-id" value="$mo-item/normalize-space(@id)"/>
-            <let name="mo-item-uri" value="concat('#', $mo-item-id)"/>
-        	<assert test="//opf:meta[normalize-space(@property)='media:duration' and normalize-space(@refines) = $mo-item-uri ]">item
-                media:duration meta element not set (expecting: meta property='media:duration'
-                    refines='<value-of select="$mo-item-uri"/>')</assert>
-        </rule>
-    </pattern>
-
     <pattern id="opf.bindings.handler">
         <rule context="opf:bindings/opf:mediaType">
             <let name="ref" value="./normalize-space(@handler)"/>
@@ -301,6 +271,52 @@
     </pattern>
     
     <include href="./mod/id-unique.sch"/>
+	
+	<!-- Media overlay checks -->
+	
+	<pattern id="opf.media.overlay">
+		<rule context="opf:item[@media-overlay]">
+			<let name="ref" value="./normalize-space(@media-overlay)"/>
+			<let name="item" value="//opf:manifest/opf:item[normalize-space(@id) = $ref]"/>
+			<let name="item-media-type" value="normalize-space($item/@media-type)"/>
+			<assert test="$item-media-type = 'application/smil+xml'">media overlay items must be of
+				the "application/smil+xml" type (given type was "<value-of select="$item-media-type"
+				/>")</assert>
+		</rule>
+	</pattern>
+	
+	<pattern id="opf.media.overlay.metadata.global">
+		<rule context="opf:manifest[opf:item[@media-overlay]]">
+			<assert test="//opf:meta[normalize-space(@property)='media:duration' and not (@refines)]">global
+				media:duration meta element not set</assert>
+		</rule>
+	</pattern>
+	
+	<pattern id="opf.media.overlay.metadata.item">
+		<rule context="opf:manifest/opf:item[@media-overlay]">
+			<let name="mo-idref" value="normalize-space(@media-overlay)"/>
+			<let name="mo-item" value="//opf:item[normalize-space(@id) = $mo-idref]"/>
+			<let name="mo-item-id" value="$mo-item/normalize-space(@id)"/>
+			<let name="mo-item-uri" value="concat('#', $mo-item-id)"/>
+			<assert test="//opf:meta[normalize-space(@property)='media:duration' and normalize-space(@refines) = $mo-item-uri ]">item
+				media:duration meta element not set (expecting: meta property='media:duration'
+				refines='<value-of select="$mo-item-uri"/>')</assert>
+		</rule>
+	</pattern>
+	
+	<pattern id="opf.media.overlay.metadata.active-class">
+		<rule context="opf:meta[normalize-space(@property)='media:active-class']">
+			<report test="@refines"> @refines must not be used with the media:active-class property</report>
+		</rule>
+	</pattern>
+	
+	<pattern id="opf.media.overlay.metadata.playback-active-class">
+		<rule context="opf:meta[normalize-space(@property)='media:playback-active-class']">
+			<report test="@refines"> @refines must not be used with the media:playback-active-class property</report>
+		</rule>
+	</pattern>
+	
+	
 	
 	<!-- EPUB 3.2 New Checks -->
 	

--- a/src/test/resources/epub3/files/package-document/mediaoverlays-active-class-refines-error.opf
+++ b/src/test/resources/epub3/files/package-document/mediaoverlays-active-class-refines-error.opf
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <metadata>
+        <dc:title>Title</dc:title>
+        <dc:language>en</dc:language>
+        <dc:identifier id="uid">NOID</dc:identifier>
+        <meta property="dcterms:modified">2019-01-01T12:00:00Z</meta>
+    	<meta property="media:active-class" refines="#mo001">-epub-media-overlay-active</meta>
+        <!-- Media Overlays Duration Properties -->
+        <meta property="media:duration">10min</meta>
+        <meta refines="#mo001" property="media:duration">10min</meta>
+    </metadata>
+    <manifest>
+        <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>
+        <item id="mo001" href="mediaoverlay_001.smil" media-type="application/smil+xml"/>
+    </manifest>
+    <spine>
+        <itemref idref="t001"/>
+    </spine>
+</package>

--- a/src/test/resources/epub3/files/package-document/mediaoverlays-playback-active-class-refines-error.opf
+++ b/src/test/resources/epub3/files/package-document/mediaoverlays-playback-active-class-refines-error.opf
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <metadata>
+        <dc:title>Title</dc:title>
+        <dc:language>en</dc:language>
+        <dc:identifier id="uid">NOID</dc:identifier>
+        <meta property="dcterms:modified">2019-01-01T12:00:00Z</meta>
+    	<meta property="media:playback-active-class" refines="#mo001">-epub-media-overlay-playing</meta>
+        <!-- Media Overlays Duration Properties -->
+        <meta property="media:duration">10min</meta>
+        <meta refines="#mo001" property="media:duration">10min</meta>
+    </metadata>
+    <manifest>
+        <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>
+        <item id="mo001" href="mediaoverlay_001.smil" media-type="application/smil+xml"/>
+    </manifest>
+    <spine>
+        <itemref idref="t001"/>
+    </spine>
+</package>

--- a/src/test/resources/epub3/mediaoverlays-package-document.feature
+++ b/src/test/resources/epub3/mediaoverlays-package-document.feature
@@ -43,7 +43,19 @@ Feature: EPUB 3 ▸ Media Overlays ▸ Package Document Checks
   Scenario: the 'media:duration' property can be expressed as a full clock value
     When checking file 'mediaoverlays-duration-fullclock-valid.opf'
     Then no errors or warnings are reported
-    
+  
   Scenario: the 'media:duration' property can be expressed as a timecount value
     When checking file 'mediaoverlays-duration-timecount-valid.opf'
     Then no errors or warnings are reported
+  
+  Scenario: Report a 'media:active-class' property with a refines attribute
+    When checking file 'mediaoverlays-active-class-refines-error.opf'
+    Then error RSC-005 is reported
+    And the message contains "must not be used with the media:active-class property"
+    And no other errors or warnings are reported
+  
+  Scenario: Report a 'media:playback-active-class' property with a refines attribute
+    When checking file 'mediaoverlays-playback-active-class-refines-error.opf'
+    Then error RSC-005 is reported
+    And the message contains "must not be used with the media:playback-active-class property"
+    And no other errors or warnings are reported


### PR DESCRIPTION
A couple of minor schema updates and tests for the ["must not" in s. 3.4](https://www.w3.org/publishing/epub/epub-mediaoverlays.html#sec-docs-assoc-style).