### PR TITLE
feat: check that item URLs have no fragment

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -272,6 +272,7 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.OPF_088, Severity.USAGE);
     severities.put(MessageId.OPF_089, Severity.ERROR);
     severities.put(MessageId.OPF_090, Severity.USAGE);
+    severities.put(MessageId.OPF_091, Severity.ERROR);
 
     // PKG
     severities.put(MessageId.PKG_001, Severity.WARNING);

--- a/src/main/java/com/adobe/epubcheck/messages/MessageId.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageId.java
@@ -266,6 +266,7 @@ public enum MessageId implements Comparable<MessageId>
   OPF_088("OPF-088"),
   OPF_089("OPF-089"),
   OPF_090("OPF-090"),
+  OPF_091("OPF-091"),
 
   // Messages relating to the entire package
   PKG_001("PKG-001"),

--- a/src/main/java/com/adobe/epubcheck/opf/OPFChecker30.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFChecker30.java
@@ -106,9 +106,12 @@ public class OPFChecker30 extends OPFChecker
           EPUBLocation.create(path, item.getLineNumber(), item.getColumnNumber()),
           preferredMimeType, mimeType);
     }
-
+    if (!PathUtil.isRemote(item.getPath()) && PathUtil.getFragment(item.getPath()) != null) {
+      report.message(MessageId.OPF_091,
+          EPUBLocation.create(path, item.getLineNumber(), item.getColumnNumber()));
+    }
     if ("application/xhtml+xml".equals(mimeType)
-        && !"xhtml".equals(Files.getFileExtension(item.getPath())))
+        && !"xhtml".equals(Files.getFileExtension(PathUtil.removeFragment(item.getPath()))))
     {
       report.message(MessageId.HTM_014a,
           EPUBLocation.create(path, item.getLineNumber(), item.getColumnNumber()), item.getPath());

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -280,7 +280,8 @@ OPF_086b_SUG.warning=the "notice" property
 OPF_087=epub:type value "%1$s" is not allowed on documents of type "%2$s".
 OPF_088=Unrecognized epub:type value "%1$s".
 OPF_089=The "alternate" link rel keyword cannot be paired with other keywords.
-OPF_090=It is encouraged to use MIME media type "%1$s" instead of "%2$s".  
+OPF_090=It is encouraged to use MIME media type "%1$s" instead of "%2$s".
+OPF_091=The item href URL must not have a fragment identifier.
 
 #Package
 PKG_001=Validating the EPUB against version %1$s but detected version %2$s.

--- a/src/test/resources/epub3/files/package-document/item-href-with-fragment-error.opf
+++ b/src/test/resources/epub3/files/package-document/item-href-with-fragment-error.opf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <metadata>
+        <dc:identifier id="uid">xxx</dc:identifier>
+        <dc:title>Title</dc:title>
+        <dc:language>en</dc:language>
+        <meta property="dcterms:modified">2019-01-01T12:00:00Z</meta>
+    </metadata>
+    <manifest>
+        <item id="t001" href="contents.xhtml#id" properties="nav" media-type="application/xhtml+xml"/>
+    </manifest>
+    <spine>
+        <itemref idref="t001"/>
+    </spine>
+</package>

--- a/src/test/resources/epub3/package-document.feature
+++ b/src/test/resources/epub3/package-document.feature
@@ -238,9 +238,14 @@ Feature: EPUB 3 ▸ Packages ▸ Package Document Checks
     And the message contains 'missing required attribute "media-type"'
     And no other errors or warnings are reported
 
-  Scenario: item paths should not contain spaces 
+  Scenario: item URLs should not contain spaces
     When checking file 'item-href-contains-spaces-warning.opf'
     Then warning PKG-010 is reported
+    And no other errors or warnings are reported
+
+  Scenario: item URLs must not have a fragment identifier
+    When checking file 'item-href-with-fragment-error.opf'
+    Then error OPF-091 is reported
     And no other errors or warnings are reported
 
   Scenario: two manifest items cannot represent the same resource 


### PR DESCRIPTION
Manifest `item` URLs that have a fragment are now reported as `OPF-091` (new check).

Fix #1250