### PR TITLE
fix: allow the 'cover-image' property on WebP images

### DIFF
--- a/src/main/java/com/adobe/epubcheck/opf/OPFHandler30.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFHandler30.java
@@ -519,7 +519,7 @@ public class OPFHandler30 extends OPFHandler
     mimeType = mimeType.trim();
     for (ITEM_PROPERTIES itemProp : itemProps)
     {
-      if (!itemProp.allowedOnTypes().contains(mimeType))
+      if (!itemProp.isAllowedForType(mimeType))
       {
         report.message(MessageId.OPF_012, location(), ITEM_VOCAB.getName(itemProp), mimeType);
       }

--- a/src/main/java/com/adobe/epubcheck/vocab/PackageVocabs.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/PackageVocabs.java
@@ -42,7 +42,7 @@ public final class PackageVocabs
 
   public static enum ITEM_PROPERTIES
   {
-    COVER_IMAGE("image/gif", "image/jpeg", "image/png", "image/svg+xml"),
+    COVER_IMAGE("image/*"),
     DATA_NAV("application/xhtml+xml"),
     DICTIONARY("application/vnd.epub.search-key-map+xml"),
     GLOSSARY("application/vnd.epub.search-key-map+xml", "application/xhtml+xml"),
@@ -59,12 +59,33 @@ public final class PackageVocabs
 
     private ITEM_PROPERTIES(String... types)
     {
-      this.types = new ImmutableSet.Builder<String>().add(types).build();
+      ImmutableSet.Builder<String> builder = new ImmutableSet.Builder<String>();
+      for (String type : types)
+      {
+        if (type.endsWith("/*"))
+        {
+          builder.add(type.substring(0, type.length() - 1));
+        }
+        else
+        {
+          builder.add(type);
+        }
+      }
+      this.types = builder.build();
     }
 
-    public Set<String> allowedOnTypes()
+    public boolean isAllowedForType(String mimetype)
     {
-      return types;
+      if (mimetype == null) return false;
+      for (String allowedType : types)
+      {
+        if (allowedType.equals(mimetype)
+            || allowedType.endsWith("/") && mimetype.startsWith(allowedType))
+        {
+          return true;
+        }
+      }
+      return false;
     }
   }
 

--- a/src/test/resources/epub3/05-package-document/files/item-property-cover-image-webp-valid.opf
+++ b/src/test/resources/epub3/05-package-document/files/item-property-cover-image-webp-valid.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <metadata>
+        <dc:title>Title</dc:title>
+        <dc:language>en</dc:language>
+        <dc:identifier id="uid">NOID</dc:identifier>
+        <meta property="dcterms:modified">2019-01-01T12:00:00Z</meta>
+    </metadata>
+    <manifest>
+        <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>
+        <item id="cover" href="cover.webp" media-type="image/webp" properties="cover-image" />
+    </manifest>
+    <spine>
+        <itemref idref="t001"/>
+    </spine>
+</package>

--- a/src/test/resources/epub3/05-package-document/package-document.feature
+++ b/src/test/resources/epub3/05-package-document/package-document.feature
@@ -524,6 +524,11 @@ Feature: EPUB 3 — Package document
   ##### cover-image
   
   @spec @xref:sec-item-resource-properties
+  Scenario: The 'cover-image' item property is allowed on WebP images 
+    When checking file 'item-property-cover-image-webp-valid.opf'
+    Then no other errors or warnings are reported
+
+  @spec @xref:sec-item-resource-properties
   Scenario: The 'cover-image' item property must occur at most once 
     When checking file 'item-property-cover-image-multiple-error.opf'
     Then error RSC-005 is reported


### PR DESCRIPTION
Prior to this commit, we used a hardcoded list of MIME types to check that the 'cover-image' property was used on images (CMT only).

Now, we only check that the MIME type stars with 'image/'.

Fix #1484