### PR TITLE
feat: no longer check that navigation links to all spine items

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -241,8 +241,8 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.OPF_055, Severity.WARNING);
     severities.put(MessageId.OPF_056, Severity.USAGE);
     severities.put(MessageId.OPF_057, Severity.SUPPRESSED);
-    severities.put(MessageId.OPF_058, Severity.USAGE);
-    severities.put(MessageId.OPF_059, Severity.USAGE);
+    severities.put(MessageId.OPF_058, Severity.SUPPRESSED);
+    severities.put(MessageId.OPF_059, Severity.SUPPRESSED);
     severities.put(MessageId.OPF_060, Severity.ERROR);
     severities.put(MessageId.OPF_061, Severity.WARNING);
     severities.put(MessageId.OPF_062, Severity.USAGE);

--- a/src/test/resources/epub3/navigation-publication.feature
+++ b/src/test/resources/epub3/navigation-publication.feature
@@ -57,11 +57,10 @@ Feature: EPUB 3 ▸ Navigation Document ▸ Full Publication Checks
     Then warning NAV-011 is reported 2 times
     And no other errors or warnings are reported
 
-  Scenario: Report as a USAGE a `toc nav` which does not link to all spine items
+  Scenario: Verify a `toc nav` which does not link to all spine items
     Given the reporting level set to USAGE
     When checking EPUB 'nav-toc-missing-references-to-spine-valid'
     Then no errors or warnings are reported
-    And usage OPF-059 is reported
 
 
 

--- a/src/test/resources/epub3/package-publication.feature
+++ b/src/test/resources/epub3/package-publication.feature
@@ -123,11 +123,10 @@ Feature: EPUB 3 ▸ Packages ▸ Full Publication Checks
     And the message contains 'Fragment identifier is not defined'
     And no other errors or warnings are reported
 
-  Scenario: Report as a USAGE a NCX which does not link to all spine items
+  Scenario: Verify an NCX which does not link to all spine items
     Given the reporting level set to USAGE
     When checking EPUB 'package-ncx-missing-references-to-spine-valid'
     Then no errors or warnings are reported
-    And usage OPF-059 is reported
 
   ### 3.4.5 Spine
 


### PR DESCRIPTION
EPUB does not require that the navigation document (or NCX in EPUB 2.0.1) links to all the documents listed in the spine.

EPUBCheck reported this as USAGE messages (`OPF-059` and `OPF-058`), which are now suppressed.

Note: this change will only be effective when the checks of the `ctc` package  are disabled.