### PR TITLE
Update message about rule review to include rule id

### DIFF
--- a/src/main/java/com/adobe/epubcheck/opf/XRefChecker.java
+++ b/src/main/java/com/adobe/epubcheck/opf/XRefChecker.java
@@ -561,7 +561,7 @@ public class XRefChecker
             EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber),
             (ref.type == Type.NAV_TOC_LINK) ? "toc" : "page-list", ref.value, orderContext);
         report.message(MessageId.INF_001,
-            EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber), "https://github.com/w3c/publ-epub-revision/issues/1283");
+            EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber), "NAV_011", "https://github.com/w3c/publ-epub-revision/issues/1283");
       }
       lastSpinePosition = targetSpinePosition;
       lastAnchorPosition = -1;
@@ -591,7 +591,7 @@ public class XRefChecker
               EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber),
               (ref.type == Type.NAV_TOC_LINK) ? "toc" : "page-list", ref.value, orderContext);
           report.message(MessageId.INF_001,
-              EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber), "https://github.com/w3c/publ-epub-revision/issues/1283");
+              EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber), "NAV_011", "https://github.com/w3c/publ-epub-revision/issues/1283");
         }
       }
       lastAnchorPosition = targetAnchorPosition;

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -1,7 +1,7 @@
 # This is the default MessageBundle.properties file
 
 #Info
-INF_001=The previous rule is under review and its severity may change in a future release. See the discussion at %1$s
+INF_001=Rule %1$s is under review and its severity may change in a future release. See the discussion at %2$s
 
 #Accessibility
 ACC_001="img" or "area" HTML element has no "alt" attribute.


### PR DESCRIPTION
Updates the message about a rule being under review to include the rule ID.  This resolves the issue of the message being ambiguous when using json output, where the order is not the same as in the default format.

Resolves #1295