### PR TITLE
test: 'scripted' property is disallowed for data blocks

### DIFF
--- a/src/test/resources/epub3/files/epub/package-manifest-prop-scripted-declared-but-unnecessary-error/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/files/epub/package-manifest-prop-scripted-declared-but-unnecessary-error/EPUB/content_001.xhtml
@@ -3,6 +3,9 @@
 	<head>
 		<meta charset="utf-8"/>
 		<title>Minimal EPUB</title>
+		<script type="application/vnd.xyz">
+			xyz
+		</script>
 	</head>
 	<body>
 		<h1>Loomings</h1>


### PR DESCRIPTION
EPUBCheck already handled data block scripts properly (see 05e5ac2351616f2b65ddfb7bf64ad54d972ed5c8)

But the test that reported an unnecessary `scripted` property did not include a data block to be sure.

Fix #1216