### PR TITLE
feat: check discouraged HTML elements (base, rp, embed)

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -136,6 +136,7 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.HTM_052, Severity.ERROR);
     severities.put(MessageId.HTM_053, Severity.INFO);
     severities.put(MessageId.HTM_054, Severity.ERROR);
+    severities.put(MessageId.HTM_055, Severity.WARNING);
 
     // Media
     severities.put(MessageId.MED_001, Severity.ERROR);

--- a/src/main/java/com/adobe/epubcheck/messages/MessageId.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageId.java
@@ -130,6 +130,7 @@ public enum MessageId implements Comparable<MessageId>
   HTM_052("HTM-052"),
   HTM_053("HTM_053"),
   HTM_054("HTM_054"),
+  HTM_055("HTM_055"),
 
   // Messages associated with media (images, audio and video)
   MED_001("MED-001"),

--- a/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
@@ -299,11 +299,12 @@ public class OPSHandler30 extends OPSHandler
     super.startElement();
 
     XMLElement e = parser.getCurrentElement();
-    String name = e.getName();
 
+    checkDiscouragedElements(e);
     processSemantics(e);
     processSectioning(e);
 
+    String name = e.getName();
     if (name.equals("html"))
     {
       vocabs = VocabUtil.parsePrefixDeclaration(
@@ -386,6 +387,23 @@ public class OPSHandler30 extends OPSHandler
     checkType(e, e.getAttributeNS(EpubConstants.EpubTypeNamespaceUri, "type"));
 
     checkSSMLPh(e.getAttributeNS("http://www.w3.org/2001/10/synthesis", "ph"));
+  }
+  
+  protected void checkDiscouragedElements(XMLElement elem)
+  {
+    if (EpubConstants.HtmlNamespaceUri.equals(elem.getNamespace()))
+    {
+      switch (elem.getName())
+      {
+      case "base":
+      case "embed":
+      case "rp":
+        report.message(MessageId.HTM_055,
+            EPUBLocation.create(path, parser.getLineNumber(), parser.getColumnNumber()),
+            elem.getName());
+      }
+
+    }
   }
 
   protected void processInlineScripts(com.adobe.epubcheck.xml.XMLElement e)

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -123,6 +123,7 @@ HTM_051=Found Microdata semantic enrichments but no RDFa. EDUPUB recommends usin
 HTM_052=The property "region-based" is only allowed on nav elements in Data Navigation Documents.
 HTM_053=Found an external file link (file://) in file: "%1$s".
 HTM_054=Custom attribute namespace ("%1$s") must not include the string "%2$s" in its domain.
+HTM_055=The "%1$s" element should not be used (discouraged construct)
 
 #media
 MED_001=Video poster must have core media image type.

--- a/src/test/resources/epub3/content-document-xhtml.feature
+++ b/src/test/resources/epub3/content-document-xhtml.feature
@@ -787,3 +787,23 @@ Feature: EPUB 3 ▸ Content Documents ▸ XHTML Document Checks
   Scenario: Verify RDF elements can be embedded in SVG
     When checking document 'svg-rdf-valid.xhtml'
     Then no errors or warnings are reported
+
+  ## Discouraged Constructs
+
+  Scenario: Report `base` as a discouraged construct
+    When checking document 'discouraged-base-warning.xhtml'
+    Then warning HTM-055 is reported
+    And the message contains 'base'
+    And no other errors or warnings are reported
+
+  Scenario: Report `embed` as a discouraged construct
+    When checking document 'discouraged-embed-warning.xhtml'
+    Then warning HTM-055 is reported
+    And the message contains 'embed'
+    And no other errors or warnings are reported
+
+  Scenario: Report `rp` as a discouraged construct
+    When checking document 'discouraged-rp-warning.xhtml'
+    Then warning HTM-055 is reported 2 times
+    And the message contains 'rp'
+    And no other errors or warnings are reported

--- a/src/test/resources/epub3/content-publication.feature
+++ b/src/test/resources/epub3/content-publication.feature
@@ -37,10 +37,12 @@ Feature: EPUB 3 ▸ Content Documents ▸ Full Publication Checks
 
   Scenario: Verify that a base url can be set
     When checking EPUB 'content-xhtml-base-url-valid'
+    Then warning HTM-055 is reported (side effect of `base` being discouraged)
     Then no errors or warnings are reported
 
   Scenario: Report relative paths as remote resources when HTML `base` is set to an extenal URL (issue 155)
     When checking EPUB 'content-xhtml-base-url-remote-relative-path-error'
+    Then warning HTM-055 is reported (side effect of `base` being discouraged)
     Then error RSC-006 is reported
     And no other errors or warnings are reported
 
@@ -213,7 +215,7 @@ Feature: EPUB 3 ▸ Content Documents ▸ Full Publication Checks
 
   Scenario: Verify that an SVG image can be referenced from `img`, `object` and `iframe` elements
     When checking EPUB 'content-xhtml-svg-reference-valid'
-    Then no errors or warnings are reported
+    And no errors or warnings are reported
 
   Scenario: Verify that `svg:switch` doesn't trigger the package document `switch` property check
     When checking EPUB 'content-xhtml-svg-switch-valid'

--- a/src/test/resources/epub3/files/content-document-xhtml/discouraged-base-warning.xhtml
+++ b/src/test/resources/epub3/files/content-document-xhtml/discouraged-base-warning.xhtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<base href="http://example.org" />
+		<title>Test</title>
+	</head>
+	<body>
+		<h1>Test</h1>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/content-document-xhtml/discouraged-embed-warning.xhtml
+++ b/src/test/resources/epub3/files/content-document-xhtml/discouraged-embed-warning.xhtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Test</title>
+	</head>
+	<body>
+		<h1>Test</h1>
+		<embed src="img.svg" type="image/svg+xml"/>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/content-document-xhtml/discouraged-rp-warning.xhtml
+++ b/src/test/resources/epub3/files/content-document-xhtml/discouraged-rp-warning.xhtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Test</title>
+	</head>
+	<body>
+		<h1>Test</h1>
+		<ruby>漢<rp>（</rp><rt>かん</rt><rp>）</rp></ruby>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/epub/content-xhtml-svg-reference-valid/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/files/epub/content-xhtml-svg-reference-valid/EPUB/content_001.xhtml
@@ -5,7 +5,6 @@
 		<title>Minimal EPUB</title>
 	</head>
 	<body>
-		<embed src="image.svg" type="image/svg+xml"></embed>
 		<iframe src="image.svg" width="256" height="256"></iframe>
 		<img src="image.svg" alt="test" />
 		<img


### PR DESCRIPTION
EPUB 3.3 discourages the use of the following elements:
- `base`
- `rp`
- `embed`

This commits:
- adds a new check HTM-055 to report all uses of discouraged elements
- add tests for discouraged constructs
- tweak existing tests that used discouraged constructs

Fix #1271