### PR TITLE
fix: report HTML discouraged constructs as "usage"

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -138,7 +138,7 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.HTM_052, Severity.ERROR);
     severities.put(MessageId.HTM_053, Severity.SUPPRESSED);
     severities.put(MessageId.HTM_054, Severity.ERROR);
-    severities.put(MessageId.HTM_055, Severity.WARNING);
+    severities.put(MessageId.HTM_055, Severity.USAGE);
     severities.put(MessageId.HTM_056, Severity.ERROR);
     severities.put(MessageId.HTM_057, Severity.ERROR);
     severities.put(MessageId.HTM_058, Severity.ERROR);

--- a/src/test/resources/epub3/03-resources/resources.feature
+++ b/src/test/resources/epub3/03-resources/resources.feature
@@ -110,16 +110,14 @@
     And no errors or warnings are reported
 
   @spec @xref:sec-foreign-resources
-  Scenario: Report a foreign resource in HTML `embed` with a manifest fallback
+  Scenario: Allow a foreign resource in HTML `embed` with a manifest fallback
     When checking EPUB 'foreign-xhtml-embed-fallback-valid'
-    And warning HTM-055 is reported (using embed is discouraged)
-    And no other errors or warnings are reported
+    Then no errors or warnings are reported
 
   @spec @xref:sec-foreign-resources
   Scenario: Report a foreign resource in HTML `embed` with no fallback
     When checking EPUB 'foreign-xhtml-embed-no-fallback-error'
     Then error RSC-032 is reported
-    And warning HTM-055 is reported (using embed is discouraged)
     And no other errors or warnings are reported
 
   @spec @xref:sec-foreign-resources
@@ -652,5 +650,4 @@
   Scenario: Report an `embed` element with a `type` attribute not matching the publication resource type
     When checking EPUB 'type-mismatch-in-embed-warning'
     Then warning OPF-013 is reported
-    And warning HTM-055 is reported (using embed is discouraged)
     And no other errors or warnings are reported

--- a/src/test/resources/epub3/06-content-document/content-document-xhtml.feature
+++ b/src/test/resources/epub3/06-content-document/content-document-xhtml.feature
@@ -197,12 +197,10 @@ Feature: EPUB 3 — Content Documents — XHTML
 
   Scenario: Verify that a base url can be set
     When checking EPUB 'content-xhtml-base-url-valid'
-    Then warning HTM-055 is reported (side effect of `base` being discouraged)
     Then no errors or warnings are reported
 
   Scenario: Report relative paths as remote resources when HTML `base` is set to an extenal URL (issue 155)
     When checking EPUB 'content-xhtml-base-url-remote-relative-path-error'
-    Then warning HTM-055 is reported (side effect of `base` being discouraged)
     Then error RSC-006 is reported
     And no other errors or warnings are reported
 
@@ -978,20 +976,23 @@ Feature: EPUB 3 — Content Documents — XHTML
   #### 6.1.4.3 Discouraged Constructs
 
   Scenario: Report `base` as a discouraged construct
+    Given the reporting level is set to usage
     When checking document 'discouraged-base-warning.xhtml'
-    Then warning HTM-055 is reported
+    Then usage HTM-055 is reported
     And the message contains 'base'
-    And no other errors or warnings are reported
+    And no errors or warnings are reported
 
   Scenario: Report `embed` as a discouraged construct
+    Given the reporting level is set to usage
     When checking document 'discouraged-embed-warning.xhtml'
-    Then warning HTM-055 is reported
+    Then usage HTM-055 is reported
     And the message contains 'embed'
     And no other errors or warnings are reported
 
   Scenario: Report `rp` as a discouraged construct
+    Given the reporting level is set to usage
     When checking document 'discouraged-rp-warning.xhtml'
-    Then warning HTM-055 is reported 2 times
+    Then usage HTM-055 is reported 2 times
     And the message contains 'rp'
     And no other errors or warnings are reported
 


### PR DESCRIPTION
The HTML discouraged constructs section is non-normative. This PR now reports use of these constructs as a usage message instead of a warning.

The severity level of `HTM-055` is now `USAGE`.

Fix #1387.