### PR TITLE
feat: better parse URL fragment micro syntaxes

### DIFF
--- a/src/main/java/com/adobe/epubcheck/opf/OPFChecker.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFChecker.java
@@ -116,6 +116,9 @@ public class OPFChecker extends AbstractChecker
 
     List<OPFItem> items = opfHandler.getItems();
     report.info(null, FeatureEnum.ITEMS_COUNT, Integer.toString(items.size()));
+    
+    // Register package doc and items to the XRefChecker
+    xrefChecker.registerResource(context.url, context.mimeType);
     for (OPFItem item : items)
     {
       xrefChecker.registerResource(item,

--- a/src/main/java/com/adobe/epubcheck/opf/OPFChecker30.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFChecker30.java
@@ -25,6 +25,8 @@ package com.adobe.epubcheck.opf;
 import java.util.Iterator;
 import java.util.Set;
 
+import org.w3c.epubcheck.url.URLFragment;
+
 import com.adobe.epubcheck.api.EPUBLocation;
 import com.adobe.epubcheck.api.EPUBProfile;
 import com.adobe.epubcheck.api.FeatureReport.Feature;
@@ -387,7 +389,8 @@ public class OPFChecker30 extends OPFChecker
         }
         else
         {
-          if (Optional.fromNullable(resource.getURL().fragment()).or("").startsWith("epubcfi("))
+          URLFragment fragment = URLFragment.parse(resource.getURL());
+          if (fragment.exists() && "epubcfi".equals(fragment.getScheme()))
           {
             report.message(MessageId.OPF_076, EPUBLocation.of(context));
           }

--- a/src/main/java/com/adobe/epubcheck/ops/OPSHandler.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSHandler.java
@@ -141,11 +141,6 @@ public class OPSHandler extends XMLHandler
 
     // If the URL was not properly parsed, return early
     if (url == null) return;
-    // If the URL is an EPUB CFI, return (not implemented)
-    if (url.fragment() != null && url.fragment().matches("epubcfi\\(.*\\)"))
-    {
-      return; // temp until cfi implemented
-    }
 
     if ("file".equals(url.scheme()))
     {

--- a/src/main/java/org/w3c/epubcheck/constants/MIMEType.java
+++ b/src/main/java/org/w3c/epubcheck/constants/MIMEType.java
@@ -5,8 +5,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.google.common.base.Optional;
-
 //FIXME 2021 Romain - document
 public enum MIMEType
 {
@@ -22,7 +20,8 @@ public enum MIMEType
   SEARCH_KEY_MAP("application/vnd.epub.search-key-map+xml"),
   SMIL("application/smil+xml"),
   SVG("image/svg+xml"),
-  XHTML("application/xhtml+xml");
+  XHTML("application/xhtml+xml"),
+  OTHER("");
 
   private static final Map<String, MIMEType> ENUM_MAP;
 
@@ -53,8 +52,8 @@ public enum MIMEType
     ENUM_MAP = Collections.unmodifiableMap(map);
   }
 
-  public static Optional<MIMEType> get(String name)
+  public static MIMEType get(String name)
   {
-    return Optional.fromNullable(ENUM_MAP.get(name.toLowerCase(Locale.ENGLISH)));
+    return ENUM_MAP.getOrDefault(name.toLowerCase(Locale.ROOT), OTHER);
   }
 }

--- a/src/main/java/org/w3c/epubcheck/constants/MIMEType.java
+++ b/src/main/java/org/w3c/epubcheck/constants/MIMEType.java
@@ -54,6 +54,6 @@ public enum MIMEType
 
   public static MIMEType get(String name)
   {
-    return ENUM_MAP.getOrDefault(name.toLowerCase(Locale.ROOT), OTHER);
+    return (name != null) ? ENUM_MAP.getOrDefault(name.toLowerCase(Locale.ROOT), OTHER) : OTHER;
   }
 }

--- a/src/main/java/org/w3c/epubcheck/core/CheckerFactory.java
+++ b/src/main/java/org/w3c/epubcheck/core/CheckerFactory.java
@@ -6,14 +6,13 @@ import com.adobe.epubcheck.bitmap.BitmapChecker;
 import com.adobe.epubcheck.css.CSSChecker;
 import com.adobe.epubcheck.dict.SearchKeyMapChecker;
 import com.adobe.epubcheck.dtbook.DTBookChecker;
-import com.adobe.epubcheck.opf.PublicationResourceChecker;
 import com.adobe.epubcheck.opf.OPFChecker;
 import com.adobe.epubcheck.opf.OPFChecker30;
+import com.adobe.epubcheck.opf.PublicationResourceChecker;
 import com.adobe.epubcheck.opf.ValidationContext;
 import com.adobe.epubcheck.ops.OPSChecker;
 import com.adobe.epubcheck.overlay.OverlayChecker;
 import com.adobe.epubcheck.util.EPUBVersion;
-import com.google.common.base.Optional;
 
 // FIXME 2021 Romain - document
 public final class CheckerFactory
@@ -25,44 +24,41 @@ public final class CheckerFactory
 
   public static Checker newChecker(ValidationContext context)
   {
-    Optional<MIMEType> mimeType = MIMEType.get(context.mimeType);
-    if (mimeType.isPresent())
+    switch (MIMEType.get(context.mimeType))
     {
-      switch (mimeType.get())
-      {
-      case CSS:
-        return new CSSChecker(context);
-      case DTBOOK:
-        return new DTBookChecker(context);
-      case EPUB:
-        // FIXME 2021 Romain - ValidationContext-based EPUB checker will come later
-        break;
-      case HTML:
-        if (context.version == EPUBVersion.VERSION_2) return new OPSChecker(context);
-        break;
-      case IMAGE_GIF:
-      case IMAGE_JPEG:
-      case IMAGE_PNG:
-        return new BitmapChecker(context);
-      case OEBPS:
-        if (context.version == EPUBVersion.VERSION_2) return new OPSChecker(context);
-        break;
-      case PACKAGE_DOC:
-        return (context.version == EPUBVersion.VERSION_2) ? new OPFChecker(context)
-            : new OPFChecker30(context);
-      case SEARCH_KEY_MAP:
-        if (context.version == EPUBVersion.VERSION_3) return new SearchKeyMapChecker(context);
-        break;
-      case SVG:
-        return new OPSChecker(context);
-      case SMIL:
-        if (context.version == EPUBVersion.VERSION_3) return new OverlayChecker(context);
-        break;
-      case XHTML:
-        return new OPSChecker(context);
-      default:
-        break;
-      }
+    case CSS:
+      return new CSSChecker(context);
+    case DTBOOK:
+      return new DTBookChecker(context);
+    case EPUB:
+      // FIXME 2021 Romain - ValidationContext-based EPUB checker will come
+      // later
+      break;
+    case HTML:
+      if (context.version == EPUBVersion.VERSION_2) return new OPSChecker(context);
+      break;
+    case IMAGE_GIF:
+    case IMAGE_JPEG:
+    case IMAGE_PNG:
+      return new BitmapChecker(context);
+    case OEBPS:
+      if (context.version == EPUBVersion.VERSION_2) return new OPSChecker(context);
+      break;
+    case PACKAGE_DOC:
+      return (context.version == EPUBVersion.VERSION_2) ? new OPFChecker(context)
+          : new OPFChecker30(context);
+    case SEARCH_KEY_MAP:
+      if (context.version == EPUBVersion.VERSION_3) return new SearchKeyMapChecker(context);
+      break;
+    case SVG:
+      return new OPSChecker(context);
+    case SMIL:
+      if (context.version == EPUBVersion.VERSION_3) return new OverlayChecker(context);
+      break;
+    case XHTML:
+      return new OPSChecker(context);
+    default:
+      break;
     }
     return new PublicationResourceChecker(context);
   }

--- a/src/main/java/org/w3c/epubcheck/url/URLFragment.java
+++ b/src/main/java/org/w3c/epubcheck/url/URLFragment.java
@@ -1,0 +1,410 @@
+package org.w3c.epubcheck.url;
+
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.w3c.epubcheck.constants.MIMEType;
+
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+
+import io.mola.galimatias.URL;
+import io.mola.galimatias.URLUtils;
+import net.sf.saxon.om.NameChecker;
+
+/**
+ * Represents a URL fragment, after parsing micro-syntaxes.
+ */
+public class URLFragment
+{
+
+  /**
+   * Represents a non-existent fragment, for which {@link #exists()} returns
+   * <code>false</code>
+   */
+  public static final URLFragment NONE = new URLFragment(new Parser().parse(null, null));
+
+  private final String fragment;
+  private final String scheme;
+  private final String id;
+  private final boolean isMediaFragment;
+  private final boolean isValid;
+
+  private URLFragment(Parser parser)
+  {
+    this.fragment = parser.fragment;
+    this.id = Strings.nullToEmpty(parser.id);
+    this.scheme = Strings.nullToEmpty(parser.scheme);
+    this.isMediaFragment = parser.isMediaFragment;
+    this.isValid = parser.isValid;
+  }
+
+  /**
+   * Returns the element ID represented by this fragment if this is an ID-based
+   * fragment, or the empty string otherwise.
+   * 
+   * @return an element ID or the empty string.
+   */
+  public String getId()
+  {
+    return id;
+  }
+
+  /**
+   * Returns the scheme represented by this fragment if this is an scheme-based
+   * fragment, or the empty string otherwise.
+   * 
+   * @return a scheme name or the empty string.
+   */
+  public String getScheme()
+  {
+    return scheme;
+  }
+
+  /**
+   * @return <code>true</code> iff the URL from which this was parsed had a
+   *           fragment.
+   */
+  public boolean exists()
+  {
+    return fragment != null;
+  }
+
+  /**
+   * @return <code>true</code> iff this fragment is the empty string or
+   *           represents a non-existent fragment.
+   */
+  public boolean isEmpty()
+  {
+    return fragment == null || fragment.isEmpty();
+  }
+
+  /**
+   * @return <code>true</code> iff this fragment is valid according to its
+   *           target MIME type.
+   */
+  public boolean isValid()
+  {
+    return isValid;
+  }
+
+  /**
+   * @return <code>true</code> iff this fragment is a media fragment.
+   */
+  public boolean isMediaFragment()
+  {
+    return isMediaFragment;
+  }
+
+  @Override
+  /**
+   * @return the full fragment string.
+   */
+  public String toString()
+  {
+    return fragment;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(fragment);
+  }
+
+  @Override
+  public boolean equals(Object obj)
+  {
+    if (this == obj) return true;
+    if (obj == null) return false;
+    if (getClass() != obj.getClass()) return false;
+    URLFragment other = (URLFragment) obj;
+    return Objects.equals(fragment, other.fragment);
+  }
+
+  /**
+   * Parse the fragment of the given URL, according to the rules defined for the
+   * given MIME type.
+   * 
+   * If the URL has no fragment, returns {@link #NONE}
+   * 
+   * <h2>HTML types "application/xhtml+xml" and "text/html"</h2>
+   *
+   * <p>
+   * The following fragment patterns are supported:
+   * </p>
+   * 
+   * <ul>
+   * <li>regular ID-based fragments (`#name`)</li>
+   * <li>scheme-based fragments (`#name(something)`)</li>
+   * <li>media fragments (`#name=value`, with name one of
+   * `t|xywh|track|id|xyn|xyr`</li>
+   * <li>fragment directives (`#name:~:text=range`)</li>
+   * </ul>
+   * 
+   * <p>
+   * Note that this deviates from the HTML standard in the following way:
+   * </p>
+   * 
+   * <ul>
+   * <li>HTML does not define specific logic for scheme-based or media
+   * fragments, which must be treated like any other IDs. However, EPUB makes
+   * use of them notably for EPUB CFI or region-based navigation.</li>
+   * <li>Fragment directives (as used in text fragments), is an incubating
+   * standard (at the time of writing) and is likely not well supported by
+   * reading system, but its syntax is specific enough to lower the risk of
+   * false-positive.</li>
+   * </ul>
+   * 
+   * <h2>SVG type "image/svg+xml"</h2>
+   *
+   * <p>
+   * The following fragment patterns are supported:
+   * </p>
+   * 
+   * <ul>
+   * <li>shorthand bare form names (<code>#name</code>). Validation checks that
+   * the name is an XML NCName.</li>
+   * <li>SVG view specification (<code>#svgView(…)</code>). Validation currently
+   * does not look into the parenthesis content.</li>
+   * <li>basic media fragments (<code>#xywh=0,0,50,50</code>). Validation checks
+   * the syntax of spatial and temporal dimensions.</li>
+   * </ul>
+   * 
+   * <h2>Other type</h2>
+   * 
+   * <p>
+   * Any other type is assumed to be XML. The following fragment patterns are
+   * supported:
+   * </p>
+   * 
+   * <ul>
+   * <li>shorthand bare form names (<code>#name</code>). Validation checks that
+   * the name is an XML NCName.</li>
+   * <li>scheme-based fragments (`#name(something)`). No validation of the
+   * scheme name or syntax.</li>
+   * </ul>
+   * 
+   * @param url
+   *          a URL
+   * @param mimetype
+   *          the MIME type of the URL target
+   * @return a parsed fragment (cannot be <code>null</code>)
+   */
+  public static URLFragment parse(URL url, String mimetype)
+  {
+    if (url == null || url.fragment() == null)
+    {
+      return NONE;
+    }
+    else
+    {
+      return new URLFragment(new Parser().parse(url.fragment(), mimetype));
+    }
+  }
+
+  /**
+   * Parse the fragment of the given URL, according to the default rules (XML
+   * MIME type), see {@link URLFragment#parse(URL, String)}.
+   * 
+   * @param url
+   *          a URL
+   * @return a parsed fragment (cannot be<code>null</code>)
+   */
+  public static URLFragment parse(URL url)
+  {
+    return parse(url, "");
+  }
+
+  private static final class Parser
+  {
+    private String fragment;
+    private String scheme;
+    private String id;
+    private boolean isMediaFragment = false;
+    private boolean isValid = true;
+
+    /*
+     * Parse the fragment, by dispatching to a type-specific method.
+     * 
+     * Note (2022): parsing would likely be more efficient if implemented as a
+     * state parser instead of using regex-based string matching.
+     */
+    private Parser parse(String fragment, String mimetype)
+    {
+      this.fragment = fragment;
+      if (fragment != null)
+      {
+        switch (MIMEType.get(mimetype))
+        {
+        case SVG:
+          parseSVGFragment(fragment);
+          break;
+        case HTML:
+        case XHTML:
+          parseHTMLFragment(fragment);
+          break;
+        default:
+          parseXMLFragment(fragment);
+          break;
+        }
+      }
+      return this;
+    }
+
+    private static final Pattern SCHEME_BASED = Pattern.compile("(\\w+)\\(.*\\)");
+    private static final Pattern MEDIA_FRAGMENT = Pattern
+        .compile("(t|xywh|track|id|xyn|xyr)=[^&]+(&[^&=]+=[^&]+)*");
+
+    // Parses an XML fragment identifier
+    private void parseXMLFragment(String fragment)
+    {
+      Matcher matcher;
+      // Schema based
+      if ((matcher = SCHEME_BASED.matcher(fragment)).matches())
+      {
+        this.scheme = matcher.group(1);
+      }
+      // ID fragment
+      else
+      {
+        this.id = URLUtils.percentDecode(fragment);
+        this.isValid = NameChecker.isValidNCName(id);
+      }
+    }
+
+    /*
+     * Parses an HTML fragment identifier
+     */
+    private void parseHTMLFragment(String fragment)
+    {
+      Matcher matcher;
+      // strip fragment directive
+      // see https://wicg.github.io/scroll-to-text-fragment/
+      int index;
+      if ((index = fragment.indexOf(":~:")) > -1)
+      {
+        fragment = fragment.substring(0, index);
+      }
+      // scheme-based fragment
+      if ((matcher = SCHEME_BASED.matcher(fragment)).matches())
+      {
+        this.scheme = matcher.group(1);
+      }
+      // media fragment
+      else if ((matcher = MEDIA_FRAGMENT.matcher(fragment)).matches())
+      {
+        this.isMediaFragment = true;
+      }
+      // ID fragment
+      else
+      {
+        this.id = URLUtils.percentDecode(fragment);
+      }
+    }
+
+    /*
+     * Parses an SVG fragment identifier, see:
+     * https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiersDefinitions
+     */
+    private void parseSVGFragment(String fragment)
+    {
+
+      if (fragment.isEmpty()) return;
+
+      // Split the fragment into &-separated components
+      Iterator<String> components = Splitter.on('&').split(fragment).iterator();
+      String first = components.next();
+
+      // SVG view specification
+      if (first.startsWith("svgView("))
+      {
+        // check the SVG view is well-formed
+        isValid = parseSVGView(first);
+        // check optional remaining components are well-formed time segments
+        while (isValid && components.hasNext())
+        {
+          isValid = parseTimeSegment(components.next());
+        }
+      }
+      // Temporal media fragment
+      else if (first.startsWith("t="))
+      {
+        isMediaFragment = true;
+        // check the first component is a well-formed time segment
+        isValid = parseTimeSegment(first);
+        // check optional remaining components are well-formed space segments
+        while (isValid && components.hasNext())
+        {
+          isValid = parseSpaceSegment(components.next());
+        }
+      }
+      // Spatial media fragment
+      else if (first.startsWith("xywh="))
+      {
+        isMediaFragment = true;
+        // check the first component is a well-formed space segment
+        isValid = parseSpaceSegment(first);
+        // check optional remaining components are well-formed time segments
+        while (isValid && components.hasNext())
+        {
+          isValid = parseTimeSegment(components.next());
+        }
+      }
+      else if (first.contains("="))
+      {
+        isValid = false;
+      }
+      // Shorthand bare name
+      else
+      {
+        // Record the ID, percent-decoded
+        this.id = URLUtils.percentDecode(first);
+        // check validity of the ID
+        this.isValid = NameChecker.isValidNCName(id);
+        // check optional remaining components are well-formed time segments
+        while (isValid && components.hasNext())
+        {
+          isValid = parseTimeSegment(components.next());
+        }
+      }
+    }
+
+    private static final Pattern SVGVIEW = Pattern.compile("svgView\\(.+\\)");
+
+    private boolean parseSVGView(String string)
+    {
+      return isValid = SVGVIEW.matcher(string).matches();
+    }
+
+    private static final Pattern SPATIAL = Pattern
+        .compile("xywh=(pixel:|percent:)?\\d+,\\d+,\\d+,\\d+");
+
+    private boolean parseSpaceSegment(String string)
+    {
+      return isValid = SPATIAL.matcher(string).matches();
+    }
+
+    private static final Pattern TEMPORAL = Pattern
+        .compile("t=(?:npt:)?(?:([0-9.:]+)(?:,([0-9.:]+))?|,([0-9.:]+))");
+    private static final Pattern NPTTIME = Pattern
+        .compile("((\\d+)|([0-5]\\d:[0-5]\\d)|(\\d+:[0-5]\\d:[0-5]\\d))(\\.\\d*)?");
+
+    private boolean parseTimeSegment(String string)
+    {
+      Matcher matcher = TEMPORAL.matcher(string);
+      if (isValid = matcher.matches())
+      {
+        int i = 1;
+        while (isValid && i <= matcher.groupCount())
+        {
+          isValid = matcher.group(i) == null || NPTTIME.matcher(matcher.group(i)).matches();
+          i++;
+        }
+      }
+      return isValid;
+    }
+  }
+
+}

--- a/src/test/java/org/w3c/epubcheck/url/URLFragmentSteps.java
+++ b/src/test/java/org/w3c/epubcheck/url/URLFragmentSteps.java
@@ -1,0 +1,67 @@
+package org.w3c.epubcheck.url;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+
+import org.w3c.epubcheck.constants.MIMEType;
+
+import com.google.common.base.Enums;
+
+import io.cucumber.java.en.Then;
+import io.mola.galimatias.GalimatiasParseException;
+import io.mola.galimatias.URL;
+
+public class URLFragmentSteps
+{
+
+  private static final URL BASE_URL = URL.fromJavaURI(URI.create("https://example.org"));
+
+  private URLFragment result;
+
+  @Then("{string} is a {} {} fragment")
+  public void testSVGFragment(String fragment, String validity, String type)
+  {
+    result = parse(fragment,
+        Enums.getIfPresent(MIMEType.class, type).or(MIMEType.OTHER).toString());
+    assertThat((result.isValid()) ? "valid" : "invalid", is(validity));
+  }
+
+  @Then("it indicates an element with ID {string}")
+  public void assertID(String id)
+  {
+    assertThat(result.getId(), is(id));
+  }
+
+  @Then("it does not indicate an element")
+  public void assertIDIsEmpty()
+  {
+    assertThat(result.getId(), is(emptyString()));
+  }
+
+  @Then("it is a media fragment")
+  public void assertMediaFragment()
+  {
+    assertTrue(result.isMediaFragment());
+  }
+
+  @Then("it has scheme {string}")
+  public void assertScheme(String scheme)
+  {
+    assertThat(result.getScheme(), is(scheme));
+  }
+
+  private URLFragment parse(String fragment, String mimetype)
+  {
+    try
+    {
+      return URLFragment.parse(BASE_URL.withFragment(fragment), mimetype);
+    } catch (GalimatiasParseException e)
+    {
+      throw new AssertionError("Could not create URL with fragment " + fragment, e);
+    }
+  }
+}

--- a/src/test/resources/epub-previews/files/epub/preview-embedded-link-cfi-error/EPUB/package.opf
+++ b/src/test/resources/epub-previews/files/epub/preview-embedded-link-cfi-error/EPUB/package.opf
@@ -24,6 +24,6 @@
     <link href="content_002.xhtml" media-type="application/xhtml+xml"/>
     <link href="style.css" media-type="text/css"/>
   </collection>
-  <link href="content_001.xhtml#epubcfi(/6/2!/4/2/1:3"/>
+  <link href="content_001.xhtml#epubcfi(/6/2!/4/2/1:3)"/>
 </collection>
 </package>

--- a/src/test/resources/unit-tests/url-fragment.feature
+++ b/src/test/resources/unit-tests/url-fragment.feature
@@ -1,0 +1,105 @@
+Feature: URL fragment parser
+  
+  Tests the parser for URL fragments
+    
+  Scenario Outline: HTML ID-based fragment <fragment>
+		* <fragment> is a valid HTML fragment
+		And it indicates an element with ID <id>
+
+    Scenarios:
+      | fragment        | id   |
+      | "id"            | "id" |
+      | "%40%40"        | "@@" |
+      | "id:~:text=a,b" | "id" |
+
+    Scenarios: Text fragments (experimental)
+      | fragment         |  id  |
+      | "id:~:text=a,b"  | "id" |
+      | ":~:text=a,b"    |  ""  |
+
+    Scenarios: "invalid" non-ID-based fragments are processed as IDs
+      | fragment   |  id         |
+      | "foo=bar"  |  "foo=bar"  |
+      | "epubcfi(" |  "epubcfi(" |
+
+
+  Scenario Outline: HTML scheme-based fragment <fragment>
+		* <fragment> is a valid HTML fragment
+		And it has scheme <scheme>
+		And it does not indicate an element
+
+    Scenarios:
+      | fragment            |   scheme   |
+      | "xpointer(id(foo))" | "xpointer" |
+      | "epubcfi(/6/4[chap01ref]!/4[body01])" |  "epubcfi"  |
+
+  Scenario Outline: HTML media fragment <fragment>
+		* <fragment> is a valid HTML fragment
+		And it is a media fragment
+		And it does not indicate an element
+
+    Scenarios:
+      | fragment       |
+      | "xywh=1,1,1,1" |
+      | "t=10"         |
+      | "track=audio"  |
+      | "id=foo"       |
+
+  Scenario Outline: SVG shorthand fragment <fragment>
+		* <fragment> is a <validity> SVG fragment
+		And it indicates an element with ID <id>
+
+    Scenarios: Shorthand fragments
+      
+      | fragment         | validity |  id   |
+      | "id"             |  valid   | "id"  |
+      | "id&t=10"        |  valid   | "id"  |
+      | "id&t=10&t=5"    |  valid   | "id"  |
+      | "id&foo=bar"     | invalid  | "id"  |
+      | "id&t="          | invalid  | "id"  |
+      | "id&"            | invalid  | "id"  |
+      | "*id"            | invalid  | "*id" | (not an NCName)
+      | "%40%40"         | invalid  | "@@"  | (not an NCName)
+    
+    
+  Scenario Outline: SVG media fragment <fragment>
+		* <fragment> is a <validity> SVG fragment
+		
+    Scenarios: Temporal media fragment
+      | fragment             | validity |
+      | "t=npt:10,20"        |  valid   |
+      | "t=npt:,121.5"       |  valid   |
+      | "t=0:02:00,121.5"    |  valid   |
+      | "t=npt:120,0:02:01." |  valid   |
+      | "t=60:00"            | invalid  |
+      | "t=00:99"            | invalid  |
+      | "t=123:00:00"        |  valid   |
+      | "t=10&xywh=0,0,1,1"  |  valid   |
+		
+    Scenarios: Spatial media fragment
+      | fragment                     | validity |
+      | "xywh=160,120,320,240"       |  valid   |
+      | "xywh=pixel:160,120,320,240" |  valid   |
+      | "xywh=percent:25,25,50,50"   |  valid   |
+      | "xywh=160,120,320"           | invalid  |
+      | "xywh=px:160,120,320,240"    | invalid  |
+		
+    Scenarios: SVG view specification
+      | fragment                                 | validity |
+      | "svgView(viewBox(0,0,200,200))"          |  valid   |
+      | "svgView(preserveAspectRatio(xMidYMid))" |  valid   |
+      | "svgView(transform(scale(5))"            |  valid   |
+      | "svgView()"                              | invalid  |
+      | "svgView(viewBox(0,0,200,200"            | invalid  |
+    
+  Scenario Outline: SVG invalid fragments <fragment>
+    Should not be parsed as legit IDs
+		* <fragment> is a <validity> SVG fragment
+		And it indicates an element with ID <id>
+
+    Scenarios: Unknown or invalid media fragments
+      | fragment  | validity | id  |
+      | "foo=bar" | invalid  | ""  |
+      | "foo="    | invalid  | ""  |
+      | "=foo"    | invalid  | ""  |
+    


### PR DESCRIPTION
This commit introduce a new `URLFragment` class to represent URL fragments.

Fragment strings are parsed into `URLFragment` instances using MIME type-specific logic, implementing some validity checks for a few micro syntaxes
including:

- shortand bare name IDs
- scheme-based fragments
- media fragments

SVG and HTML/XHTML MIME types are supported.

The parser is tested in the `url-fragment.feature` feature file, in a new `unit-tests` directory.