### PR TITLE
fix: OPF-018 was incorrectly reported with inline CSS

### DIFF
--- a/src/main/java/com/adobe/epubcheck/css/CSSChecker.java
+++ b/src/main/java/com/adobe/epubcheck/css/CSSChecker.java
@@ -45,7 +45,7 @@ public class CSSChecker extends PublicationResourceChecker
   private int line; // where css string occurs in host
   private final boolean isStyleAttribute;
 
-  private enum Mode
+  enum Mode
   {
     FILE,
     STRING
@@ -94,7 +94,7 @@ public class CSSChecker extends PublicationResourceChecker
     try
     {
 
-      CSSHandler handler = new CSSHandler(context);
+      CSSHandler handler = new CSSHandler(context, mode);
       if (this.mode == Mode.STRING && this.line > -1)
       {
         handler.setStartingLineNumber(this.line);

--- a/src/test/resources/epub3/05-package-document/files/package-remote-font-in-inline-css-missing-property-error/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/05-package-document/files/package-remote-font-in-inline-css-missing-property-error/EPUB/content_001.xhtml
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:epub="http://www.idpf.org/2007/ops" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+	lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Minimal EPUB</title>
+		<style>
+			@font-face {
+			  font-family: "Open Sans";
+			  src: url("https://example.org/font") format("woff");
+			}</style>
+	</head>
+	<body>
+		<h1>Loomings</h1>
+		<p>Call me Ishmael.</p>
+	</body>
+</html>

--- a/src/test/resources/epub3/05-package-document/files/package-remote-font-in-inline-css-missing-property-error/EPUB/nav.xhtml
+++ b/src/test/resources/epub3/05-package-document/files/package-remote-font-in-inline-css-missing-property-error/EPUB/nav.xhtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/epub3/05-package-document/files/package-remote-font-in-inline-css-missing-property-error/EPUB/package.opf
+++ b/src/test/resources/epub3/05-package-document/files/package-remote-font-in-inline-css-missing-property-error/EPUB/package.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="q">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+</metadata>
+<manifest>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml"/>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  <item id="font" href="https://example.org/font" media-type="font/woff"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/src/test/resources/epub3/05-package-document/files/package-remote-font-in-inline-css-missing-property-error/META-INF/container.xml
+++ b/src/test/resources/epub3/05-package-document/files/package-remote-font-in-inline-css-missing-property-error/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+	<rootfiles>
+		<rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/epub3/05-package-document/files/package-remote-font-in-inline-css-missing-property-error/mimetype
+++ b/src/test/resources/epub3/05-package-document/files/package-remote-font-in-inline-css-missing-property-error/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/src/test/resources/epub3/05-package-document/files/package-remote-resource-and-inline-css-valid/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/05-package-document/files/package-remote-resource-and-inline-css-valid/EPUB/content_001.xhtml
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:epub="http://www.idpf.org/2007/ops" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+	lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Minimal EPUB</title>
+		<style>
+			.red {
+			  color: red;
+			}</style>
+	</head>
+	<body>
+		<h1>Loomings</h1>
+		<p>Call me Ishmael.</p>
+		<video src="https://example.org/video.mp4"></video>
+	</body>
+</html>

--- a/src/test/resources/epub3/05-package-document/files/package-remote-resource-and-inline-css-valid/EPUB/nav.xhtml
+++ b/src/test/resources/epub3/05-package-document/files/package-remote-resource-and-inline-css-valid/EPUB/nav.xhtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/epub3/05-package-document/files/package-remote-resource-and-inline-css-valid/EPUB/package.opf
+++ b/src/test/resources/epub3/05-package-document/files/package-remote-resource-and-inline-css-valid/EPUB/package.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="q">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+</metadata>
+<manifest>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml" properties="remote-resources"/>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  <item id="video"  href="https://example.org/video.mp4" media-type="video/mp4"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/src/test/resources/epub3/05-package-document/files/package-remote-resource-and-inline-css-valid/META-INF/container.xml
+++ b/src/test/resources/epub3/05-package-document/files/package-remote-resource-and-inline-css-valid/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+	<rootfiles>
+		<rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/epub3/05-package-document/files/package-remote-resource-and-inline-css-valid/mimetype
+++ b/src/test/resources/epub3/05-package-document/files/package-remote-resource-and-inline-css-valid/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/src/test/resources/epub3/05-package-document/package-document.feature
+++ b/src/test/resources/epub3/05-package-document/package-document.feature
@@ -535,6 +535,12 @@ Feature: EPUB 3 — Package document
     And no other errors or warnings are reported
 
   @spec @xref:sec-item-resource-properties
+  Scenario: Report a missing `remote-resources` property when inline CSS has remote references
+    When checking EPUB 'package-remote-font-in-inline-css-missing-property-error'
+    Then error OPF-014 is reported
+    And no other errors or warnings are reported
+
+  @spec @xref:sec-item-resource-properties
   Scenario: Report an SVG using remote fonts without the `remote-resource` property set in the package document
     When checking EPUB 'package-remote-font-in-svg-missing-property-error'
     Then error OPF-014 is reported
@@ -569,6 +575,12 @@ Feature: EPUB 3 — Package document
     When checking EPUB 'package-remote-audio-in-overlays-missing-property-error'
     Then error OPF-014 is reported
     And no other errors or warnings are reported
+
+  @spec @xref:sec-item-resource-properties
+  Scenario: Verify that inline CSS does not trigger an unrequired `remote-resources` property error
+    When checking EPUB 'package-remote-resource-and-inline-css-valid'
+    Then no errors or warnings are reported
+
 
   #####  scripted
 


### PR DESCRIPTION
`OPF-018` checks that the `remote-resources` property is not defined if no remote resource was found.
Prior to this PR, it was incorrectly reported when an XHTML content document carrying the property also contained inline CSS: the CSS checker thought that the property was not required since no remote resource was found in the CSS itself.
This commit fixes that bug by only checking `OPF-018` for standalone CSS documents.

Fix #1335