### PR TITLE
fix: allow decimal viewport dimensions in fixed-layout

### DIFF
--- a/src/main/java/org/w3c/epubcheck/util/microsyntax/ViewportMeta.java
+++ b/src/main/java/org/w3c/epubcheck/util/microsyntax/ViewportMeta.java
@@ -12,8 +12,8 @@ import com.google.common.collect.ListMultimap;
 
 public class ViewportMeta
 {
-  private static Pattern VIEWPORT_HEIGHT_REGEX = Pattern.compile("\\d+|device-height");
-  private static Pattern VIEWPORT_WIDTH_REGEX = Pattern.compile("\\d+|device-width");
+  private static Pattern VIEWPORT_HEIGHT_REGEX = Pattern.compile("\\d+(\\.\\d+)?|device-height");
+  private static Pattern VIEWPORT_WIDTH_REGEX = Pattern.compile("\\d+(\\.\\d+)?|device-width");
 
   public static ViewportMeta parse(String string, ErrorHandler errorHandler)
   {
@@ -26,6 +26,7 @@ public class ViewportMeta
     switch (Preconditions.checkNotNull(name))
     {
     case "width":
+      
       return VIEWPORT_WIDTH_REGEX.matcher(value).matches();
     case "height":
       return VIEWPORT_HEIGHT_REGEX.matcher(value).matches();

--- a/src/test/resources/epub3/08-layout/files/content-fxl-xhtml-viewport-float-valid/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/08-layout/files/content-fxl-xhtml-viewport-float-valid/EPUB/content_001.xhtml
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<meta name="viewport" content="width=600.999,height=1200.5" />
+		<title>Minimal EPUB</title>
+	</head>
+	<body>
+		<h1>Loomings</h1>
+		<p>Call me Ishmael.</p>
+	</body>
+</html>

--- a/src/test/resources/epub3/08-layout/files/content-fxl-xhtml-viewport-float-valid/EPUB/nav.xhtml
+++ b/src/test/resources/epub3/08-layout/files/content-fxl-xhtml-viewport-float-valid/EPUB/nav.xhtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/epub3/08-layout/files/content-fxl-xhtml-viewport-float-valid/EPUB/package.opf
+++ b/src/test/resources/epub3/08-layout/files/content-fxl-xhtml-viewport-float-valid/EPUB/package.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="q">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+  <meta property="rendition:layout">pre-paginated</meta>
+</metadata>
+<manifest>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml"/>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/src/test/resources/epub3/08-layout/files/content-fxl-xhtml-viewport-float-valid/META-INF/container.xml
+++ b/src/test/resources/epub3/08-layout/files/content-fxl-xhtml-viewport-float-valid/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+	<rootfiles>
+		<rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/epub3/08-layout/files/content-fxl-xhtml-viewport-float-valid/mimetype
+++ b/src/test/resources/epub3/08-layout/files/content-fxl-xhtml-viewport-float-valid/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/src/test/resources/epub3/08-layout/layout.feature
+++ b/src/test/resources/epub3/08-layout/layout.feature
@@ -215,6 +215,11 @@ Feature: EPUB 3 — Layout Rendering Control
     Then no errors or warnings are reported
 
   @spec @xref:sec-fxl-content-dimensions
+  Scenario: Verify a fixed-layout XHTML document with non-integer viewport dimensions
+    When checking EPUB 'content-fxl-xhtml-viewport-float-valid'
+    Then no errors or warnings are reported
+
+  @spec @xref:sec-fxl-content-dimensions
   Scenario: Verify a fixed-layout XHTML document with a valid viewport with whitespace
     When checking EPUB 'content-fxl-xhtml-viewport-whitespace-valid'
     Then no errors or warnings are reported


### PR DESCRIPTION
The spec only says dimensions must be a "positive number" (or keyword), it does not specifically forbid decimal values.

Fix #1481