### PR TITLE
fix: allow the 'glossary' manifest item property

### DIFF
--- a/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
@@ -245,6 +245,10 @@ public class OPSHandler30 extends OPSHandler
       allowedProperties.add(ITEM_PROPERTIES.INDEX);
       context.featureReport.report(FeatureEnum.INDEX, parser.getLocation(), null);
     }
+    if (types.contains(EPUB_TYPES.GLOSSARY))
+    {
+      allowedProperties.add(ITEM_PROPERTIES.GLOSSARY);
+    }
   }
   
   @Override

--- a/src/test/resources/epub-dictionaries/dictionaries-publication.feature
+++ b/src/test/resources/epub-dictionaries/dictionaries-publication.feature
@@ -97,3 +97,16 @@ Feature: EPUB Dictionaries and Glossaries ▸ Full Publication Checks
     When checking EPUB 'dictionary-multiple-no-content-error'
     Then error OPF-078 is reported
     And no other errors or warnings are reported
+
+  ### 2.5.2 Glossary Identification
+
+  Scenario: Verify a publication with a single glossary
+    Given EPUBCheck configured with the 'default' profile
+    When checking EPUB 'glossary-single-valid'
+    Then no errors or warnings are reported
+
+  Scenario: Verify the 'glossary' manifest item property is not mandatory in the default checking profile
+    Note: we cannot check that the property is mandatory in EPUB Glossaries, as there is no dedicated profile for these
+    Given EPUBCheck configured with the 'default' profile
+    When checking EPUB 'glossary-single-package-property-not-defined-error'
+    Then no errors or warnings are reported

--- a/src/test/resources/epub-dictionaries/files/epub/glossary-single-package-property-not-defined-error/EPUB/content_001.xhtml
+++ b/src/test/resources/epub-dictionaries/files/epub/glossary-single-package-property-not-defined-error/EPUB/content_001.xhtml
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" xmlns:epub="http://www.idpf.org/2007/ops">
+	<head>
+		<meta charset="utf-8" />
+		<title>Minimal EPUB</title>
+	</head>
+	<body>
+		<h2>Glossary</h2>
+		<section epub:type="glossary">
+			<dl>
+				<dt id="term">term</dt>
+				<dd>definition</dd>
+			</dl>
+		</section>
+	</body>
+</html>

--- a/src/test/resources/epub-dictionaries/files/epub/glossary-single-package-property-not-defined-error/EPUB/nav.xhtml
+++ b/src/test/resources/epub-dictionaries/files/epub/glossary-single-package-property-not-defined-error/EPUB/nav.xhtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/epub-dictionaries/files/epub/glossary-single-package-property-not-defined-error/EPUB/package.opf
+++ b/src/test/resources/epub-dictionaries/files/epub/glossary-single-package-property-not-defined-error/EPUB/package.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="q">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+</metadata>
+<manifest>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml"/>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  <item id="skm" href="search.xml" properties="glossary search-key-map" media-type="application/vnd.epub.search-key-map+xml"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/src/test/resources/epub-dictionaries/files/epub/glossary-single-package-property-not-defined-error/EPUB/search.xml
+++ b/src/test/resources/epub-dictionaries/files/epub/glossary-single-package-property-not-defined-error/EPUB/search.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<search-key-map xml:lang="en" xmlns="http://www.idpf.org/2007/ops">
+    <search-key-group href="content_001.xhtml#term">
+        <match value="term">
+            <value value="term"/>
+        </match>
+    </search-key-group>
+</search-key-map>

--- a/src/test/resources/epub-dictionaries/files/epub/glossary-single-package-property-not-defined-error/META-INF/container.xml
+++ b/src/test/resources/epub-dictionaries/files/epub/glossary-single-package-property-not-defined-error/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
+	<rootfiles>
+		<rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/epub-dictionaries/files/epub/glossary-single-package-property-not-defined-error/mimetype
+++ b/src/test/resources/epub-dictionaries/files/epub/glossary-single-package-property-not-defined-error/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/src/test/resources/epub-dictionaries/files/epub/glossary-single-valid/EPUB/content_001.xhtml
+++ b/src/test/resources/epub-dictionaries/files/epub/glossary-single-valid/EPUB/content_001.xhtml
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" xmlns:epub="http://www.idpf.org/2007/ops">
+	<head>
+		<meta charset="utf-8" />
+		<title>Minimal EPUB</title>
+	</head>
+	<body>
+		<h2>Glossary</h2>
+		<section epub:type="glossary">
+			<dl>
+				<dt id="term">term</dt>
+				<dd>definition</dd>
+			</dl>
+		</section>
+	</body>
+</html>

--- a/src/test/resources/epub-dictionaries/files/epub/glossary-single-valid/EPUB/nav.xhtml
+++ b/src/test/resources/epub-dictionaries/files/epub/glossary-single-valid/EPUB/nav.xhtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/epub-dictionaries/files/epub/glossary-single-valid/EPUB/package.opf
+++ b/src/test/resources/epub-dictionaries/files/epub/glossary-single-valid/EPUB/package.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="q">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+</metadata>
+<manifest>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml" properties="glossary"/>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  <item id="skm" href="search.xml" properties="glossary search-key-map" media-type="application/vnd.epub.search-key-map+xml"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/src/test/resources/epub-dictionaries/files/epub/glossary-single-valid/EPUB/search.xml
+++ b/src/test/resources/epub-dictionaries/files/epub/glossary-single-valid/EPUB/search.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<search-key-map xml:lang="en" xmlns="http://www.idpf.org/2007/ops">
+    <search-key-group href="content_001.xhtml#term">
+        <match value="term">
+            <value value="term"/>
+        </match>
+    </search-key-group>
+</search-key-map>

--- a/src/test/resources/epub-dictionaries/files/epub/glossary-single-valid/META-INF/container.xml
+++ b/src/test/resources/epub-dictionaries/files/epub/glossary-single-valid/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
+	<rootfiles>
+		<rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/epub-dictionaries/files/epub/glossary-single-valid/mimetype
+++ b/src/test/resources/epub-dictionaries/files/epub/glossary-single-valid/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/src/test/resources/epub3/package-publication.feature
+++ b/src/test/resources/epub3/package-publication.feature
@@ -154,7 +154,7 @@ Feature: EPUB 3 ▸ Packages ▸ Full Publication Checks
 
   Scenario: Verify content documents are identified as containing mathml
     When checking EPUB 'package-mathml-valid'
-    Then no errors or warnings are reported
+    Then no errors or warnings are reported    
 
 
   ###  E.2.4 remote-resources


### PR DESCRIPTION
The `glossary` manifest item property is defined in the EPUB dictionaries
and Glossaries 1.0 specification:
  http://idpf.org/epub/dict/epub-dict.html#sec-2.5.3

This fix allows the property to be defined on XHTML manifest items when
the content contains an element with a `glossary` `epub:type` attribute.

Fixes #1170