### PR TITLE
feat: do not report Media Overlays ordering mismatch

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -151,7 +151,7 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.MED_012, Severity.ERROR);
     severities.put(MessageId.MED_013, Severity.ERROR);
     severities.put(MessageId.MED_014, Severity.ERROR);
-    severities.put(MessageId.MED_015, Severity.ERROR);
+    severities.put(MessageId.MED_015, Severity.USAGE);
 
     // NAV
     severities.put(MessageId.NAV_001, Severity.ERROR);

--- a/src/test/resources/epub3/mediaoverlays-publication.feature
+++ b/src/test/resources/epub3/mediaoverlays-publication.feature
@@ -50,8 +50,9 @@ Feature: EPUB 3 ▸ Media Overlays ▸ Full Publication Checks
   ### 3.2.1 Structure
 
   Scenario: Report an overlay document whose text elements do not match the dom order of the corresponding content document
+    Given the reporting level is set to USAGE
     When checking EPUB 'mediaoverlays-text-reading-order-error'
-    Then error MED-015 is reported
+    Then usage MED-015 is reported
     And no other errors or warnings are reported
 
   ### 3.5.1 Including Media Overlays


### PR DESCRIPTION
This PR demotes MED-015 to a USAGE. EPUB 3.3 will no longer required that Media Overlays are in content order. 

This proactively implements #1225, and goes a little further to what was proposed in the discussion by using `USAGE` instead of a `WARNING`.