### PR TITLE
Check remote-resources property is set for media overlay documents

### DIFF
--- a/src/test/resources/epub3/files/epub/package-manifest-prop-remote-resource-overlays-error/EPUB/chapter_001_overlay.smil
+++ b/src/test/resources/epub3/files/epub/package-manifest-prop-remote-resource-overlays-error/EPUB/chapter_001_overlay.smil
@@ -1,0 +1,8 @@
+<smil xmlns="http://www.w3.org/ns/SMIL" xmlns:epub="http://www.idpf.org/2007/ops" version="3.0">
+	<body>
+		<par id="heading1">
+			<text src="content_001.xhtml#hd01"/>
+			<audio src="http://example.com/audio/c001.mp4" clipBegin="0:00:24.500"/>
+		</par>
+	</body>
+</smil>

--- a/src/test/resources/epub3/files/epub/package-manifest-prop-remote-resource-overlays-error/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/files/epub/package-manifest-prop-remote-resource-overlays-error/EPUB/content_001.xhtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal EPUB</title>
+	</head>
+	<body>
+		<h1 id="hd01">Loomings</h1>
+		<p>boring boring boring</p>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/epub/package-manifest-prop-remote-resource-overlays-error/EPUB/nav.xhtml
+++ b/src/test/resources/epub3/files/epub/package-manifest-prop-remote-resource-overlays-error/EPUB/nav.xhtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/epub/package-manifest-prop-remote-resource-overlays-error/EPUB/package.opf
+++ b/src/test/resources/epub3/files/epub/package-manifest-prop-remote-resource-overlays-error/EPUB/package.opf
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="q">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+	<!--MEDIA OVERLAY METADATA-->
+	<meta property="media:duration" refines="#chapter_001_overlay">0:14:20.500</meta>
+	<meta property="media:duration">0:14:20.500</meta>
+</metadata>
+<manifest>
+	<item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml" media-overlay="chapter_001_overlay"/>
+	<item id="chapter_001_overlay" href="chapter_001_overlay.smil" media-type="application/smil+xml"/>
+	<item id="chapter_001_audio" href="http://example.com/audio/c001.mp4" media-type="audio/mp4"/>
+	<item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/src/test/resources/epub3/files/epub/package-manifest-prop-remote-resource-overlays-error/META-INF/container.xml
+++ b/src/test/resources/epub3/files/epub/package-manifest-prop-remote-resource-overlays-error/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
+	<rootfiles>
+		<rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/epub3/files/epub/package-manifest-prop-remote-resource-overlays-error/mimetype
+++ b/src/test/resources/epub3/files/epub/package-manifest-prop-remote-resource-overlays-error/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/src/test/resources/epub3/package-publication.feature
+++ b/src/test/resources/epub3/package-publication.feature
@@ -174,6 +174,11 @@ Feature: EPUB 3 ▸ Packages ▸ Full Publication Checks
     Then warning OPF-018 is reported
     And no other errors or warnings are reported
 
+  Scenario: Report a media overlay document with remote resources but missing the `remote-resources` property
+    When checking EPUB 'package-manifest-prop-remote-resource-overlays-error'
+    Then error OPF-014 is reported
+    And no other errors or warnings are reported
+
 
   ###  E.2.5 scripted
 


### PR DESCRIPTION
This PR makes the following changes:

- adds a check on audio start tags to flag when there are remote resource references
- adds a check on the end of the smil document to verify that remote-resources is specified on the package item declaration

Also adds a test to report an error when the property is not set.