### PR TITLE
fix: do not check fragment identifiers on PDF references

### DIFF
--- a/src/main/java/org/w3c/epubcheck/core/references/ResourceReferencesChecker.java
+++ b/src/main/java/org/w3c/epubcheck/core/references/ResourceReferencesChecker.java
@@ -169,11 +169,15 @@ public class ResourceReferencesChecker
       {
         Reference.Type targetIDType = resourceRegistry.getIDType(fragment.getId(),
             targetResource);
-        if (targetIDType == null)
+
+        // Check that target ID exists (if the target is XHTML or SVG)
+        if (targetIDType == null
+            && (MIMEType.SVG.is(targetMimetype) || MIMEType.XHTML.is(targetMimetype)))
         {
           report.message(MessageId.RSC_012, reference.location.context(reference.url.toString()));
           throw new CheckAbortException();
         }
+        
         switch (reference.type)
         {
         case SVG_PAINT:

--- a/src/test/resources/epub3/06-content-document/content-document-xhtml.feature
+++ b/src/test/resources/epub3/06-content-document/content-document-xhtml.feature
@@ -523,6 +523,11 @@ Feature: EPUB 3 — Content Documents — XHTML
     And no other errors or warnings are reported
 
 
+  #### Objects
+
+  Scenario: Allow fragment identifiers on PDFs
+    When checking EPUB 'object-pdf-fragment-valid'
+    Then no errors or warnings are reported
 
   ####  Schematron Assertions
 

--- a/src/test/resources/epub3/06-content-document/files/object-pdf-fragment-valid/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/06-content-document/files/object-pdf-fragment-valid/EPUB/content_001.xhtml
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns:epub="http://www.idpf.org/2007/ops" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal EPUB</title>
+	</head>
+	<body>
+		<h1>Loomings</h1>
+		<p>Call me Ishmael.</p>
+		<object data="test.pdf#view=FitV" type="application/pdf"></object>
+	</body>
+</html>

--- a/src/test/resources/epub3/06-content-document/files/object-pdf-fragment-valid/EPUB/nav.xhtml
+++ b/src/test/resources/epub3/06-content-document/files/object-pdf-fragment-valid/EPUB/nav.xhtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/epub3/06-content-document/files/object-pdf-fragment-valid/EPUB/package.opf
+++ b/src/test/resources/epub3/06-content-document/files/object-pdf-fragment-valid/EPUB/package.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="q">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+</metadata>
+<manifest>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml"/>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+  <item id="pdf" href="test.pdf" media-type="application/pdf" fallback="content_001"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/src/test/resources/epub3/06-content-document/files/object-pdf-fragment-valid/META-INF/container.xml
+++ b/src/test/resources/epub3/06-content-document/files/object-pdf-fragment-valid/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+	<rootfiles>
+		<rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/epub3/06-content-document/files/object-pdf-fragment-valid/mimetype
+++ b/src/test/resources/epub3/06-content-document/files/object-pdf-fragment-valid/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip


### PR DESCRIPTION
Fix #1482