### PR TITLE
Don't issue warnings on IDNs in href attributes

### DIFF
--- a/src/test/resources/epub3/content-document-xhtml.feature
+++ b/src/test/resources/epub3/content-document-xhtml.feature
@@ -437,6 +437,10 @@ Feature: EPUB 3 ▸ Content Documents ▸ XHTML Document Checks
     When checking document 'url-valid.xhtml'
     Then no errors or warnings are reported
 
+  Scenario: Verify IDN hosts pass through without a warning
+    When checking document 'url-idn-hosts-allowed.xhtml'
+    Then no errors or warnings are reported
+    
   Scenario: Report non-conforming URLs
     When checking document 'url-invalid-error.xhtml'
     Then error RSC-020 is reported 2 times
@@ -451,7 +455,6 @@ Feature: EPUB 3 ▸ Content Documents ▸ XHTML Document Checks
     When checking document 'url-unregistered-scheme-warning.xhtml'
     And warning HTM-025 is reported
     And no other errors or warnings are reported
-
 
   ####  XML Support
 

--- a/src/test/resources/epub3/files/content-document-xhtml/url-idn-hosts-allowed.xhtml
+++ b/src/test/resources/epub3/files/content-document-xhtml/url-idn-hosts-allowed.xhtml
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Host parsing issues</title>
+	</head>
+	<body>
+		<p>
+			<a href="https://www.jüdische-gemeinden.de/index.php/gemeinden/u-z/2477-wilna-vilnius-litauen/">Don't warn about internationalized domain names (see issue #1277)</a>
+			<a href="https://SŒUR.COM/">Don't warn about internationalized domain names (see issue #1277)</a>
+			<a href="http://微博.cn/">Don't warn about internationalized domain names (see issue #1277)</a>
+			<a href="http://www.j%C3%BCdische-gemeinden.de/">Also accept host names that are URL encoded</a>
+		</p>
+	</body>
+</html>


### PR DESCRIPTION
This PR is meant to solve the issue reported in #1277 

I've added cucumber tests and ensured that existing tests (via ' mvn test' ) succeed, but please review if you find any remaining logical or other flaws.