### PR TITLE
Verify media:duration property values are valid smil clock values

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/package-30.sch
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/package-30.sch
@@ -128,6 +128,14 @@
                     refines='<value-of select="$mo-item-uri"/>')</assert>
         </rule>
     </pattern>
+	
+	<pattern id="opf.duration.metadata.item">
+		<rule context="//opf:meta[normalize-space(@property)='media:duration']">
+			<assert
+				test="matches(normalize-space(),'^(([0-9]+:[0-5][0-9]:[0-5][0-9](\.[0-9]+)?)|((\s*)[0-5][0-9]:[0-5][0-9](\.[0-9]+)?(\s*))|((\s*)[0-9]+(\.[0-9]+)?(h|min|s|ms)?(\s*)))$')"
+				>The value of the media:duration property must be a valid SMIL3 clock value</assert>
+		</rule>
+	</pattern>
 
     <pattern id="opf.bindings.handler">
         <rule context="opf:bindings/opf:mediaType">

--- a/src/main/resources/com/adobe/epubcheck/schema/30/package-30.sch
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/package-30.sch
@@ -130,7 +130,7 @@
     </pattern>
 	
 	<pattern id="opf.duration.metadata.item">
-		<rule context="//opf:meta[normalize-space(@property)='media:duration']">
+		<rule context="opf:meta[normalize-space(@property)='media:duration']">
 			<assert
 				test="matches(normalize-space(),'^(([0-9]+:[0-5][0-9]:[0-5][0-9](\.[0-9]+)?)|((\s*)[0-5][0-9]:[0-5][0-9](\.[0-9]+)?(\s*))|((\s*)[0-9]+(\.[0-9]+)?(h|min|s|ms)?(\s*)))$')"
 				>The value of the media:duration property must be a valid SMIL3 clock value</assert>

--- a/src/test/resources/epub3/files/package-document/mediaoverlays-duration-clock-values-error.opf
+++ b/src/test/resources/epub3/files/package-document/mediaoverlays-duration-clock-values-error.opf
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <metadata>
+        <dc:title>Title</dc:title>
+        <dc:language>en</dc:language>
+        <dc:identifier id="uid">NOID</dc:identifier>
+        <meta property="dcterms:modified">2019-01-01T12:00:00Z</meta>
+        <!-- Media Overlays Duration Properties -->
+        <meta property="media:duration">0:01:30,200</meta>
+        <meta refines="#mo001" property="media:duration">0:9999:12.121</meta>
+    	<meta refines="#mo002" property="media:duration">45mon</meta>
+    </metadata>
+    <manifest>
+        <item id="t001" href="contents_001.xhtml" properties="nav" media-type="application/xhtml+xml"/>
+        <item id="mo001" href="mediaoverlay_001.smil" media-type="application/smil+xml"/>
+    	<item id="t002" href="contents_002.xhtml" media-type="application/xhtml+xml"/>
+    	<item id="mo002" href="mediaoverlay_002.smil" media-type="application/smil+xml"/>
+    </manifest>
+    <spine>
+        <itemref idref="t001"/>
+    </spine>
+</package>

--- a/src/test/resources/epub3/mediaoverlays-package-document.feature
+++ b/src/test/resources/epub3/mediaoverlays-package-document.feature
@@ -43,7 +43,14 @@ Feature: EPUB 3 ▸ Media Overlays ▸ Package Document Checks
   Scenario: the 'media:duration' property can be expressed as a full clock value
     When checking file 'mediaoverlays-duration-fullclock-valid.opf'
     Then no errors or warnings are reported
-    
+  
   Scenario: the 'media:duration' property can be expressed as a timecount value
     When checking file 'mediaoverlays-duration-timecount-valid.opf'
     Then no errors or warnings are reported
+  
+  Scenario: Repoort 'media:duration' properties with non-clock values
+    When checking file 'mediaoverlays-duration-clock-values-error.opf'
+    Then error RSC-005 is reported 3 times
+    And the message contains "must be a valid SMIL3 clock value"
+    And no other errors or warnings are reported
+

--- a/src/test/resources/epub3/mediaoverlays-package-document.feature
+++ b/src/test/resources/epub3/mediaoverlays-package-document.feature
@@ -50,7 +50,9 @@ Feature: EPUB 3 ▸ Media Overlays ▸ Package Document Checks
   
   Scenario: Repoort 'media:duration' properties with non-clock values
     When checking file 'mediaoverlays-duration-clock-values-error.opf'
-    Then error RSC-005 is reported 3 times
-    And the message contains "must be a valid SMIL3 clock value"
+    Then the following errors are reported
+      | RSC-005 | must be a valid SMIL3 clock value |
+      | RSC-005 | must be a valid SMIL3 clock value |
+      | RSC-005 | must be a valid SMIL3 clock value |
     And no other errors or warnings are reported
 


### PR DESCRIPTION
The PR adds a schematron test to check that media:duration values are valid smil clock values based on the regex used in the media overlays rnc to verify clipBegin and clipEnd.