### PR TITLE
fix: remove "under review" notice for toc nav ordering warning

### DIFF
--- a/src/main/java/com/adobe/epubcheck/opf/XRefChecker.java
+++ b/src/main/java/com/adobe/epubcheck/opf/XRefChecker.java
@@ -560,8 +560,6 @@ public class XRefChecker
         report.message(MessageId.NAV_011,
             EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber),
             (ref.type == Type.NAV_TOC_LINK) ? "toc" : "page-list", ref.value, orderContext);
-        report.message(MessageId.INF_001,
-            EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber), "https://github.com/w3c/publ-epub-revision/issues/1283");
       }
       lastSpinePosition = targetSpinePosition;
       lastAnchorPosition = -1;
@@ -590,8 +588,6 @@ public class XRefChecker
           report.message(MessageId.NAV_011,
               EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber),
               (ref.type == Type.NAV_TOC_LINK) ? "toc" : "page-list", ref.value, orderContext);
-          report.message(MessageId.INF_001,
-              EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber), "https://github.com/w3c/publ-epub-revision/issues/1283");
         }
       }
       lastAnchorPosition = targetAnchorPosition;

--- a/src/test/resources/epub3/navigation-publication.feature
+++ b/src/test/resources/epub3/navigation-publication.feature
@@ -50,13 +50,11 @@ Feature: EPUB 3 ▸ Navigation Document ▸ Full Publication Checks
   Scenario: Report a `toc nav` whose links do not match the spine order 
     When checking EPUB 'nav-toc-unordered-spine-warning'
     Then warning NAV-011 is reported
-    And info INF-001 is reported
     And no other errors or warnings are reported
 
   Scenario: Report a `toc nav` whose link fragments do match the document order
     When checking EPUB 'nav-toc-unordered-fragments-warning'
     Then warning NAV-011 is reported 2 times
-    And info INF-001 is reported
     And no other errors or warnings are reported
 
   Scenario: Report as a USAGE a `toc nav` which does not link to all spine items
@@ -76,13 +74,11 @@ Feature: EPUB 3 ▸ Navigation Document ▸ Full Publication Checks
   Scenario: Report a `page-list nav` whose links do not match the spine order 
     When checking EPUB 'nav-page-list-unordered-spine-warning'
     Then warning NAV-011 is reported
-    And info INF-001 is reported
     And no other errors or warnings are reported
 
   Scenario: Report a `page-list nav` whose links do match the document order
     When checking EPUB 'nav-page-list-unordered-fragments-warning'
     Then warning NAV-011 is reported
-    And info INF-001 is reported
     And no other errors or warnings are reported
 
 


### PR DESCRIPTION
Fix #1194