### PR TITLE
improve checks of package links

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -292,6 +292,7 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.OPF_096, Severity.ERROR);
     severities.put(MessageId.OPF_096b, Severity.USAGE);
     severities.put(MessageId.OPF_097, Severity.USAGE);
+    severities.put(MessageId.OPF_098, Severity.ERROR);
 
     // PKG
     severities.put(MessageId.PKG_001, Severity.WARNING);

--- a/src/main/java/com/adobe/epubcheck/messages/MessageId.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageId.java
@@ -286,6 +286,7 @@ public enum MessageId implements Comparable<MessageId>
   OPF_096("OPF-096"),
   OPF_096b("OPF-096b"),
   OPF_097("OPF-097"),
+  OPF_098("OPF-098"),
 
   // Messages relating to the entire package
   PKG_001("PKG-001"),

--- a/src/main/java/com/adobe/epubcheck/opf/OPFChecker30.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFChecker30.java
@@ -412,10 +412,10 @@ public class OPFChecker30 extends OPFChecker
     LinkedResources links = ((OPFHandler30) opfHandler).getLinkedResources();
     for (LinkedResource link : links.asList())
     {
-      if (opfHandler.getItemByURL(link.getDocumentURL()).isPresent())
+      Optional<OPFItem> item = opfHandler.getItemByURL(link.getDocumentURL());
+      if (item.isPresent() && !item.get().isInSpine())
       {
-        // FIXME 2022 check how to report the URL
-        report.message(MessageId.OPF_067, EPUBLocation.of(context), link.getDocumentURL().path());
+        report.message(MessageId.OPF_067, EPUBLocation.of(context), item.get().getPath());
       }
     }
   }

--- a/src/main/java/com/adobe/epubcheck/opf/OPFHandler30.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFHandler30.java
@@ -400,10 +400,20 @@ public class OPFHandler30 extends OPFHandler
     if (url != null)
     {
       // Data URLs are not allowed on `link` elements
-      if ("data".equals(url.scheme())) {
+      if ("data".equals(url.scheme()))
+      {
         report.message(MessageId.RSC_029, location());
         return;
       }
+      // The `href` attribute MUST not reference resources via elements
+      // in the package document itself
+      if (url.fragment() != null && !url.fragment().isEmpty()
+          && URLUtils.docURL(url).equals(context.url))
+      {
+        report.message(MessageId.OPF_098, location(), href);
+        return;
+      }
+
       if (context.isRemote(url))
       {
         report.info(path, FeatureEnum.REFERENCE, href);

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -213,7 +213,8 @@ OPF_094=The "media-type" attribute is required for "%1$s" links.
 OPF_095=The "media-type" attribute of "voicing" links must be an audio MIME type, but found "%1$s".
 OPF_096=Non-linear content must be reachable, but found no hyperlink to "%1$s".
 OPF_096b=No hyperlink was found to non-linear document "%1$s", please check that it can be reached from scripted content.
-OPF_097=Resource "%1$s" is listed in the manifest, but no reference to it was found in content documents. 
+OPF_097=Resource "%1$s" is listed in the manifest, but no reference to it was found in content documents.
+OPF_098=The "href" attribute must not reference resources via elements in the package document itself, but found URL "%1$s".
 
 #Package
 PKG_001=Validating the EPUB against version %1$s but detected version %2$s.

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -214,7 +214,7 @@ OPF_095=The "media-type" attribute of "voicing" links must be an audio MIME type
 OPF_096=Non-linear content must be reachable, but found no hyperlink to "%1$s".
 OPF_096b=No hyperlink was found to non-linear document "%1$s", please check that it can be reached from scripted content.
 OPF_097=Resource "%1$s" is listed in the manifest, but no reference to it was found in content documents.
-OPF_098=The "href" attribute must not reference resources via elements in the package document itself, but found URL "%1$s".
+OPF_098=The "href" attribute must reference resources, not elements in the package document, but found URL "%1$s".
 
 #Package
 PKG_001=Validating the EPUB against version %1$s but detected version %2$s.

--- a/src/test/resources/epub3/05-package-document/files/link-to-embedded-resource-valid/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/05-package-document/files/link-to-embedded-resource-valid/EPUB/content_001.xhtml
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html xmlns:epub="http://www.idpf.org/2007/ops" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+	lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Minimal EPUB</title>
+		<script id="meta-json" type="application/ld+json">
+			{
+        "@context" : "http://schema.org",
+        "name" : "test"
+      }
+    </script>
+	</head>
+	<body>
+		<h1>Loomings</h1>
+		<p>Call me Ishmael.</p>
+	</body>
+</html>

--- a/src/test/resources/epub3/05-package-document/files/link-to-embedded-resource-valid/EPUB/nav.xhtml
+++ b/src/test/resources/epub3/05-package-document/files/link-to-embedded-resource-valid/EPUB/nav.xhtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/epub3/05-package-document/files/link-to-embedded-resource-valid/EPUB/package.opf
+++ b/src/test/resources/epub3/05-package-document/files/link-to-embedded-resource-valid/EPUB/package.opf
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title id="title">Minimal EPUB 3.0</dc:title>
+    <dc:language>en</dc:language>
+    <dc:identifier id="q">NOID</dc:identifier>
+    <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+    <link rel="record" href="content_001.xhtml#meta-json" media-type="application/xhtml+xml" hreflang="en"
+    />
+  </metadata>
+  <manifest>
+    <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  </manifest>
+  <spine>
+    <itemref idref="content_001"/>
+  </spine>
+</package>

--- a/src/test/resources/epub3/05-package-document/files/link-to-embedded-resource-valid/META-INF/container.xml
+++ b/src/test/resources/epub3/05-package-document/files/link-to-embedded-resource-valid/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+	<rootfiles>
+		<rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/epub3/05-package-document/files/link-to-embedded-resource-valid/mimetype
+++ b/src/test/resources/epub3/05-package-document/files/link-to-embedded-resource-valid/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/src/test/resources/epub3/05-package-document/files/link-to-package-document-id-error.opf
+++ b/src/test/resources/epub3/05-package-document/files/link-to-package-document-id-error.opf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    prefix="example: https:example.org">
+    <metadata>
+        <dc:title>Title</dc:title>
+        <dc:language>en</dc:language>
+        <dc:identifier id="uid">NOID</dc:identifier>
+        <meta property="dcterms:modified">2019-01-01T12:00:00Z</meta>
+        <!-- link MUST NOT reference resources via elements in the package document -->
+        <link rel="example:property" href="#t001" media-type="application/xhtml+xml"/>
+    </metadata>
+    <manifest>
+        <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>
+    </manifest>
+    <spine>
+        <itemref idref="t001"/>
+    </spine>
+</package>

--- a/src/test/resources/epub3/05-package-document/files/link-to-spine-item-valid.opf
+++ b/src/test/resources/epub3/05-package-document/files/link-to-spine-item-valid.opf
@@ -7,8 +7,7 @@
         <dc:language>en</dc:language>
         <dc:identifier id="uid">NOID</dc:identifier>
         <meta property="dcterms:modified">2019-01-01T12:00:00Z</meta>
-        <!--Linked resources MUST NOT be listed in the manifest.-->
-        <link rel="example:property" href="contents.xhtml#ch1" media-type="application/xhtml+xml"/>
+        <link rel="example:property" href="contents.xhtml" media-type="application/xhtml+xml"/>
     </metadata>
     <manifest>
         <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>

--- a/src/test/resources/epub3/05-package-document/package-document.feature
+++ b/src/test/resources/epub3/05-package-document/package-document.feature
@@ -31,10 +31,9 @@ Feature: EPUB 3 — Package document
   
   @spec @xref:attrdef-href
   Scenario: 'link' target must not reference a manifest ID
-    When checking file 'link-to-publication-resource-error.opf'
-    Then error OPF-067 is reported
+    When checking file 'link-to-package-document-id-error.opf'
+    Then error OPF-098 is reported
     And no other errors or warnings are reported
-
 
 
   ### 5.3.3 The id attribute

--- a/src/test/resources/epub3/05-package-document/package-document.feature
+++ b/src/test/resources/epub3/05-package-document/package-document.feature
@@ -382,6 +382,16 @@ Feature: EPUB 3 — Package document
     When checking file 'link-hreflang-not-well-formed-error.opf'
     Then error OPF-092 is reported
     And no other errors or warnings are reported
+
+  @spec @xref:sec-link-elem
+  Scenario: Allow a link to a resource referenced from the spine
+    When checking file 'link-to-spine-item-valid.opf'
+    Then no errors or warnings are reported
+
+  @spec @xref:sec-link-elem
+  Scenario: Allow a link to a resource embedded in a content document
+    When checking EPUB 'link-to-embedded-resource-valid'
+    Then no errors or warnings are reported
   
   
   ### 5.6 Manifest section


### PR DESCRIPTION
## fix: allow links to resources embedded in content documents  
  
  This commit checks that the linked resource is not in the spine before
  reporting `OPF-067` ("The resource "…" must not be listed both as a
  "link" element in the package metadata and as a manifest item.").
  
  Effectively, this allows package links to publication resources in the
  two cases identified in the EPUB 3.3 specification:
  
  > Resources referenced from the link element are publication resources
  > only when they are:
  > - referenced from the spine; or
  > - included or embedded in an EPUB content document
  
  Fix #1454

## feat: report package link to package document elements  
  
  This commit introduces a new error message (`OPF-098`) to report `href` attributes
  containing a URL to package document elements.
  
  This implements a check for the following specification statement:
  > The URL string MUST NOT reference resources via elements in the package document