### PR TITLE
test: add test for internationalized domain names in URLs

### DIFF
--- a/src/test/resources/epub3/06-content-document/files/a-href-valid.xhtml
+++ b/src/test/resources/epub3/06-content-document/files/a-href-valid.xhtml
@@ -8,5 +8,8 @@
 		<h1>Test</h1>
 		<!--	This list of hyperlinks can be extended for testing purposes	-->
 		<a href="mailto:abc%7C@example.com">email me</a>
+		<a href="https://ü.example.org">internationalize domain name</a>
+		<a href="https://微博.example.org/">internationalize domain name</a>
+		<a href="https://%C3%BC.example.org/">internationalize domain name</a>
 	</body>
 </html>


### PR DESCRIPTION
IDN are now accepted, since relying on the Galimatias URL parser.

Close #1277, close #1280