### PR TITLE
fix: support CSS logical combination pseudo-classes

### DIFF
--- a/src/main/java/org/idpf/epubcheck/util/css/ForgivingErrorHandler.java
+++ b/src/main/java/org/idpf/epubcheck/util/css/ForgivingErrorHandler.java
@@ -1,0 +1,17 @@
+package org.idpf.epubcheck.util.css;
+
+import org.idpf.epubcheck.util.css.CssExceptions.CssException;
+
+public final class ForgivingErrorHandler implements CssErrorHandler
+{
+
+  public static final ForgivingErrorHandler INSTANCE = new ForgivingErrorHandler();
+
+  @Override
+  public void error(CssException e)
+    throws CssException
+  {
+    // do nothing
+  }
+
+}

--- a/src/test/resources/epub3/00-minimal/minimal.feature
+++ b/src/test/resources/epub3/00-minimal/minimal.feature
@@ -8,7 +8,6 @@
     Given EPUB test files located at '/epub3/00-minimal/files/'
     And EPUBCheck with default settings
 
-
   Scenario: Verify a minimal expanded EPUB
     When checking EPUB 'minimal'
     Then no errors or warnings are reported

--- a/src/test/resources/epub3/06-content-document/files/content-css-selectors-valid/EPUB/style.css
+++ b/src/test/resources/epub3/06-content-document/files/content-css-selectors-valid/EPUB/style.css
@@ -29,3 +29,23 @@ p > span:nth-child(even) {
 div[epub|type = "chapter"] {
   padding: 2em;
 }
+
+:active {
+  font-size: 1em;
+}
+
+:is(h1,h2,h3) {
+  font-size: 1em;
+}
+
+:not(nav[epub|type="landmarks"]) {
+  font-size: 1em;
+}
+
+:not(nav.class) {
+  font-size: 1em;
+}
+
+:has(>img) {
+  font-size: 1em;
+}


### PR DESCRIPTION
This commit update the CSS grammar parser to support funcitonal pseudo- classes taking selector listrs as argument.

In effect, this impacts the parsing of the following pseudo-classes:
- `:is()` (taking a forgiving selector list)
- `:not()` (taking a selector list)
- `:where()` (taking a forgiving selector list)
- `:has()` (taking a forgiving relative selector list)

Fixes #1289, Fixes #1354