### PR TITLE
fix: allow nav items containing multiple images

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/30/edupub/edu-structure.sch
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/edupub/edu-structure.sch
@@ -35,7 +35,7 @@
 			
 			<report test="count($headings) &gt; 1">More than one ranked heading found as direct descendant of body.</report>
 			
-			<report test="count($headings) = 1 and string-length(normalize-space(concat($headings,$headings/html:img/@alt,$headings//@aria-label))) = 0">Empty ranked heading detected.</report>
+			<report test="count($headings) = 1 and string-length(normalize-space(string-join($headings|$headings/html:img/@alt|$headings//@aria-label))) = 0">Empty ranked heading detected.</report>
 			
 			<report test="@aria-label and (normalize-space($headings) = normalize-space(@aria-label))">The value of the "aria-label" attribute must not be the same as the content of the heading.</report>
 		</rule>
@@ -53,7 +53,7 @@
 			
 			<report test="count($headings) &gt; 1">More than one ranked heading found as direct descendant of <value-of select="name()"/>.</report>
 			
-			<report test="count($headings) = 1 and string-length(normalize-space(concat($headings,$headings/html:img/@alt,$headings//@aria-label))) = 0">Empty ranked heading detected.</report>
+			<report test="count($headings) = 1 and string-length(normalize-space(string-join($headings|$headings/html:img/@alt|$headings//@aria-label))) = 0">Empty ranked heading detected.</report>
 			
 			<report test="@aria-label and (normalize-space($headings) = normalize-space(@aria-label))">The value of the "aria-label" attribute must not be the same as the content of the heading.</report>
 		</rule>

--- a/src/main/resources/com/adobe/epubcheck/schema/30/epub-nav-30.sch
+++ b/src/main/resources/com/adobe/epubcheck/schema/30/epub-nav-30.sch
@@ -47,7 +47,7 @@
     <pattern id="link-labels">
         <rule context="html:nav[@epub:type]//html:ol//html:a">
             <assert
-                test="string-length(normalize-space(concat(.,./html:img/@alt,.//@aria-label))) > 0"
+                test="string-length(normalize-space(string-join(.|./html:img/@alt|.//@aria-label))) > 0"
                 >Anchors within nav elements must contain text</assert>
         </rule>
     </pattern>
@@ -55,7 +55,7 @@
     <pattern id="span-labels">
         <rule context="html:nav[@epub:type]//html:ol//html:span">
             <assert
-                test="string-length(normalize-space(concat(.,./html:img/@alt,.//@aria-label))) > 0"
+                test="string-length(normalize-space(string-join(.|./html:img/@alt|.//@aria-label))) > 0"
                 >Spans within nav elements must contain text</assert>
         </rule>
     </pattern>
@@ -72,7 +72,7 @@
     <pattern id="heading-content">
         <rule context="html:h1|html:h2|html:h3|html:h4|html:h5|html:h6">
             <assert
-                test="string-length(normalize-space(concat(.,./html:img/@alt,.//@aria-label))) > 0"
+                test="string-length(normalize-space(string-join(.|./html:img/@alt|.//@aria-label))) > 0"
                 >Heading elements must contain text</assert>
         </rule>
     </pattern>

--- a/src/test/resources/epub3/07-navigation-document/files/content-model-a-multiple-images-valid.xhtml
+++ b/src/test/resources/epub3/07-navigation-document/files/content-model-a-multiple-images-valid.xhtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+    <head>
+        <meta charset="utf-8"/>
+            <title>Minimal Nav</title>
+    </head>
+    <body>
+        <nav epub:type="toc">
+            <ol>
+                <li><a href="content_001.xhtml"><img src="decorative.jpg" alt="" /><img src="textual.jpg" alt="some text" /></a></li>
+            </ol>
+        </nav>
+    </body>
+</html>

--- a/src/test/resources/epub3/07-navigation-document/files/content-model-li-label-multiple-images-valid.xhtml
+++ b/src/test/resources/epub3/07-navigation-document/files/content-model-li-label-multiple-images-valid.xhtml
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en"
+    lang="en">
+    <head>
+        <meta charset="utf-8" />
+            <title>Minimal Nav</title>
+    </head>
+    <body>
+        <nav epub:type="toc">
+            <ol>
+                <li>
+                    <span><img src="decorative.jpg" alt="" /><img src="textual.jpg" alt="some text" /></span>
+                    <ol>
+                        <li><a href="content_001.xhtml">content 001</a></li>
+                    </ol>
+                </li>
+            </ol>
+        </nav>
+    </body>
+</html>

--- a/src/test/resources/epub3/07-navigation-document/navigation-document.feature
+++ b/src/test/resources/epub3/07-navigation-document/navigation-document.feature
@@ -63,6 +63,11 @@ Feature: EPUB 3 — Navigation Document
     Then error RSC-005 is reported
     And the message contains 'Spans within nav elements must contain text'
     And no other errors or warnings are reported
+    
+  Scenario: Allow multiple images in a list item label
+  	Given EPUBCheck configured to check a navigation document
+    When checking document 'content-model-li-label-multiple-images-valid.xhtml'
+    Then no errors or warnings are reported
 
   @spec @xref:sec-nav-def-model
   Scenario: Report a leaf list item with no link (just a span label)
@@ -79,6 +84,11 @@ Feature: EPUB 3 — Navigation Document
     Then error RSC-005 is reported
     And the message contains 'Anchors within nav elements must contain text'
     And no other errors or warnings are reported
+    
+  Scenario: Allow multiple images in a nav hyperlink
+  	Given EPUBCheck configured to check a navigation document
+    When checking document 'content-model-a-multiple-images-valid.xhtml'
+    Then no errors or warnings are reported
 
   @spec @xref:sec-nav-def-model
   Scenario: Report a nav hyperlink without content (but an empty nested span)


### PR DESCRIPTION
A bug in the Schematron XPath expressions caused a fatal error to be reported when nav doc items contained multiple images.

This commit fix the relevant expressions by using the `string-join` function instead of `concat`, allowing to join arbitrary sequences of text nodes.

Fix #1476