### PR TITLE
fix: declaring prefixes for default vocabs is an error

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -199,7 +199,7 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.OPF_006, Severity.ERROR);
     severities.put(MessageId.OPF_007, Severity.WARNING);
     severities.put(MessageId.OPF_007a, Severity.ERROR);
-    severities.put(MessageId.OPF_007b, Severity.WARNING);
+    severities.put(MessageId.OPF_007b, Severity.ERROR);
     severities.put(MessageId.OPF_008, Severity.ERROR);
     severities.put(MessageId.OPF_009, Severity.ERROR);
     severities.put(MessageId.OPF_010, Severity.ERROR);

--- a/src/test/java/com/adobe/epubcheck/vocab/VocabTest.java
+++ b/src/test/java/com/adobe/epubcheck/vocab/VocabTest.java
@@ -375,7 +375,7 @@ public class VocabTest
   @Test
   public void testDefaultDeclaredPrefix()
   {
-    expectedWarnings.add(MessageId.OPF_007b);
+    expectedErrors.add(MessageId.OPF_007b);
     Map<String, Vocab> actual = testVocabs(
         "default: http://example.org/default# hello: http://example.org/hello#");
     assertThat(actual.entrySet().size(), is(PREDEF_VOCABS.keySet().size() + 1));

--- a/src/test/resources/epub3/D-vocabularies/vocabulary-association.feature
+++ b/src/test/resources/epub3/D-vocabularies/vocabulary-association.feature
@@ -27,10 +27,8 @@ Feature: EPUB 3 — Vocabularies — Vocabulary association
 
   @spec @xref:sec-prefix-attr
   Scenario: default vocabularies must not be assigned a prefix
-  	Note: This should be an error, but is currently reported as a warning
-  	See issue 522: https://github.com/w3c/epubcheck/issues/522
     When checking file 'property-prefix-declaration-default-vocabs-error.opf'
-    Then warning OPF-007b is reported 4 times (once for each default vocabulary)
+    Then error OPF-007b is reported 4 times (once for each default vocabulary)
     And no other errors or warnings are reported
 
   @spec @xref:sec-prefix-attr


### PR DESCRIPTION
This commit reverts `OPF-007b` to being an error.

Fixes #1306