### PR TITLE
feat: update checking of the package rendering vocabulary

### DIFF
--- a/src/main/java/com/adobe/epubcheck/opf/OPFHandler30.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFHandler30.java
@@ -58,6 +58,7 @@ import org.w3c.epubcheck.url.URLUtils;
 
 import com.adobe.epubcheck.api.EPUBLocation;
 import com.adobe.epubcheck.api.QuietReport;
+import com.adobe.epubcheck.messages.LocalizedMessages;
 import com.adobe.epubcheck.messages.MessageId;
 import com.adobe.epubcheck.opf.ResourceCollection.Roles;
 import com.adobe.epubcheck.opf.XRefChecker.Type;
@@ -592,8 +593,9 @@ public class OPFHandler30 extends OPFHandler
 
     if (prop.isPresent() && !metadataBuilders.isEmpty())
     {
+      String value = Strings.nullToEmpty((String) e.getPrivateData()).trim();
       metadataBuilders.peekFirst().meta(e.getAttribute("id"), prop.get(),
-          (String) e.getPrivateData(), e.getAttribute("refines"));
+          value, e.getAttribute("refines"));
 
       // Primary metadata checks
       if (metadataBuilders.size() == 1)
@@ -607,6 +609,14 @@ public class OPFHandler30 extends OPFHandler
         case "media:playback-active-class":
           context.featureReport.report(FeatureEnum.MEDIA_OVERLAYS_PLAYBACK_ACTIVE_CLASS, location(),
               e.getPrivateData().toString());
+          break;
+        case "rendition:spread":
+          if (value.equals("portrait"))
+          {
+            report.message(MessageId.OPF_086, location(), "rendition:spread portrait",
+                LocalizedMessages.getInstance(context.locale)
+                    .getSuggestion(MessageId.OPF_086, null));
+          }
           break;
         default:
           break;

--- a/src/main/java/com/adobe/epubcheck/vocab/RenditionVocabs.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/RenditionVocabs.java
@@ -1,43 +1,96 @@
 package com.adobe.epubcheck.vocab;
 
+import com.adobe.epubcheck.opf.ValidationContext;
+import com.google.common.base.Preconditions;
+
 public final class RenditionVocabs
 {
   public static final String PREFIX = "rendition";
   public static final String URI = "http://www.idpf.org/vocab/rendition/#";
 
   public static final EnumVocab<META_PROPERTIES> META_VOCAB = new EnumVocab<META_PROPERTIES>(
-      META_PROPERTIES.class, URI);
+      META_PROPERTIES.class, URI, PREFIX);
 
-  public enum META_PROPERTIES
+  public enum META_PROPERTIES implements PropertyStatus
   {
-    FLOW,
     LAYOUT,
     ORIENTATION,
     SPREAD,
-    VIEWPORT
+    VIEWPORT(DEPRECATED),
+    FLOW;
+
+    private final PropertyStatus status;
+
+    private META_PROPERTIES()
+    {
+      this(ALLOWED);
+    }
+
+    private META_PROPERTIES(PropertyStatus status)
+    {
+      this.status = Preconditions.checkNotNull(status);
+    }
+
+    @Override
+    public boolean isAllowed(ValidationContext context)
+    {
+      return status.isAllowed(context);
+    }
+
+    @Override
+    public boolean isDeprecated()
+    {
+      return status.isDeprecated();
+    }
   }
 
   public static final EnumVocab<ITEMREF_PROPERTIES> ITEMREF_VOCAB = new EnumVocab<ITEMREF_PROPERTIES>(
       ITEMREF_PROPERTIES.class, URI);
 
-  public enum ITEMREF_PROPERTIES
+  public enum ITEMREF_PROPERTIES implements PropertyStatus
   {
-    ALIGN_X_CENTER,
-    FLOW_AUTO,
-    FLOW_PAGINATED,
-    FLOW_SCROLLED_CONTINUOUS,
-    FLOW_SCROLLED_DOC,
     LAYOUT_PRE_PAGINATED,
     LAYOUT_REFLOWABLE,
     ORIENTATION_AUTO,
     ORIENTATION_LANDSCAPE,
     ORIENTATION_PORTRAIT,
-    PAGE_SPREAD_CENTER,
     SPREAD_AUTO,
     SPREAD_BOTH,
     SPREAD_LANDSCAPE,
     SPREAD_NONE,
-    SPREAD_PORTRAIT
+    SPREAD_PORTRAIT(DEPRECATED),
+    PAGE_SPREAD_CENTER,
+    PAGE_SPREAD_LEFT,
+    PAGE_SPREAD_RIGHT,
+    FLOW_PAGINATED,
+    FLOW_SCROLLED_CONTINUOUS,
+    FLOW_SCROLLED_DOC,
+    FLOW_AUTO,
+    ALIGN_X_CENTER;
+
+    private final PropertyStatus status;
+
+    private ITEMREF_PROPERTIES()
+    {
+      this(ALLOWED);
+    }
+
+    private ITEMREF_PROPERTIES(PropertyStatus status)
+    {
+      this.status = Preconditions.checkNotNull(status);
+    }
+
+    @Override
+    public boolean isAllowed(ValidationContext context)
+    {
+      return status.isAllowed(context);
+    }
+
+    @Override
+    public boolean isDeprecated()
+    {
+      return status.isDeprecated();
+    }
   }
 
   private RenditionVocabs()

--- a/src/main/resources/com/adobe/epubcheck/schema/30/package-30.sch
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/package-30.sch
@@ -455,24 +455,8 @@
 		</rule>
 	</pattern>
 	
-	<pattern id="opf.meta.viewport.deprecated">
-		<rule context="opf:metadata/opf:meta[normalize-space(@property)='rendition:viewport']">
-			<report test=".">WARNING: Use of the rendition:viewport property is deprecated</report>
-		</rule>
-	</pattern>
-	
-	<pattern id="opf.meta.spread.portrait.deprecated">
-		<rule context="opf:metadata/opf:meta[normalize-space(@property)='rendition:spread']">
-			<report test=". = 'portrait'">WARNING: Use of the rendition:spread value "portrait" is deprecated in favour of the value "both"</report>
-		</rule>
-	</pattern>
-	
-	<pattern id="opf.itemref.spread.portrait.deprecated">
-		<rule context="opf:spine/opf:itemref[@properties]">
-			<report test="tokenize(@properties,'\s+')='rendition:spread-portrait'">WARNING: Use of the "rendition:spread-portrait" spine override is deprecated in favour of "rendition:spread-both"</report>
-		</rule>
-	</pattern>
-	
+
+  <!--FIXME deprecation should be in vocab-->
 	<pattern id="opf.meta.meta-auth.deprecated">
 		<rule context="opf:metadata/opf:meta[normalize-space(@property)='meta-auth']">
 			<report test=".">WARNING: Use of the meta-auth property is deprecated</report>

--- a/src/test/resources/epub3/08-layout/layout.feature
+++ b/src/test/resources/epub3/08-layout/layout.feature
@@ -140,6 +140,12 @@ Feature: EPUB 3 — Layout Rendering Control
     And the message contains "refines"
     And no other errors or warnings are reported
 
+  @spec @xref:spread
+  Scenario: the 'rendition:spread' 'portrait' value is deprecated as a global value
+    When checking file 'rendition-spread-portrait-global-deprecated-warning.opf'
+    Then warning OPF-086 is reported
+    And no other errors or warnings are reported
+
   #### 8.2.2.3.1 Synthetic spread overrides
   
   @spec @xref:spread-overrides
@@ -152,18 +158,6 @@ Feature: EPUB 3 — Layout Rendering Control
     When checking file 'rendition-spread-itemref-conflict-error.opf'
     Then error RSC-005 is reported
     And the message contains "are mutually exclusive"
-    And no other errors or warnings are reported
-
-  Scenario: the 'rendition:spread' 'portrait' value is deprecated as a global value
-    When checking file 'rendition-spread-portrait-global-deprecated-warning.opf'
-    Then warning RSC-017 is reported
-    And the message contains "is deprecated"
-    And no other errors or warnings are reported
-
-  Scenario: the 'rendition:spread' 'spread-portrait' value is deprecated as a spine override
-    When checking file 'rendition-spread-portrait-itemref-deprecated-warning.opf'
-    Then warning RSC-017 is reported
-    And the message contains "is deprecated"
     And no other errors or warnings are reported
 
 
@@ -181,25 +175,31 @@ Feature: EPUB 3 — Layout Rendering Control
     And the message contains "are mutually exclusive"
     And no other errors or warnings are reported
 
+  @spec @xref:spread
+  Scenario: the 'rendition:spread-portrait' value is deprecated as a spine override
+    When checking file 'rendition-spread-portrait-itemref-deprecated-warning.opf'
+    Then warning OPF-086 is reported
+    And no other errors or warnings are reported
+
 
   #### 8.2.2.5 Viewport dimensions (deprecated)
 
+	@spec @xref:viewport
   Scenario: the 'rendition:viewport' property is deprecated
     When checking file 'rendition-viewport-deprecated-warning.opf'
-    Then warning RSC-017 is reported
-    And the message contains "is deprecated"
+    Then warning OPF-086 is reported
     And no other errors or warnings are reported
 
   Scenario: the 'rendition:viewport' property syntax errors are reported
     When checking file 'rendition-viewport-syntax-error.opf'
-    Then warning RSC-017 is reported (since 'viewport' is deprecated)
+    Then warning OPF-086 is reported (since 'viewport' is deprecated)
     And error RSC-005 is reported
     And the message contains 'The value of the "rendition:viewport" property must be of the form'
     And no other errors or warnings are reported
 
   Scenario: the 'rendition:viewport' property cannot be declared more than once
     When checking file 'rendition-viewport-duplicate-error.opf'
-    Then warning RSC-017 is reported 2 times (since 'viewport' is deprecated)
+    Then warning OPF-086 is reported 2 times (since 'viewport' is deprecated)
     And error RSC-005 is reported
     And the message contains 'The "rendition:viewport" property must not occur more than one time as a global value'
     And no other errors or warnings are reported

--- a/src/test/resources/epub3/D-vocabularies/files/rendition-property-unknown-error.opf
+++ b/src/test/resources/epub3/D-vocabularies/files/rendition-property-unknown-error.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
+  xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata>
+    <dc:identifier id="uid">NOID</dc:identifier>
+    <dc:title>Title</dc:title>
+    <dc:language>en</dc:language>
+    <meta property="dcterms:modified">2019-01-01T12:00:00Z</meta>
+    <meta property="rendition:unknown">error</meta>
+  </metadata>
+  <manifest>
+    <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="t001"/>
+  </spine>
+</package>

--- a/src/test/resources/epub3/D-vocabularies/package-rendering-vocab.feature
+++ b/src/test/resources/epub3/D-vocabularies/package-rendering-vocab.feature
@@ -1,0 +1,24 @@
+Feature: EPUB 3 — Vocabularies — Package rendering vocabulary
+
+
+  Checks conformance to the "Package rendering vocabulary" section of the EPUB 3.3 specification:
+    https://www.w3.org/TR/epub-33/#app-rendering-vocab
+
+
+  Background: 
+    Given EPUB test files located at '/epub3/D-vocabularies/files/'
+    And EPUBCheck with default settings
+    
+  # Note: 
+  # The properties themselves are tested in the "layout.feature" file,
+  # since all the properties are defined in that section and not in the
+  # vocabulary appendix.
+
+  # D.5.1 Package rendering vocabulary
+
+  @spec @xref:sec-rendering-custom-properties
+  Scenario: Report a custom rendition property using the 'rendition' prefix
+    When checking file 'rendition-property-unknown-error.opf'
+    Then error OPF-027 is reported
+    And no other errors or warnings are reported
+  


### PR DESCRIPTION
- deprecated properties are now reported as `OPF-086`, like for other deprecated properties, instead of `RSC-017`. This means the check relies on the `Property#isDeprecated` facility, instead of custom Schematron code.
- deprecated property value is checked in custom Java code the `OPFHandler30#processMeta()` method.
- verify that custom properties cannot be defined using the reserved "rendition" prefix. A new feature file is added for this single test, to match the spec section ordering.

Fix #1327