### PR TITLE
refactor: set 'hreflang' schema type to 'datatype.languagecode'

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/package-30.rnc
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/package-30.rnc
@@ -30,7 +30,7 @@
       
    opf.property.attr = attribute property { datatype.property }
    opf.rel.attr = attribute rel { datatype.properties }
-   opf.hreflang.attr = attribute hreflang { "" | datatype.string.nonempty }
+   opf.hreflang.attr = attribute hreflang { "" | datatype.languagecode }
    opf.scheme.attr = attribute scheme { datatype.property }
    opf.refines.attr = attribute refines { datatype.URI }
    
@@ -129,5 +129,5 @@
    opf.href.attr = attribute href { datatype.URI }
    opf.id.attr = attribute id { datatype.ID }
    opf.i18n.attrs = opf.xml.lang.attr? & opf.dir.attr?
-   opf.xml.lang.attr = attribute xml:lang { "" | datatype.string.nonempty }
+   opf.xml.lang.attr = attribute xml:lang { "" | datatype.languagecode }
    opf.dir.attr = attribute dir { 'ltr' | 'rtl' | 'auto' }

--- a/src/test/resources/epub3/05-package-document/package-document.feature
+++ b/src/test/resources/epub3/05-package-document/package-document.feature
@@ -361,7 +361,8 @@ Feature: EPUB 3 — Package document
     When checking file 'link-rel-record-properties-undefined-error.opf'
     Then error OPF-027 is reported
     And no other errors or warnings are reported
-    
+
+  @spec @xref:sec-link-elem
   Scenario: the 'link' element can have an 'hreflang' attribute
     When checking file 'link-hreflang-valid.opf'
     Then no other errors or warnings are reported


### PR DESCRIPTION
This change is quite transparent and does not impact test, but makes the schema typing more consistent.

Also adds a spec ref tag to the valid test case.

Fix #1385