### PR TITLE
feat: re-implement relevant checks from the `ctc` package in core handlers

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -324,7 +324,7 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.RSC_015, Severity.ERROR);
     severities.put(MessageId.RSC_016, Severity.FATAL);
     severities.put(MessageId.RSC_017, Severity.WARNING);
-    severities.put(MessageId.RSC_018, Severity.WARNING);
+    severities.put(MessageId.RSC_018, Severity.SUPPRESSED); // Reported as RSC-007
     severities.put(MessageId.RSC_019, Severity.WARNING);
     severities.put(MessageId.RSC_020, Severity.ERROR);
     severities.put(MessageId.RSC_021, Severity.ERROR);

--- a/src/main/java/com/adobe/epubcheck/ops/OPSHandler.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSHandler.java
@@ -212,6 +212,9 @@ public class OPSHandler implements XMLHandler
         }
       }
     }
+    if ("file".equals(uri.getScheme())) {
+      report.message(MessageId.HTM_053, parser.getLocation(), uri);
+    }
 
     /*
      * mgy 20120417 adding check for base to initial if clause as part of

--- a/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
@@ -325,6 +325,11 @@ public class OPSHandler30 extends OPSHandler
       requiredProperties.add(ITEM_PROPERTIES.MATHML);
       inMathML = true;
       hasAltorAnnotation = (null != e.getAttribute("alttext"));
+      String altimg = e.getAttribute("altimg");
+      if (altimg != null) {
+        super.checkImage(e, null, "altimg");
+      }
+        
     }
     else if (name.equals("svg"))
     {

--- a/src/test/resources/epub3/content-document-xhtml.feature
+++ b/src/test/resources/epub3/content-document-xhtml.feature
@@ -242,6 +242,11 @@ Feature: EPUB 3 ▸ Content Documents ▸ XHTML Document Checks
     When checking document 'link-rel-stylesheet-alternate-valid.xhtml'
     Then no errors or warnings are reported
 
+  Scenario: Report `link` element defining an alternative stylesheet with no title
+    When checking document 'link-rel-stylesheet-alternate-no-title-error.xhtml'
+    Then error CSS-015 is reported 2 times (one for a missing title, one for an empty title)
+    And no other errors or warnings are reported
+
 
   ####  Lists
 

--- a/src/test/resources/epub3/content-publication.feature
+++ b/src/test/resources/epub3/content-publication.feature
@@ -182,7 +182,7 @@ Feature: EPUB 3 ▸ Content Documents ▸ Full Publication Checks
 
   Scenario: Report a MathML formula with an alternative image that cannot be found
     When checking EPUB 'content-xhtml-mathml-altimg-not-found-warning'
-    Then warning RSC-018 is reported
+    Then error RSC-007 is reported
     And no other errors or warnings are reported
 
 

--- a/src/test/resources/epub3/files/content-document-xhtml/link-rel-stylesheet-alternate-no-title-error.xhtml
+++ b/src/test/resources/epub3/files/content-document-xhtml/link-rel-stylesheet-alternate-no-title-error.xhtml
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Test</title>
+		<link href="tite-empty.css" rel="alternate stylesheet" type="text/css" title="" />
+		<link href="title-missing.css" rel="alternate stylesheet" type="text/css" />
+	</head>
+	<body>
+		<h1>Test</h1>
+	</body>
+</html>


### PR DESCRIPTION
## reimplement HTM-046 and HTM-047 in OPSHandler30

`HTM-046` and `HTM-048` check that HTML fixed-layout documents
have viewport metadata.

This change reimplements these checks in `OPSHandler30` so that the
`ctc` package can be disabled.

## report `RSC-018` as `RSC-007` instead

RSC-018 was introduced in the `ctc` package to check the images
specified in the MathML `altimg` attribute exist in the container.

EPUBCheck already has an error code  for missing resources, namely `RSC-018`.

This  change adds a check for the `altimg` in OPSHandler, and suppresses
`RSC-018`.

## move HTM-053 check to OPSHandler

`HTM-053` is an INFO-level message that reports links to local files
(absolute `file` URLs).

This check is moved to the core OPSHandler checks, so we can
safely disable the `ctc` package.

Note: these changes will only be effective when the `ctc` package is removed.