### PR TITLE
feat: check that the manifest is not self-referencing

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
+++ b/src/main/java/com/adobe/epubcheck/messages/DefaultSeverities.java
@@ -293,6 +293,7 @@ class DefaultSeverities implements Severities
     severities.put(MessageId.OPF_096b, Severity.USAGE);
     severities.put(MessageId.OPF_097, Severity.USAGE);
     severities.put(MessageId.OPF_098, Severity.ERROR);
+    severities.put(MessageId.OPF_099, Severity.ERROR);
 
     // PKG
     severities.put(MessageId.PKG_001, Severity.WARNING);

--- a/src/main/java/com/adobe/epubcheck/messages/MessageId.java
+++ b/src/main/java/com/adobe/epubcheck/messages/MessageId.java
@@ -287,6 +287,7 @@ public enum MessageId implements Comparable<MessageId>
   OPF_096b("OPF-096b"),
   OPF_097("OPF-097"),
   OPF_098("OPF-098"),
+  OPF_099("OPF-099"),
 
   // Messages relating to the entire package
   PKG_001("PKG-001"),

--- a/src/main/java/com/adobe/epubcheck/opf/OPFChecker.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFChecker.java
@@ -35,6 +35,7 @@ import org.w3c.epubcheck.core.AbstractChecker;
 import org.w3c.epubcheck.core.Checker;
 import org.w3c.epubcheck.core.CheckerFactory;
 import org.w3c.epubcheck.core.references.ResourceReferencesChecker;
+import org.w3c.epubcheck.util.url.URLUtils;
 
 import com.adobe.epubcheck.api.EPUBLocation;
 import com.adobe.epubcheck.api.EPUBProfile;
@@ -215,6 +216,11 @@ public class OPFChecker extends AbstractChecker
         // FIXME 2022 check duplicates at build time (in OPFHandler)
         report.message(MessageId.OPF_074, item.getLocation(), item.getPath());
       }
+      // check that the manifest does not include the package document itself
+      else if (item.getURL().equals(context.url))
+      {
+        report.message(MessageId.OPF_099, item.getLocation());
+      }
       else
       {
         checkItem(item, opfHandler);
@@ -358,6 +364,12 @@ public class OPFChecker extends AbstractChecker
   {
     // We do not currently support checking resources defined as data URLs
     if (item.hasDataURL())
+    {
+      return;
+    }
+    // Abort if the item is this package document
+    // (this is disallowed, and reported elsewhere)
+    if (URLUtils.docURL(item.getURL()).equals(context.url))
     {
       return;
     }

--- a/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
+++ b/src/main/resources/com/adobe/epubcheck/messages/MessageBundle.properties
@@ -215,6 +215,7 @@ OPF_096=Non-linear content must be reachable, but found no hyperlink to "%1$s".
 OPF_096b=No hyperlink was found to non-linear document "%1$s", please check that it can be reached from scripted content.
 OPF_097=Resource "%1$s" is listed in the manifest, but no reference to it was found in content documents.
 OPF_098=The "href" attribute must reference resources, not elements in the package document, but found URL "%1$s".
+OPF_099=The manifest must not list the package document.
 
 #Package
 PKG_001=Validating the EPUB against version %1$s but detected version %2$s.

--- a/src/test/resources/epub3/05-package-document/files/manifest-self-referencing-error.opf
+++ b/src/test/resources/epub3/05-package-document/files/manifest-self-referencing-error.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title id="title">Minimal EPUB 3.0</dc:title>
+    <dc:language>en</dc:language>
+    <dc:identifier id="q">NOID</dc:identifier>
+    <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+  </metadata>
+  <manifest>
+    <item id="self" href="./manifest-self-referencing-error.opf" media-type="application/oebps-package+xml"/>
+    <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  </manifest>
+  <spine>
+    <itemref idref="content_001"/>
+  </spine>
+</package>

--- a/src/test/resources/epub3/05-package-document/files/manifest-self-referencing-error/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/05-package-document/files/manifest-self-referencing-error/EPUB/content_001.xhtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns:epub="http://www.idpf.org/2007/ops" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal EPUB</title>
+	</head>
+	<body>
+		<h1>Loomings</h1>
+		<p>Call me Ishmael.</p>
+	</body>
+</html>

--- a/src/test/resources/epub3/05-package-document/files/manifest-self-referencing-error/EPUB/nav.xhtml
+++ b/src/test/resources/epub3/05-package-document/files/manifest-self-referencing-error/EPUB/nav.xhtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/epub3/05-package-document/files/manifest-self-referencing-error/EPUB/package.opf
+++ b/src/test/resources/epub3/05-package-document/files/manifest-self-referencing-error/EPUB/package.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title id="title">Minimal EPUB 3.0</dc:title>
+    <dc:language>en</dc:language>
+    <dc:identifier id="q">NOID</dc:identifier>
+    <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+  </metadata>
+  <manifest>
+    <item id="self" href="./package.opf" media-type="application/oebps-package+xml"/>
+    <item id="content_001" href="content_001.xhtml" media-type="application/xhtml+xml"/>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  </manifest>
+  <spine>
+    <itemref idref="content_001"/>
+  </spine>
+</package>

--- a/src/test/resources/epub3/05-package-document/files/manifest-self-referencing-error/META-INF/container.xml
+++ b/src/test/resources/epub3/05-package-document/files/manifest-self-referencing-error/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+	<rootfiles>
+		<rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/epub3/05-package-document/files/manifest-self-referencing-error/mimetype
+++ b/src/test/resources/epub3/05-package-document/files/manifest-self-referencing-error/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/src/test/resources/epub3/05-package-document/package-document.feature
+++ b/src/test/resources/epub3/05-package-document/package-document.feature
@@ -422,6 +422,18 @@ Feature: EPUB 3 — Package document
     Then error RSC-008 is reported
     And no other errors or warnings are reported
 
+  @spec @xref:sec-manifest-elem
+  Scenario: Report a self-referencing manifest (full publication check)
+    When checking EPUB 'manifest-self-referencing-error'
+    Then error OPF-099 is reported
+    And no other errors or warnings are reported
+
+  @spec @xref:sec-manifest-elem
+  Scenario: Report a self-referencing manifest (single file check)
+    When checking file 'manifest-self-referencing-error.opf'
+    Then error OPF-099 is reported
+    And no other errors or warnings are reported
+
   Scenario: Report (usage) a container resource that is not listed in the manifest
     Given the reporting level is set to usage  
     When checking EPUB 'manifest-not-listing-container-resource-usage'


### PR DESCRIPTION
This commit adds a new check, reported as `OPF-099` (error), to verify that the package document `manifest` does not include an `item` element that refers to the package document itself.

This statement was apparently not checked by EPUBCheck previously. Worse, the code was entering an infinite loop, as the package document checker was creating a new checker for itself, recursively.

Fix #1453