### PR TITLE
feat: warn about non-HTTPS remote resource references

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -347,6 +347,7 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.RSC_028, Severity.ERROR);
     severities.put(MessageId.RSC_029, Severity.ERROR);
     severities.put(MessageId.RSC_030, Severity.ERROR);
+    severities.put(MessageId.RSC_031, Severity.WARNING);
 
     // Scripting
     severities.put(MessageId.SCP_001, Severity.SUPPRESSED); // checking scripts is out of scope

--- a/src/main/java/com/adobe/epubcheck/messages/MessageId.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageId.java
@@ -341,6 +341,7 @@ public enum MessageId implements Comparable<MessageId>
   RSC_028("RSC-028"),
   RSC_029("RSC-029"),
   RSC_030("RSC-030"),
+  RSC_031("RSC-031"),
 
   // Messages relating to scripting
   SCP_001("SCP-001"),

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -356,6 +356,7 @@ RSC_027=XML document is encoded in UTF-16. It should be encoded in UTF-8 instead
 RSC_028=XML documents must be encoded in UTF-8, but %1%s was detected.
 RSC_029=Data URL is not allowed in this context.
 RSC_030=File URLs are not allowed in EPUB, but found "%1$s".
+RSC_031=Remote resource references should use HTTPS, but found "%1$s".
 
 #Scripting
 SCP_001=Use of Javascript eval() function in EPUB scripts is a security risk.

--- a/src/test/resources/epub3/03-resources/files/resources-remote-audio-sources-foreign-valid/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/03-resources/files/resources-remote-audio-sources-foreign-valid/EPUB/content_001.xhtml
@@ -7,8 +7,8 @@
 	<body>
 		<!-- remote audio sources, one in a foreign type -->
 		<audio>
-			<source src="http://example.org/remote.foo" />
-			<source src="http://example.org/remote.mp4" />
+			<source src="https://example.org/remote.foo" />
+			<source src="https://example.org/remote.mp4" />
 		</audio>
 	</body>
 </html>

--- a/src/test/resources/epub3/03-resources/files/resources-remote-audio-sources-valid/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/03-resources/files/resources-remote-audio-sources-valid/EPUB/content_001.xhtml
@@ -6,8 +6,8 @@
 	</head>
 	<body>
 		<audio controls="controls">
-			<source src="http://example.com/audio/src-1.mp4" type="audio/mp4"/>
-			<source src="http://example.com/audio/src-2.mp4" type="audio/mp4"/>
+			<source src="https://example.com/audio/src-1.mp4" type="audio/mp4"/>
+			<source src="https://example.com/audio/src-2.mp4" type="audio/mp4"/>
 		</audio>
 	</body>
 </html>

--- a/src/test/resources/epub3/03-resources/files/resources-remote-audio-sources-valid/EPUB/package.opf
+++ b/src/test/resources/epub3/03-resources/files/resources-remote-audio-sources-valid/EPUB/package.opf
@@ -9,8 +9,8 @@
 <manifest>
   <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml" properties="remote-resources"/>
   <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
-  <item id="audio1" href="http://example.com/audio/src-1.mp4" media-type="audio/mp4" />
-  <item id="audio2" href="http://example.com/audio/src-2.mp4" media-type="audio/mp4" />
+  <item id="audio1" href="https://example.com/audio/src-1.mp4" media-type="audio/mp4" />
+  <item id="audio2" href="https://example.com/audio/src-2.mp4" media-type="audio/mp4" />
 </manifest>
 <spine>
   <itemref idref="content_001" />

--- a/src/test/resources/epub3/03-resources/files/resources-remote-audio-valid/EPUB/package.opf
+++ b/src/test/resources/epub3/03-resources/files/resources-remote-audio-valid/EPUB/package.opf
@@ -9,9 +9,8 @@
 <manifest>
   <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml" properties="remote-resources"/>
   <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
-  <item id="audio-1" href="http://example.org/remote.mp4" media-type="audio/mp4" />
-  <item id="audio-2" href="https://example.org/remote.mp4" media-type="audio/mp4" />
-  <item id="audio-3" href="http://example.org/remote.mp4?test" media-type="audio/mp4" />
+  <item id="audio-1" href="https://example.org/remote.mp4" media-type="audio/mp4" />
+  <item id="audio-2" href="https://example.org/remote.mp4?test" media-type="audio/mp4" />
 </manifest>
 <spine>
   <itemref idref="content_001" />

--- a/src/test/resources/epub3/03-resources/files/resources-remote-not-https-warning/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/03-resources/files/resources-remote-not-https-warning/EPUB/content_001.xhtml
@@ -5,9 +5,7 @@
 		<title>Minimal EPUB</title>
 	</head>
 	<body>
-		<!-- remote https URL -->
-		<audio src="https://example.org/remote.mp4" />
-		<!-- remote URL with query -->
-		<audio src="https://example.org/remote.mp4?test" />
+		<audio src="http://example.org/audio.mp4" /><!--not https-->
+		<video src="http://example.org/video.mp4" /><!--not https-->
 	</body>
 </html>

--- a/src/test/resources/epub3/03-resources/files/resources-remote-not-https-warning/EPUB/nav.xhtml
+++ b/src/test/resources/epub3/03-resources/files/resources-remote-not-https-warning/EPUB/nav.xhtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/epub3/03-resources/files/resources-remote-not-https-warning/EPUB/package.opf
+++ b/src/test/resources/epub3/03-resources/files/resources-remote-not-https-warning/EPUB/package.opf
@@ -8,9 +8,12 @@
 </metadata>
 <manifest>
   <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml" properties="remote-resources"/>
+  <item id="css"  href="style.css" media-type="text/css" properties="remote-resources"/>
   <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
-  <item id="audio" href="https://example.org/remote.foo" media-type="audio/foo"/>
-  <item id="audio-fallback" href="https://example.org/remote.mp4" media-type="audio/mp4" /></manifest>
+  <item id="audio" href="http://example.org/audio.mp4" media-type="audio/mp4" />
+  <item id="font"  href="http://example.org/font" media-type="font/woff"/>
+  <item id="video" href="http://example.org/video.mp4" media-type="video/mp4" />
+</manifest>
 <spine>
   <itemref idref="content_001" />
 </spine>

--- a/src/test/resources/epub3/03-resources/files/resources-remote-not-https-warning/EPUB/style.css
+++ b/src/test/resources/epub3/03-resources/files/resources-remote-not-https-warning/EPUB/style.css
@@ -1,0 +1,4 @@
+@font-face {
+  font-family: "Open Sans";
+  src: url("http://example.org/font") format("woff");
+}

--- a/src/test/resources/epub3/03-resources/files/resources-remote-not-https-warning/META-INF/container.xml
+++ b/src/test/resources/epub3/03-resources/files/resources-remote-not-https-warning/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+	<rootfiles>
+		<rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/epub3/03-resources/files/resources-remote-not-https-warning/mimetype
+++ b/src/test/resources/epub3/03-resources/files/resources-remote-not-https-warning/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/src/test/resources/epub3/03-resources/files/resources-remote-video-valid/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/03-resources/files/resources-remote-video-valid/EPUB/content_001.xhtml
@@ -5,11 +5,9 @@
 		<title>Minimal EPUB</title>
 	</head>
 	<body>
-		<!-- remote http URL -->
-		<video src="http://example.org/remote.mp4" />
 		<!-- remote https URL -->
 		<video src="https://example.org/remote.mp4" />
 		<!-- remote URL with query -->
-		<video src="http://example.org/remote.mp4?test" />
+		<video src="https://example.org/remote.mp4?test" />
 	</body>
 </html>

--- a/src/test/resources/epub3/03-resources/files/resources-remote-video-valid/EPUB/package.opf
+++ b/src/test/resources/epub3/03-resources/files/resources-remote-video-valid/EPUB/package.opf
@@ -9,9 +9,8 @@
 <manifest>
   <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml" properties="remote-resources"/>
   <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
-  <item id="video-1" href="http://example.org/remote.mp4" media-type="video/mp4" />
-  <item id="video-2" href="https://example.org/remote.mp4" media-type="video/mp4" />
-  <item id="video-3" href="http://example.org/remote.mp4?test" media-type="video/mp4" />
+  <item id="video-1" href="https://example.org/remote.mp4" media-type="video/mp4" />
+  <item id="video-2" href="https://example.org/remote.mp4?test" media-type="video/mp4" />
 </manifest>
 <spine>
   <itemref idref="content_001" />

--- a/src/test/resources/epub3/03-resources/resources.feature
+++ b/src/test/resources/epub3/03-resources/resources.feature
@@ -385,6 +385,12 @@
     Then error RSC-006 is reported
     And no other errors or warnings are reported
 
+  @spec @xref:sec-resource-locations
+  Scenario: Warn about a remote resource with a non `https` URL
+    When checking EPUB 'resources-remote-not-https-warning'
+    Then warning RSC-031 is reported 3 times
+    And no other errors or warnings are reported
+
   ## 3.7 Data URLs
 
   @spec @xref:sec-data-urls

--- a/src/test/resources/epub3/05-package-document/files/package-manifest-prop-remote-resource-undeclared-error/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/05-package-document/files/package-manifest-prop-remote-resource-undeclared-error/EPUB/content_001.xhtml
@@ -5,7 +5,7 @@
 		<title>Minimal EPUB</title>
 	</head>
 	<body>
-		<video src="http://test.com/lorem.ogg" width="640" height="360" controls="controls">
+		<video src="https://example.org/lorem.ogg" width="640" height="360" controls="controls">
 			Your reader doesn't support video!
 		</video>
 	</body>

--- a/src/test/resources/epub3/05-package-document/files/package-manifest-prop-remote-resource-undeclared-error/EPUB/package.opf
+++ b/src/test/resources/epub3/05-package-document/files/package-manifest-prop-remote-resource-undeclared-error/EPUB/package.opf
@@ -9,7 +9,7 @@
 <manifest>
   <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml"/>
   <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
-  <item id="video" href="http://test.com/lorem.ogg" media-type="video/ogg" />
+  <item id="video" href="https://example.org/lorem.ogg" media-type="video/ogg" />
 </manifest>
 <spine>
   <itemref idref="content_001" />

--- a/src/test/resources/epub3/05-package-document/files/package-remote-audio-in-overlays-missing-property-error/EPUB/chapter_001_overlay.smil
+++ b/src/test/resources/epub3/05-package-document/files/package-remote-audio-in-overlays-missing-property-error/EPUB/chapter_001_overlay.smil
@@ -2,7 +2,7 @@
 	<body>
 		<par id="heading1">
 			<text src="content_001.xhtml#hd01"/>
-			<audio src="http://example.com/audio/c001.mp4" clipBegin="0:00:24.500"/>
+			<audio src="https://example.com/audio/c001.mp4" clipBegin="0:00:24.500"/>
 		</par>
 	</body>
 </smil>

--- a/src/test/resources/epub3/05-package-document/files/package-remote-audio-in-overlays-missing-property-error/EPUB/package.opf
+++ b/src/test/resources/epub3/05-package-document/files/package-remote-audio-in-overlays-missing-property-error/EPUB/package.opf
@@ -12,7 +12,7 @@
 <manifest>
 	<item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml" media-overlay="chapter_001_overlay"/>
 	<item id="chapter_001_overlay" href="chapter_001_overlay.smil" media-type="application/smil+xml"/>
-	<item id="chapter_001_audio" href="http://example.com/audio/c001.mp4" media-type="audio/mp4"/>
+	<item id="chapter_001_audio" href="https://example.com/audio/c001.mp4" media-type="audio/mp4"/>
 	<item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
 </manifest>
 <spine>

--- a/src/test/resources/epub3/05-package-document/files/package-remote-audio-missing-property-error/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/05-package-document/files/package-remote-audio-missing-property-error/EPUB/content_001.xhtml
@@ -6,6 +6,6 @@
 	</head>
 	<body>
 		<!-- remote http URL -->
-		<audio src="http://example.org/remote.mp4" />
+		<audio src="https://example.org/remote.mp4" />
 	</body>
 </html>

--- a/src/test/resources/epub3/05-package-document/files/package-remote-audio-missing-property-error/EPUB/package.opf
+++ b/src/test/resources/epub3/05-package-document/files/package-remote-audio-missing-property-error/EPUB/package.opf
@@ -9,7 +9,7 @@
 <manifest>
   <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml"/>
   <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
-  <item id="audio" href="http://example.org/remote.mp4" media-type="audio/mp4"/>
+  <item id="audio" href="https://example.org/remote.mp4" media-type="audio/mp4"/>
 </manifest>
 <spine>
   <itemref idref="content_001" />

--- a/src/test/resources/epub3/05-package-document/files/package-remote-audio-sources-undeclared-error/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/05-package-document/files/package-remote-audio-sources-undeclared-error/EPUB/content_001.xhtml
@@ -6,8 +6,8 @@
 	</head>
 	<body>
 		<audio controls="controls">
-			<source src="http://example.com/audio/src-1.mp4" type="audio/mp4"/>
-			<source src="http://example.com/audio/src-2.mp4" type="audio/mp4"/>
+			<source src="https://example.com/audio/src-1.mp4" type="audio/mp4"/>
+			<source src="https://example.com/audio/src-2.mp4" type="audio/mp4"/>
 		</audio>
 	</body>
 </html>

--- a/src/test/resources/epub3/05-package-document/files/package-remote-audio-sources-undeclared-error/EPUB/package.opf
+++ b/src/test/resources/epub3/05-package-document/files/package-remote-audio-sources-undeclared-error/EPUB/package.opf
@@ -9,7 +9,7 @@
 <manifest>
   <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml" properties="remote-resources"/>
   <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
-  <item id="audio1" href="http://example.com/audio/src-1.mp4" media-type="audio/mp4" />
+  <item id="audio1" href="https://example.com/audio/src-1.mp4" media-type="audio/mp4" />
   <!--<item id="audio2" href="http://example.com/audio/src-2.mp4" media-type="audio/mp4" />-->
 </manifest>
 <spine>

--- a/src/test/resources/epub3/05-package-document/files/package-remote-audio-undeclared-error/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/05-package-document/files/package-remote-audio-undeclared-error/EPUB/content_001.xhtml
@@ -6,6 +6,6 @@
 	</head>
 	<body>
 		<!-- remote http URL -->
-		<audio src="http://example.org/remote.mp4" />
+		<audio src="https://example.org/remote.mp4" />
 	</body>
 </html>

--- a/src/test/resources/epub3/06-content-document/files/content-xhtml-video-poster-media-type-error/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/06-content-document/files/content-xhtml-video-poster-media-type-error/EPUB/content_001.xhtml
@@ -5,7 +5,7 @@
 		<title>Minimal EPUB</title>
 	</head>
 	<body>
-		<video src="http://test.com/lorem.ogg" width="640" height="360" controls="controls" poster="poster.png">
+		<video src="https://example.org/lorem.ogg" width="640" height="360" controls="controls" poster="poster.png">
 			
 		</video>
 	</body>

--- a/src/test/resources/epub3/06-content-document/files/content-xhtml-video-poster-media-type-error/EPUB/package.opf
+++ b/src/test/resources/epub3/06-content-document/files/content-xhtml-video-poster-media-type-error/EPUB/package.opf
@@ -10,7 +10,7 @@
   <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml" properties="remote-resources"/>
   <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
   <item id="poster" href="poster.png" media-type="text/abc" />
-  <item id="video" href="http://test.com/lorem.ogg" media-type="video/ogg" />
+  <item id="video" href="https://example.org/lorem.ogg" media-type="video/ogg" />
 </manifest>
 <spine>
   <itemref idref="content_001" />


### PR DESCRIPTION
This commit introduces a new check `RSC-031` (warning) that is reported when a reference to a remote resource (font, audio, video) is not using HTTPS.

Fix #1337