### PR TITLE
feat: ignore Nav Doc `nav` elements with no epub:type

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/epub-nav-30.sch
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/epub-nav-30.sch
@@ -75,12 +75,6 @@
         </rule>
     </pattern>
     
-    <pattern id="other-nav-type">
-        <rule context="html:nav">
-            <report test="not(@epub:type)">WARNING: nav elements should have an epub:type attribute</report>
-        </rule>
-    </pattern>
-
     <!-- warnings mode <pattern id="page-list-flat">
         <rule context="html:body//html:nav[@epub:type='page-list']">
         <assert test="count(.//html:ol) = 1">The page-list navigation structure should be a

--- a/src/test/resources/epub3/files/navigation-document/nav-type-missing-not-restricted-valid.xhtml
+++ b/src/test/resources/epub3/files/navigation-document/nav-type-missing-not-restricted-valid.xhtml
@@ -13,6 +13,11 @@
     </nav>
     <nav>
       <div>I have not type, I'm free!</div>
+      <ol>
+        <li>
+          <span>Look, I am a leaf item with no link!</span>
+        </li>
+      </ol>
     </nav>
   </body>
 </html>

--- a/src/test/resources/epub3/navigation-document.feature
+++ b/src/test/resources/epub3/navigation-document.feature
@@ -90,7 +90,6 @@ Feature: EPUB 3 ▸ Navigation Document ▸ Navigation Document Checks
   Scenario: Report a missing `toc` nav
     When checking document 'nav-toc-missing-error.xhtml'
     Then error RSC-005 is reported (toc nav missing)
-    And warning RSC-017 is reported (side-effect warning because of the type-less nav)
     And no other errors or warnings are reported
 
   #### 5.4.2.3 The page-list nav Element  
@@ -139,10 +138,6 @@ Feature: EPUB 3 ▸ Navigation Document ▸ Navigation Document Checks
     When checking document 'nav-other-lot-valid.xhtml'
     Then no errors or warnings are reported
 
-  Scenario: Report a nav without a declared epub:type
-    When checking document 'nav-other-type-missing-warning.xhtml'
-    Then warning RSC-017 is reported
-    And no other errors or warnings are reported
     
   Scenario: Report a nav other than 'toc'/'page-list'/'landmarks' without a heading
     When checking document 'nav-other-heading-missing-error.xhtml'
@@ -150,6 +145,9 @@ Feature: EPUB 3 ▸ Navigation Document ▸ Navigation Document Checks
     And the message contains 'must have a heading'
     And no other errors or warnings are reported
 
+  Scenario: Verify a nav without a declared epub:type is not restricted
+    When checking document 'nav-type-missing-not-restricted-valid.xhtml'
+    Then no errors or warnings are reported
 
   ### 5.4.3 The hidden attribute
 


### PR DESCRIPTION
EPUB 3.3, allows `nav` elements with no `epub:type` attribute in the Navigation Document, without any content model restrictions.

This commit:
- update the schema to discard the previously-reported warning
- update the tests

Fix #1222