### PR TITLE
feat: report empty URL as a schema error instead of HTM-008

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -102,7 +102,7 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.HTM_005, Severity.USAGE);
     severities.put(MessageId.HTM_006, Severity.SUPPRESSED);
     severities.put(MessageId.HTM_007, Severity.WARNING);
-    severities.put(MessageId.HTM_008, Severity.ERROR);
+    severities.put(MessageId.HTM_008, Severity.SUPPRESSED);
     severities.put(MessageId.HTM_009, Severity.ERROR);
     severities.put(MessageId.HTM_010, Severity.USAGE);
     severities.put(MessageId.HTM_011, Severity.ERROR);

--- a/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
@@ -678,14 +678,7 @@ public class OPSHandler30 extends OPSHandler
 
   protected URL checkResourceURL(String src)
   {
-    if (src == null) return null;
-    // check that the URL is not empty
-    // TODO this should be moved to a schema check
-    if (src.trim().isEmpty())
-    {
-      report.message(MessageId.HTM_008, location());
-      return null;
-    }
+    if (src == null || src.trim().isEmpty()) return null;
 
     // parse and check the URL
     URL url = checkURL(src);

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -42,7 +42,6 @@ HTM_003=External entities are not allowed in EPUB v3 documents. External entity 
 HTM_004=Irregular DOCTYPE: found "%1$s", expected "%2$s".
 HTM_005=An external reference was found.
 HTM_007=Empty or whitespace-only value of attribute ssml:ph.
-HTM_008=The resource URL must not be empty
 HTM_009=The DOCTYPE provided is obsolete or irregular and can be removed.
 HTM_010=Namespace uri "%1$s" was found.
 HTM_011=Entity is undeclared.

--- a/src/main/resources/com/adobe/epubcheck/schema/30/mod/html5/common.rnc
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/mod/html5/common.rnc
@@ -335,7 +335,7 @@ common.attrs.other =
 		)
 
 	common.data.uri.non-empty =
-		datatype.IRI
+		datatype.string.nonempty
 
 	common.data.uris =
 		list { datatype.IRI* }

--- a/src/test/resources/epub3/06-content-document/content-document-xhtml.feature
+++ b/src/test/resources/epub3/06-content-document/content-document-xhtml.feature
@@ -313,7 +313,7 @@ Feature: EPUB 3 — Content Documents — XHTML
 
   Scenario: Report an `img` element with an empty `src` attribute
     When checking document 'img-src-empty-error.xhtml'
-    Then error HTM-008 is reported
+    Then error RSC-005 is reported
     And no other errors or warnings are reported
 
   Scenario: Report an `img` element with no `alt` attribute

--- a/src/test/resources/epub3/06-content-document/files/img-src-empty-error.xhtml
+++ b/src/test/resources/epub3/06-content-document/files/img-src-empty-error.xhtml
@@ -6,6 +6,6 @@
 	</head>
 	<body>
 		<h1>Test</h1>
-		<img src="" alt="empty"/>
+		<img src="   " alt="empty"/>
 	</body>
 </html>


### PR DESCRIPTION
This change effectively removes `HTM-008` by integrating (the emptyness part of) the check for valid non-empty URL in the RelaxNG schema.