### PR TITLE
fix: fix CVE-2021-23792 vulnerability from imageio-jpeg

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-jpeg</artifactId>
-            <version>3.4.1</version>
+            <version>3.9.4</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>


### PR DESCRIPTION
Bumps imageio-jpeg version to 3.9.4.

Fix #1336