### PR TITLE
feat: report reserved string in XHTML custom attribute namespaces

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -135,6 +135,7 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.HTM_051, Severity.WARNING);
     severities.put(MessageId.HTM_052, Severity.ERROR);
     severities.put(MessageId.HTM_053, Severity.INFO);
+    severities.put(MessageId.HTM_054, Severity.ERROR);
 
     // Media
     severities.put(MessageId.MED_001, Severity.ERROR);

--- a/src/main/java/com/adobe/epubcheck/messages/MessageId.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageId.java
@@ -129,6 +129,7 @@ public enum MessageId implements Comparable<MessageId>
   HTM_051("HTM-051"),
   HTM_052("HTM-052"),
   HTM_053("HTM_053"),
+  HTM_054("HTM_054"),
 
   // Messages associated with media (images, audio and video)
   MED_001("MED-001"),

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -122,6 +122,7 @@ HTM_050=Found epub:type="pagebreak" attribute in content document.
 HTM_051=Found Microdata semantic enrichments but no RDFa. EDUPUB recommends using RDFa Lite.
 HTM_052=The property "region-based" is only allowed on nav elements in Data Navigation Documents.
 HTM_053=Found an external file link (file://) in file: "%1$s".
+HTM_054=Custom attribute namespace ("%1$s") must not include the string "%2$s" in its domain.
 
 #media
 MED_001=Video poster must have core media image type.

--- a/src/test/resources/epub3/content-document-xhtml.feature
+++ b/src/test/resources/epub3/content-document-xhtml.feature
@@ -615,7 +615,11 @@ Feature: EPUB 3 ▸ Content Documents ▸ XHTML Document Checks
   Scenario: Verify attributes in custom namespaces are ignored
     When checking document 'attrs-custom-ns-valid.xhtml'
     Then no errors or warnings are reported
-
+    
+  Scenario: Report custom attributes using reserved strings in their namespace
+    When checking document 'attrs-custom-ns-reserved-error.xhtml'
+    Then error HTM-054 is reported 2 times
+    And no other errors or warnings are reported
 
   ## 2.5 HTML Deviations and Constraints
 

--- a/src/test/resources/epub3/files/content-document-xhtml/attrs-custom-ns-reserved-error.xhtml
+++ b/src/test/resources/epub3/files/content-document-xhtml/attrs-custom-ns-reserved-error.xhtml
@@ -4,7 +4,9 @@
 		<meta charset="utf-8" />
 		<title>Test</title>
 	</head>
-	<body custom:attribute="allowed" xmlns:custom="http://example.org">
+	<body w3:attr="disallowed" idpf:attr="disallowed" ok:attr="allowed"
+		xmlns:w3="http://example.w3.org" xmlns:idpf="http://example.idpf.org"
+		xmlns:ok="http://example.org/w3.org">
 		<h1>Test</h1>
 	</body>
 </html>


### PR DESCRIPTION
EPUB 3.3 disallows "w3.org" and "idpf.org" in domains of XHTML custom attribute namespaces.

Fix #1190