### PR TITLE
fix: allow empty `xml:lang` attributes in Package Documents

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/package-30.rnc
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/package-30.rnc
@@ -128,5 +128,5 @@
    opf.href.attr = attribute href { datatype.URI }
    opf.id.attr = attribute id { datatype.ID }
    opf.i18n.attrs = opf.xml.lang.attr? & opf.dir.attr?
-   opf.xml.lang.attr = attribute xml:lang { datatype.languagecode }
+   opf.xml.lang.attr = attribute xml:lang { "" | datatype.languagecode }
    opf.dir.attr = attribute dir { 'ltr' | 'rtl' }

--- a/src/test/resources/epub3/files/package-document/lang-empty-valid.opf
+++ b/src/test/resources/epub3/files/package-document/lang-empty-valid.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <metadata>
+        <dc:title>Title</dc:title>
+        <dc:language>en</dc:language>
+        <dc:identifier id="uid">NOID</dc:identifier>
+        <meta property="dcterms:modified">2019-01-01T12:00:00Z</meta>
+        <dc:creator xml:lang="">Jane Doe</dc:creator>
+    </metadata>
+    <manifest>
+        <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>
+    </manifest>
+    <spine>
+        <itemref idref="t001"/>
+    </spine>
+</package>

--- a/src/test/resources/epub3/package-document.feature
+++ b/src/test/resources/epub3/package-document.feature
@@ -30,8 +30,8 @@ Feature: EPUB 3 ▸ Packages ▸ Package Document Checks
     Then fatal error RSC-016 is reported (parsing error)
     And error RSC-005 is reported (schema error)
     And no other errors or warnings are reported
-    
-      
+
+
   # 3.4 Pacakge Document Definition
   
   ## 3.4.1 The package element
@@ -86,6 +86,10 @@ Feature: EPUB 3 ▸ Packages ▸ Package Document Checks
     When checking file 'id-duplicate-with-spaces-error.opf'
     Then error RSC-005 is reported 2 times (once for each ID)
     And no other errors or warnings are reported
+
+  Scenario: the `xml:lang` attribute can be empty  
+    When checking file 'lang-empty-valid.opf'
+    Then no other errors or warnings are reported
   
   ## 3.4.3 Metadata
   ### 3.4.3 The metadata element


### PR DESCRIPTION
An empty `xml:lang` attribute can explicitly indicate that the content
does not inherit the context language.

Fixes #777