### PR TITLE
fix: do not require the Navigation Document to have an index

### DIFF
--- a/src/main/java/com/adobe/epubcheck/nav/NavChecker.java
+++ b/src/main/java/com/adobe/epubcheck/nav/NavChecker.java
@@ -50,9 +50,9 @@ public class NavChecker implements ContentChecker, DocumentValidator
   @SuppressWarnings("unchecked")
   private final static ValidatorMap validatorMap = ValidatorMap.builder()
       .putAll(XMLValidators.NAV_30_RNC, XMLValidators.XHTML_30_SCH, XMLValidators.NAV_30_SCH)
-      .putAll(and(Predicates.or(profile(EPUBProfile.EDUPUB), hasPubType(OPFData.DC_TYPE_EDUPUB)),
-              not(
-                      hasProp(EpubCheckVocab.VOCAB.get(EpubCheckVocab.PROPERTIES.FIXED_LAYOUT))),
+      .putAll(
+          and(Predicates.or(profile(EPUBProfile.EDUPUB), hasPubType(OPFData.DC_TYPE_EDUPUB)),
+              not(hasProp(EpubCheckVocab.VOCAB.get(EpubCheckVocab.PROPERTIES.FIXED_LAYOUT))),
               not(hasProp(EpubCheckVocab.VOCAB.get(EpubCheckVocab.PROPERTIES.NON_LINEAR)))),
           XMLValidators.XHTML_EDUPUB_STRUCTURE_SCH, XMLValidators.XHTML_EDUPUB_SEMANTICS_SCH,
           XMLValidators.XHTML_IDX_SCH)
@@ -61,10 +61,9 @@ public class NavChecker implements ContentChecker, DocumentValidator
               mimetype("application/xhtml+xml"), version(EPUBVersion.VERSION_3)),
           XMLValidators.XHTML_DICT_SCH)
       .putAll(
-          and(or(profile(EPUBProfile.IDX), hasPubType(OPFData.DC_TYPE_INDEX),
-              hasProp(PackageVocabs.ITEM_VOCAB.get(PackageVocabs.ITEM_PROPERTIES.INDEX)),
+          and(or(hasProp(PackageVocabs.ITEM_VOCAB.get(PackageVocabs.ITEM_PROPERTIES.INDEX)),
               hasProp(EpubCheckVocab.VOCAB.get(EpubCheckVocab.PROPERTIES.IN_INDEX_COLLECTION))),
-          mimetype("application/xhtml+xml"), version(EPUBVersion.VERSION_3)),
+              mimetype("application/xhtml+xml"), version(EPUBVersion.VERSION_3)),
           XMLValidators.XHTML_IDX_SCH, XMLValidators.XHTML_IDX_INDEX_SCH)
       .build();
 

--- a/src/test/resources/epub-indexes/indexes-publication.feature
+++ b/src/test/resources/epub-indexes/indexes-publication.feature
@@ -22,9 +22,6 @@ Feature: EPUB Indexes ▸ Full Publication Checks
     When checking EPUB 'index-whole-pub-content-model-error'
     Then error RSC-005 is reported
     And the message contains 'An "index" must contain one and only one "index-entry-list"'
-    # FIXME #1122 this error shouldn’t be reported on the Nav Doc
-    Then error RSC-005 is reported
-    And the message contains 'At least one "index" element must be present in a document declared as an index in the OPF'
     And no other errors or warnings are reported
 
   Scenario: Report a single-file index with an invalid content model
@@ -47,16 +44,12 @@ Feature: EPUB Indexes ▸ Full Publication Checks
   Scenario: Verify an index publication
     Given EPUBCheck configured with the 'idx' profile
     When checking EPUB 'index-whole-pub-valid'
-    # FIXME #1122 this error shouldn’t be reported on the Nav Doc
-    Then error RSC-005 is reported
-    And the message contains 'At least one "index" element must be present in a document declared as an index in the OPF'
     And no other errors or warnings are reported
 
   Scenario: Report an index publication without an index
     Given EPUBCheck configured with the 'idx' profile
     When checking EPUB 'index-whole-pub-no-index-error'
-    # FIXME #1122 this error shouldn’t be reported on the Nav Doc
-    Then error RSC-005 is reported 2 times
+    Then error RSC-005 is reported
     And the message contains 'At least one "index" element must be present in a document declared as an index in the OPF'
     And no other errors or warnings are reported
 


### PR DESCRIPTION
This fix removes the index-specific schemas when checking the Navigation
Document.

It is probably too simple, a better implementation would only do so if
the Nav Doc is not in the spine or is not the only Content Document in
the spine, but there is no easy way to check that latter condition in
the NavChecker.

The fix is a reasonable compromise, as a false-negative (the Nav Doc
**must** have index content when it is the unique Content Document) should
be pretty rare, and is always better than a false-positive.

Fixes #1122