### PR TITLE
Do not url decode relative references

### DIFF
--- a/src/main/java/com/adobe/epubcheck/util/PathUtil.java
+++ b/src/main/java/com/adobe/epubcheck/util/PathUtil.java
@@ -67,15 +67,6 @@ public class PathUtil
       return normalizePath(ref);
     }
 
-    try
-    {
-      ref = URLDecoder.decode(ref.replace("+", "%2B"), "UTF-8");
-    } catch (UnsupportedEncodingException e)
-    {
-      // UTF-8 is guaranteed to be supported
-      throw new InternalError(e.toString());
-    }
-
     // Normalize base
     base = normalizePath(REGEX_URI_FRAGMENT.split(base)[0]);
 


### PR DESCRIPTION
Currently, `<item href="difficult_filename_%23.png">` is url-decoded to `difficult_filename_#.png` and then interpreted as a url fragment, which feels like incorrect behavior.

It's unlikely this change is in the right place, so I'm making this change mainly to see what CI says (I hope there's CI that runs on PRs...)