### PR TITLE
fix: do not report fragment-only CSS URLs

### DIFF
--- a/src/main/java/com/adobe/epubcheck/css/CSSHandler.java
+++ b/src/main/java/com/adobe/epubcheck/css/CSSHandler.java
@@ -320,10 +320,15 @@ public class CSSHandler implements CssContentHandler, CssErrorHandler
   {
     if (uri != null && uri.trim().length() > 0)
     {
-      String resolved = PathUtil.resolveRelativeReference(path, uri);
-      xrefChecker.registerReference(path, correctedLineNumber(line), correctedColumnNumber(line, col), resolved, type);
-      if (PathUtil.isRemote(resolved)) {
-        detectedProperties.add(ITEM_PROPERTIES.REMOTE_RESOURCES);
+      // Fragment-only URLs should be resolved relative to the host document
+      // Since we don't have access to the path of the host document(s) here,
+      // we ignore this case 
+      if (!uri.startsWith("#")) {
+        String resolved = PathUtil.resolveRelativeReference(path, uri);
+        xrefChecker.registerReference(path, correctedLineNumber(line), correctedColumnNumber(line, col), resolved, type);
+        if (PathUtil.isRemote(resolved)) {
+          detectedProperties.add(ITEM_PROPERTIES.REMOTE_RESOURCES);
+        }
       }
     }
     else

--- a/src/test/resources/epub3/content-publication.feature
+++ b/src/test/resources/epub3/content-publication.feature
@@ -401,6 +401,10 @@ Feature: EPUB 3 ▸ Content Documents ▸ Full Publication Checks
     When checking EPUB 'content-css-font-size-zero-valid'
     Then no errors or warnings are reported
 
+  Scenario: Verify a fragment-only URL does not trigger a "fragment not defined" error 
+    When checking EPUB 'content-css-url-fragment-valid'
+    Then no errors or warnings are reported
+
 
   ##  6.  Fixed Layouts
 

--- a/src/test/resources/epub3/files/epub/content-css-url-fragment-valid/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/files/epub/content-css-url-fragment-valid/EPUB/content_001.xhtml
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal EPUB</title>
+		<link type="text/css" rel="stylesheet" href="style.css" />
+	</head>
+	<body>
+		<h1>Loomings</h1>
+		<p>Call me Ishmael.</p>
+		<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+			<defs>
+				<filter id="filter">
+					<feColorMatrix type="matrix" values="0.3333 0.3333 0.3333 0 0
+						0.3333 0.3333 0.3333 0 0
+						0.3333 0.3333 0.3333 0 0
+						0 0 0 1 0" />
+				</filter>
+			</defs>
+		</svg>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/epub/content-css-url-fragment-valid/EPUB/nav.xhtml
+++ b/src/test/resources/epub3/files/epub/content-css-url-fragment-valid/EPUB/nav.xhtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/epub/content-css-url-fragment-valid/EPUB/package.opf
+++ b/src/test/resources/epub3/files/epub/content-css-url-fragment-valid/EPUB/package.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="q">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+</metadata>
+<manifest>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml" properties="svg"/>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  <item id="css" href="style.css" media-type="text/css" />
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/src/test/resources/epub3/files/epub/content-css-url-fragment-valid/EPUB/style.css
+++ b/src/test/resources/epub3/files/epub/content-css-url-fragment-valid/EPUB/style.css
@@ -1,0 +1,4 @@
+body {
+  color: inherit;
+  filter: url(#filter);
+}

--- a/src/test/resources/epub3/files/epub/content-css-url-fragment-valid/META-INF/container.xml
+++ b/src/test/resources/epub3/files/epub/content-css-url-fragment-valid/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+	<rootfiles>
+		<rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/epub3/files/epub/content-css-url-fragment-valid/mimetype
+++ b/src/test/resources/epub3/files/epub/content-css-url-fragment-valid/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip


### PR DESCRIPTION
CSS defines a special processing for the resolution of fragment-only URLs.
These are resolved based on the HTML document, not relative to the
stylesheet.

For example, an SVG filter inlined in the HTML can be refered in CSS as:

```
* {
  filter: url(#filter);
}
```

Such fragment-only URLs were previously reported as errors in EPUBCheck,
since the related fragment could not be found in the CSS document!

This change fixes the issue by ignoring fragment-only URLs in CSS. In
other words, these URLs will not be registered to the XRefChecker.

Fixes #1198