### PR TITLE
feat: page-list nav does not have to match reading order

### DIFF
--- a/src/main/java/com/adobe/epubcheck/opf/XRefChecker.java
+++ b/src/main/java/com/adobe/epubcheck/opf/XRefChecker.java
@@ -310,7 +310,6 @@ public class XRefChecker
       }
     }
     checkReadingOrder(tocLinks, -1, -1);
-    checkReadingOrder(pageListLinks, -1, -1);
     checkReadingOrder(overlayLinks, -1, -1);
   }
 

--- a/src/test/resources/epub3/navigation-publication.feature
+++ b/src/test/resources/epub3/navigation-publication.feature
@@ -71,14 +71,12 @@ Feature: EPUB 3 ▸ Navigation Document ▸ Full Publication Checks
     When checking EPUB 'nav-page-list-reading-order-valid'
     Then no errors or warnings are reported
 
-  Scenario: Report a `page-list nav` whose links do not match the spine order 
+  Scenario: Verify a `page-list nav` whose links do not match the spine order 
     When checking EPUB 'nav-page-list-unordered-spine-warning'
-    Then warning NAV-011 is reported
     And no other errors or warnings are reported
 
-  Scenario: Report a `page-list nav` whose links do match the document order
+  Scenario: Verify a `page-list nav` whose links do match the document order
     When checking EPUB 'nav-page-list-unordered-fragments-warning'
-    Then warning NAV-011 is reported
     And no other errors or warnings are reported
 
 


### PR DESCRIPTION
This commit:
- removes the call to check the page list reading order
- keeps the checking code, as well as NAV-011
- update tests

Fix #1237