### PR TITLE
feat: disable usage reports related to javascript content

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -334,16 +334,16 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.RSC_025, Severity.USAGE);
 
     // Scripting
-    severities.put(MessageId.SCP_001, Severity.USAGE);
-    severities.put(MessageId.SCP_002, Severity.USAGE);
-    severities.put(MessageId.SCP_003, Severity.USAGE);
+    severities.put(MessageId.SCP_001, Severity.SUPPRESSED); // checking scripts is out of scope
+    severities.put(MessageId.SCP_002, Severity.SUPPRESSED); // checking scripts is out of scope
+    severities.put(MessageId.SCP_003, Severity.SUPPRESSED); // checking scripts is out of scope
     severities.put(MessageId.SCP_004, Severity.SUPPRESSED); // Scripts are not forbidden in EPUB 2.0.1
     severities.put(MessageId.SCP_005, Severity.SUPPRESSED);
-    severities.put(MessageId.SCP_006, Severity.USAGE);
-    severities.put(MessageId.SCP_007, Severity.USAGE);
-    severities.put(MessageId.SCP_008, Severity.USAGE);
-    severities.put(MessageId.SCP_009, Severity.USAGE);
-    severities.put(MessageId.SCP_010, Severity.USAGE);
+    severities.put(MessageId.SCP_006, Severity.SUPPRESSED); 
+    severities.put(MessageId.SCP_007, Severity.SUPPRESSED); // checking scripts is out of scope
+    severities.put(MessageId.SCP_008, Severity.SUPPRESSED); // checking scripts is out of scope
+    severities.put(MessageId.SCP_009, Severity.SUPPRESSED); // checking scripts is out of scope
+    severities.put(MessageId.SCP_010, Severity.SUPPRESSED);
   }
 
 }

--- a/src/test/resources/epub3/resources-publication.feature
+++ b/src/test/resources/epub3/resources-publication.feature
@@ -233,8 +233,6 @@ Feature: EPUB 3 ▸ Publication Resources ▸ Full Publication Checks
     When checking EPUB 'resources-remote-resource-for-script-foreign-valid'
     Then usage OPF-018b is reported (since the `remote-resources` property couldn't be verified)
     And usage RSC-006b is reported (to suggest checking scripts manually)
-    And usage SCP-002 is reported (since xmlhttprequest is a secrity risk)
-    And usage SCP-010 is reported (since `script` is used)
     And no other errors or warnings are reported
 
   Scenario: Verify that a remote core media type resource is allowed when used by a script
@@ -242,8 +240,6 @@ Feature: EPUB 3 ▸ Publication Resources ▸ Full Publication Checks
     When checking EPUB 'resources-remote-resource-for-script-cmt-valid'
     Then usage OPF-018b is reported (since the `remote-resources` property couldn't be verified)
     And usage RSC-006b is reported (to suggest checking scripts manually)
-    And usage SCP-002 is reported (since xmlhttprequest is a secrity risk)
-    And usage SCP-010 is reported (since `script` is used)
     And no other errors or warnings are reported
 
   Scenario: Report a remote top-level Content Documents


### PR DESCRIPTION
The `ctc` package contained checks that looked at javascript content and tried to detect suspicious or potentially problematic usage patterns.

This check were necessarily incomplete, and based on regex pattern matching, so inherently open to many false positives or false negatives.

This change  suppresses all of them. Inspecting javascript is not possible and out of scope for EPUBCheck.

Note: this change will only be effective when the checks of the `ctc` package  are disabled.