### PR TITLE
feat: check Media Overlays total duration consistency

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -153,6 +153,7 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.MED_013, Severity.ERROR);
     severities.put(MessageId.MED_014, Severity.ERROR);
     severities.put(MessageId.MED_015, Severity.USAGE);
+    severities.put(MessageId.MED_016, Severity.WARNING);
 
     // NAV
     severities.put(MessageId.NAV_001, Severity.ERROR);

--- a/src/main/java/com/adobe/epubcheck/messages/MessageId.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageId.java
@@ -147,6 +147,7 @@ public enum MessageId implements Comparable<MessageId>
   MED_013("MED_013"),
   MED_014("MED_014"),
   MED_015("MED_015"),
+  MED_016("MED_016"),
 
   // Epub3 based table of content errors
   NAV_001("NAV-001"),

--- a/src/main/java/com/adobe/epubcheck/opf/MetadataSet.java
+++ b/src/main/java/com/adobe/epubcheck/opf/MetadataSet.java
@@ -353,6 +353,15 @@ public final class MetadataSet
     {
       return refiners;
     }
+    
+    /**
+     * Whether this is a primary metadata expression (as opposed to a refining
+     * expression)
+     * @return <code>true</code> if and only if this is a primary metadata expression
+     */
+    public boolean isPrimary() {
+      return !refines.isPresent();
+    }
 
     @Override
     public String toString()

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -140,6 +140,7 @@ MED_012=The "media-overlay" attribute does not match the ID of the Media Overlay
 MED_013=Media Overlay Document referenced from the "media-overlay" attribute does not contain a reference to this Content Document.
 MED_014=A non-empty fragment identifier is required.
 MED_015=Media overlay text references must be in reading order. Text target "%1$s" is before the previous link target in %2$s order.
+MED_016=Media Overlays total duration should be the sum of the durations of all Media Overlays documents. 
 
 #NAV EPUB v3 Table of contents
 NAV_001=The nav file is not supported for EPUB v2.

--- a/src/test/resources/epub3/files/package-document/mediaoverlays-duration-single-not-defined-error.opf
+++ b/src/test/resources/epub3/files/package-document/mediaoverlays-duration-single-not-defined-error.opf
@@ -7,13 +7,17 @@
         <dc:identifier id="uid">NOID</dc:identifier>
         <meta property="dcterms:modified">2019-01-01T12:00:00Z</meta>
         <meta property="media:duration">10min</meta>
-        <!--<meta refines="#media001" property="media:duration">10min</meta>-->
+        <meta refines="#media001" property="media:duration">10min</meta>
+<!--        <meta refines="#media002" property="media:duration">10min</meta>-->
     </metadata>
     <manifest>
-        <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml" media-overlay="media001"/>
-        <item id="media001" href="media001.smil" media-type="application/smil+xml" />
+        <item id="t001" href="nav.xhtml" properties="nav" media-type="application/xhtml+xml" media-overlay="media001"/>
+        <item id="t002" href="contents.xhtml" media-type="application/xhtml+xml" media-overlay="media002"/>
+        <item id="media001" href="media001.smil" media-type="application/smil+xml"/>
+        <item id="media002" href="media002.smil" media-type="application/smil+xml" />
     </manifest>
     <spine>
         <itemref idref="t001"/>
+        <itemref idref="t002"/>
     </spine>
 </package>

--- a/src/test/resources/epub3/files/package-document/mediaoverlays-duration-total-not-sum-warning.opf
+++ b/src/test/resources/epub3/files/package-document/mediaoverlays-duration-total-not-sum-warning.opf
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <metadata>
+        <dc:title>Title</dc:title>
+        <dc:language>en</dc:language>
+        <dc:identifier id="uid">NOID</dc:identifier>
+        <meta property="dcterms:modified">2019-01-01T12:00:00Z</meta>
+        <!-- Media Overlays Duration Properties -->
+        <meta property="media:duration">10min</meta>
+        <meta refines="#mo001" property="media:duration">5min</meta>
+        <meta refines="#mo002" property="media:duration">0:05:00.200</meta>
+    </metadata>
+    <manifest>
+        <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>
+        <item id="mo001" href="mediaoverlay_001.smil" media-type="application/smil+xml"/>
+        <item id="mo002" href="mediaoverlay_002.smil" media-type="application/smil+xml"/>
+    </manifest>
+    <spine>
+        <itemref idref="t001"/>
+    </spine>
+</package>

--- a/src/test/resources/epub3/files/package-document/mediaoverlays-type-invalid-error.opf
+++ b/src/test/resources/epub3/files/package-document/mediaoverlays-type-invalid-error.opf
@@ -7,7 +7,7 @@
         <dc:identifier id="uid">NOID</dc:identifier>
         <meta property="dcterms:modified">2019-01-01T12:00:00Z</meta>
         <meta property="media:duration">0:32:00</meta>
-        <meta refines="#media001" property="media:duration">12min</meta>
+        <meta refines="#media001" property="media:duration">32min</meta>
     </metadata>
     <manifest>
         <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml" media-overlay="media001"/>

--- a/src/test/resources/epub3/mediaoverlays-package-document.feature
+++ b/src/test/resources/epub3/mediaoverlays-package-document.feature
@@ -42,7 +42,11 @@ Feature: EPUB 3 ▸ Media Overlays ▸ Package Document Checks
     Then error RSC-005 is reported
     And the message contains "item media:duration meta element not set"
     And no other errors or warnings are reported
-    
+
+  Scenario: the total duration should be the sum of all Media Overlay durations
+    When checking file 'mediaoverlays-duration-total-not-sum-warning.opf'
+    Then warning MED-016 is reported
+    And no other errors or warnings are reported
   
 
   # C. Media Overlays Metadata Vocabulary


### PR DESCRIPTION
EPUB 3.3 now recommends that the total MO duration equals the sum of individual MO durations.

This commit:
- implements this check by inspecting metadata in the OPF checker, using the `SmilClock` class to sum the durations.
- tweak existing tests to make their declared total duration matching the individual durations

Fix #1217

Note: the 1s tolerance will be in another PR