### PR TITLE
feat: check that 'page-list' and 'landmarks' nav are flat lists

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/epub-nav-30.sch
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/epub-nav-30.sch
@@ -24,6 +24,7 @@
 
     <pattern id="landmarks">
         <rule context="html:nav[tokenize(@epub:type,'\s+')='landmarks']//html:ol//html:a">
+            <let name="current" value="."/>
             <let name="current_type_normalized" value="tokenize(lower-case(@epub:type),'\s+')"/>
             <let name="current_href_normalized" value="normalize-space(lower-case(@href))"/>
 
@@ -35,10 +36,11 @@
                 and only reported within the same ancestor landmarks element
             -->
             <assert test="
-                count(ancestor::html:nav//html:ol//html:a[
+                empty(ancestor::html:nav//html:ol//html:a[
+                    not(. is $current) and
                     tokenize(lower-case(@epub:type),'\s+') = $current_type_normalized and
                     normalize-space(lower-case(@href)) = $current_href_normalized
-                    ]) le 1">Another landmark was found with the same epub:type and same reference to "<value-of select="$current_href_normalized"/>"</assert>
+                    ])">Another landmark was found with the same epub:type and same reference to "<value-of select="$current_href_normalized"/>"</assert>
         </rule>
     </pattern>
 
@@ -75,12 +77,11 @@
         </rule>
     </pattern>
     
-    <!-- warnings mode <pattern id="page-list-flat">
-        <rule context="html:body//html:nav[@epub:type='page-list']">
-        <assert test="count(.//html:ol) = 1">The page-list navigation structure should be a
-        list, not a nested hierarchy</assert>
+    <pattern id="flat-nav">
+        <rule context="html:nav[tokenize(@epub:type,'\s+') = ('page-list','landmarks')]">
+            <assert test="count(.//html:ol) = 1">WARNING: A "<value-of select="@epub:type"/>" nav element should contain
+                only a single ol descendant (no nested sublists)</assert>
         </rule>
-        </pattern> 
-    -->
+    </pattern>
 
 </schema>

--- a/src/test/resources/epub3/files/navigation-document/nav-landmarks-nested-warning.xhtml
+++ b/src/test/resources/epub3/files/navigation-document/nav-landmarks-nested-warning.xhtml
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en"
+    lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>Minimal Nav</title>
+    </head>
+    <body>
+        <nav epub:type="toc">
+            <ol>
+                <li><a href="content_001.xhtml">content 001</a></li>
+            </ol>
+        </nav>
+        <nav epub:type="landmarks">
+            <h2>Guide</h2>
+            <ol>
+                <li><a epub:type="toc" href="#toc">Table of Contents</a>
+                    <ol>
+                        <li><a epub:type="loi" href="#index">Illustrations</a></li>
+                    </ol>
+                </li>
+                <li><a epub:type="bodymatter" href="content.html#bodymatter">Content</a></li>
+            </ol>
+        </nav>
+    </body>
+</html>

--- a/src/test/resources/epub3/files/navigation-document/nav-page-list-nested-warning.xhtml
+++ b/src/test/resources/epub3/files/navigation-document/nav-page-list-nested-warning.xhtml
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en"
+    lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>Minimal Nav</title>
+    </head>
+    <body>
+        <nav epub:type="toc">
+            <ol>
+                <li><a href="content_001.xhtml">content 001</a></li>
+            </ol>
+        </nav>
+        <nav epub:type="page-list">
+            <h2>Pagebreaks of the print version, third edition</h2>
+            <ol>
+                <li><a href="chap1.xhtml#p1">Page 1</a>
+                    <ol>
+                        <li><a href="chap1.xhtml#p1-a">Page 1-a</a></li>
+                    </ol>
+                </li>
+                <li><a href="chap1.xhtml#p2">Page 2</a></li>
+            </ol>
+        </nav>
+    </body>
+</html>

--- a/src/test/resources/epub3/navigation-document.feature
+++ b/src/test/resources/epub3/navigation-document.feature
@@ -104,6 +104,13 @@ Feature: EPUB 3 ▸ Navigation Document ▸ Navigation Document Checks
     And the message contains 'Multiple occurrences of the "page-list" nav element'
     And no other errors or warnings are reported
 
+  Scenario: Report nested `ol` in `page-list` nav
+    When checking document 'nav-page-list-nested-warning.xhtml'
+    Then warning RSC-017 is reported
+    And the message contains "page-list"
+    And the message contains "no nested sublists"
+    And no other errors or warnings are reported
+
   #### 5.4.2.4 The landmarks nav Element
 
   Scenario: Allow a `landmarks` nav
@@ -130,6 +137,13 @@ Feature: EPUB 3 ▸ Navigation Document ▸ Navigation Document Checks
     When checking document 'nav-landmarks-type-twice-same-resource-error.xhtml'
     Then error RSC-005 is reported 2 times
     And the message contains 'Another landmark was found with the same epub:type and same reference'
+    And no other errors or warnings are reported
+
+  Scenario: Report nested `ol` in `landmarks` nav
+    When checking document 'nav-landmarks-nested-warning.xhtml'
+    Then warning RSC-017 is reported
+    And the message contains "landmarks"
+    And the message contains "no nested sublists"
     And no other errors or warnings are reported
     
   #### 5.4.2.5 Other nav Elements


### PR DESCRIPTION
EPUB 3.3 clarifies that authors should not use nested lists for 'page-list' and 'landmarks' nav.

This commit:
- reports a schema warning for nested 'page-list' or 'landmarks' nav (implemented in schematron)
- add tests

Fix #1279