### PR TITLE
feat: allow multiple roles for creator, contributor, and publisher

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/package-30.sch
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/package-30.sch
@@ -128,10 +128,8 @@
     
     <pattern id="opf.meta.role">
         <rule context="opf:meta[normalize-space(@property)='role']">
-            <assert test="exists(../(dc:creator|dc:contributor)[concat('#',normalize-space(@id)) = normalize-space(current()/@refines)])"
-                >Property "role" must refine a "creator" or "contributor" property.</assert>
-            <report test="exists(preceding-sibling::opf:meta[normalize-space(@property) = normalize-space(current()/@property)][normalize-space(@refines) = normalize-space(current()/@refines)])"
-                >Property "role" cannot be declared more than once to refine a single "creator" or "contributor" property.</report>
+            <assert test="exists(../(dc:creator|dc:contributor|dc:publisher)[concat('#',normalize-space(@id)) = normalize-space(current()/@refines)])"
+                >Property "role" must refine a "creator", "contributor", or "publisher" property.</assert>
         </rule>
     </pattern>
     

--- a/src/test/resources/epub3/files/package-document/metadata-meta-role-refines-disallowed-error.opf
+++ b/src/test/resources/epub3/files/package-document/metadata-meta-role-refines-disallowed-error.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <metadata>
+        <dc:title id="title">Title</dc:title>
+        <dc:language>en</dc:language>
+        <dc:identifier id="uid">NOID</dc:identifier>
+        <meta property="dcterms:modified">2019-01-01T12:00:00Z</meta>
+        <meta property="role" refines="#title">title</meta>
+    </metadata>
+    <manifest>
+        <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>
+    </manifest>
+    <spine>
+        <itemref idref="t001"/>
+    </spine>
+</package>

--- a/src/test/resources/epub3/files/package-document/metadata-meta-role-valid.opf
+++ b/src/test/resources/epub3/files/package-document/metadata-meta-role-valid.opf
@@ -8,9 +8,19 @@
         <meta property="dcterms:modified">2019-01-01T12:00:00Z</meta>
         <dc:creator id="creator1">Jane Doe</dc:creator>
         <dc:creator id="creator2">John Doe</dc:creator>
+        <dc:contributor id="contributor">Claudia Contributor</dc:contributor>
+        <dc:publisher id="publisher">Paula Publisher</dc:publisher>
+        <!-- Multiple roles for a single creator -->
         <meta property="role" refines="#creator1">aut</meta>
-        <meta property="role" refines="#creator1">edt</meta>
+        <meta property="role" refines="#creator1">ill</meta>
+        <!--Role for another creator-->
         <meta property="role" refines="#creator2">aut</meta>
+        <!-- Multiple roles for a contributor -->
+        <meta property="role" refines="#contributor">ill</meta>
+        <meta property="role" refines="#contributor">bkd</meta>
+        <!-- Multiple roles for a publisher -->
+        <meta property="role" refines="#publisher">pbl</meta>
+        <meta property="role" refines="#publisher">pbd</meta>
     </metadata>
     <manifest>
         <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>

--- a/src/test/resources/epub3/package-document.feature
+++ b/src/test/resources/epub3/package-document.feature
@@ -730,10 +730,14 @@ Feature: EPUB 3 ▸ Packages ▸ Package Document Checks
     And the message contains "the meta-auth property is deprecated"
     And no other errors or warnings are reported
 
-  Scenario: 'role' metadata cannot be defined more than once to refine the same expression 
-    When checking file 'metadata-meta-role-cardinality-error.opf'
+  Scenario: 'role' metadata can be used once or more to refine a creator, contributor, or publisher 
+    When checking file 'metadata-meta-role-valid.opf'
+    Then no errors or warnings are reported
+
+  Scenario: 'role' metadata cannot be used to refine properties other than creator, contributor, or publisher  
+    When checking file 'metadata-meta-role-refines-disallowed-error.opf'
     Then error RSC-005 is reported
-    And the message contains '"role" cannot be declared more than once'
+    And the message contains '"role" must refine a "creator", "contributor", or "publisher" property'
     And no other errors or warnings are reported
   
   Scenario: 'source-of' metadata can be used to refine the pagination source 


### PR DESCRIPTION
This PR proactively implements the relaxed EPUB 3.3 rules for the `role` property, to fix #1230.