### PR TITLE
feat: loosen restriction on where remote resources can be referenced

### DIFF
--- a/src/main/java/com/adobe/epubcheck/opf/XRefChecker.java
+++ b/src/main/java/com/adobe/epubcheck/opf/XRefChecker.java
@@ -326,7 +326,17 @@ public class XRefChecker
         && !(version == EPUBVersion.VERSION_3 && res != null && res.item.isInSpine())
         // audio, video, and fonts can be remote resources in EPUB 3
         && !(version == EPUBVersion.VERSION_3
-            && EnumSet.of(Type.AUDIO, Type.VIDEO, Type.FONT).contains(ref.type)))
+            && (res != null
+                // if the item is declared, check its mime type
+                && (OPFChecker30.isAudioType(res.item.getMimeType())
+                    || OPFChecker30.isVideoType(res.item.getMimeType())
+                    || OPFChecker30.isFontType(res.item.getMimeType()))
+               // else, check if the reference is a type allowing remote resources
+               || ref.type == Type.FONT
+               || ref.type == Type.AUDIO
+               || ref.type == Type.VIDEO
+             )
+      ))
     {
       report.message(MessageId.RSC_006,
           EPUBLocation.create(ref.source, ref.lineNumber, ref.columnNumber, ref.refResource));

--- a/src/test/resources/epub3/files/epub/resources-remote-audio-object-valid/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/files/epub/resources-remote-audio-object-valid/EPUB/content_001.xhtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Minimal EPUB</title>
+	</head>
+	<body>
+		<!-- remote http URL -->
+		<object data="https://example.org/remote.mp4" type="audio/mp4">audio</object>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/epub/resources-remote-audio-object-valid/EPUB/nav.xhtml
+++ b/src/test/resources/epub3/files/epub/resources-remote-audio-object-valid/EPUB/nav.xhtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/epub/resources-remote-audio-object-valid/EPUB/package.opf
+++ b/src/test/resources/epub3/files/epub/resources-remote-audio-object-valid/EPUB/package.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="q">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+</metadata>
+<manifest>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml" properties="remote-resources"/>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  <item id="audio" href="https://example.org/remote.mp4" media-type="audio/mp4" />
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/src/test/resources/epub3/files/epub/resources-remote-audio-object-valid/META-INF/container.xml
+++ b/src/test/resources/epub3/files/epub/resources-remote-audio-object-valid/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+	<rootfiles>
+		<rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/epub3/files/epub/resources-remote-audio-object-valid/mimetype
+++ b/src/test/resources/epub3/files/epub/resources-remote-audio-object-valid/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/src/test/resources/epub3/files/epub/resources-remote-video-object-valid/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/files/epub/resources-remote-video-object-valid/EPUB/content_001.xhtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Minimal EPUB</title>
+	</head>
+	<body>
+		<!-- remote http URL -->
+		<object data="https://example.org/remote.mp4" type="video/mp4">video</object>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/epub/resources-remote-video-object-valid/EPUB/nav.xhtml
+++ b/src/test/resources/epub3/files/epub/resources-remote-video-object-valid/EPUB/nav.xhtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/epub3/files/epub/resources-remote-video-object-valid/EPUB/package.opf
+++ b/src/test/resources/epub3/files/epub/resources-remote-video-object-valid/EPUB/package.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="q">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+</metadata>
+<manifest>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml" properties="remote-resources"/>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  <item id="video" href="https://example.org/remote.mp4" media-type="video/mp4" />
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/src/test/resources/epub3/files/epub/resources-remote-video-object-valid/META-INF/container.xml
+++ b/src/test/resources/epub3/files/epub/resources-remote-video-object-valid/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+	<rootfiles>
+		<rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/epub3/files/epub/resources-remote-video-object-valid/mimetype
+++ b/src/test/resources/epub3/files/epub/resources-remote-video-object-valid/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/src/test/resources/epub3/resources-publication.feature
+++ b/src/test/resources/epub3/resources-publication.feature
@@ -108,6 +108,11 @@ Feature: EPUB 3 ▸ Publication Resources ▸ Full Publication Checks
     When checking EPUB 'resources-remote-audio-valid'
     Then no errors or warnings are reported
 
+  Scenario: Verify that remote audio resources are allowed anywhere
+    (not only in `audio` elements)
+    When checking EPUB 'resources-remote-audio-object-valid'
+    Then no errors or warnings are reported
+
   Scenario: Verify that remote audio resources defined in the `sources` element are allowed
     When checking EPUB 'resources-remote-audio-sources-valid'
     Then no errors or warnings are reported
@@ -118,6 +123,11 @@ Feature: EPUB 3 ▸ Publication Resources ▸ Full Publication Checks
 
   Scenario: Verify that remote video resources are allowed
     When checking EPUB 'resources-remote-video-valid'
+    Then no errors or warnings are reported
+
+  Scenario: Verify that remote video resources are allowed anywhere
+    (not only in `video` elements)
+    When checking EPUB 'resources-remote-audio-object-valid'
     Then no errors or warnings are reported
 
   Scenario: Report a reference to a remote resource from an `iframe` element when the resource is declared in the package document (issue 852)


### PR DESCRIPTION
Previously, EPUBCheck only allowed remote resources when they were used in elements we knew allowed remote resources (e.g. audio, video, font declaration).

This commit improves this check by first checking that the resource media type allows remote resources, regardless of where the resource is used.

Fix #1288