### PR TITLE
feat: allow "pageBreakSource" package metadata (incubation)

### DIFF
--- a/src/main/java/com/adobe/epubcheck/opf/OPFHandler30.java
+++ b/src/main/java/com/adobe/epubcheck/opf/OPFHandler30.java
@@ -45,6 +45,7 @@ import static com.adobe.epubcheck.vocab.PackageVocabs.LINKREL_VOCAB;
 import static com.adobe.epubcheck.vocab.PackageVocabs.LINK_VOCAB;
 import static com.adobe.epubcheck.vocab.PackageVocabs.LINK_VOCAB_URI;
 import static com.adobe.epubcheck.vocab.PackageVocabs.META_VOCAB;
+import static com.adobe.epubcheck.vocab.PackageVocabs.META_VOCAB_CAMEL;
 import static com.adobe.epubcheck.vocab.PackageVocabs.META_VOCAB_URI;
 
 import java.util.Deque;
@@ -65,6 +66,7 @@ import com.adobe.epubcheck.opf.ResourceCollection.Roles;
 import com.adobe.epubcheck.util.EpubConstants;
 import com.adobe.epubcheck.util.FeatureEnum;
 import com.adobe.epubcheck.vocab.AccessibilityVocab;
+import com.adobe.epubcheck.vocab.AggregateVocab;
 import com.adobe.epubcheck.vocab.DCMESVocab;
 import com.adobe.epubcheck.vocab.EpubCheckVocab;
 import com.adobe.epubcheck.vocab.MediaOverlaysVocab;
@@ -94,7 +96,7 @@ public class OPFHandler30 extends OPFHandler
       .put(DCTERMS_PREFIX, DCTERMS_VOCAB).put(MARC_PREFIX, MARC_VOCAB).put(ONIX_PREFIX, ONIX_VOCAB)
       .put(SCHEMA_PREFIX, SCHEMA_VOCAB).put(XSD_PREFIX, XSD_VOCAB).build();
   private static final Map<String, Vocab> RESERVED_META_VOCABS = new ImmutableMap.Builder<String, Vocab>()
-      .put("", META_VOCAB).put(AccessibilityVocab.PREFIX, AccessibilityVocab.META_VOCAB)
+      .put("", AggregateVocab.of(META_VOCAB, META_VOCAB_CAMEL)).put(AccessibilityVocab.PREFIX, AccessibilityVocab.META_VOCAB)
       .put(MediaOverlaysVocab.PREFIX, MediaOverlaysVocab.VOCAB)
       .put(RenditionVocabs.PREFIX, RenditionVocabs.META_VOCAB).putAll(RESERVED_VOCABS).build();
   private static final Map<String, Vocab> RESERVED_ITEM_VOCABS = new ImmutableMap.Builder<String, Vocab>()

--- a/src/main/java/com/adobe/epubcheck/vocab/PackageVocabs.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/PackageVocabs.java
@@ -3,6 +3,7 @@ package com.adobe.epubcheck.vocab;
 import java.util.Set;
 
 import com.adobe.epubcheck.opf.ValidationContext;
+import com.google.common.base.CaseFormat;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 
@@ -35,6 +36,14 @@ public final class PackageVocabs
     TARGET_LANGUAGE, // DICT
     TERM,
     TITLE_TYPE
+  }
+
+  public static EnumVocab<META_PROPERTIES_CAMEL> META_VOCAB_CAMEL = new EnumVocab<META_PROPERTIES_CAMEL>(
+      META_PROPERTIES_CAMEL.class, CaseFormat.LOWER_CAMEL, META_VOCAB_URI);
+
+  public static enum META_PROPERTIES_CAMEL
+  {
+    PAGE_BREAK_SOURCE,
   }
 
   public static EnumVocab<ITEM_PROPERTIES> ITEM_VOCAB = new EnumVocab<ITEM_PROPERTIES>(

--- a/src/test/resources/epub3/D-vocabularies/files/metadata-meta-pageBreakSource-valid.opf
+++ b/src/test/resources/epub3/D-vocabularies/files/metadata-meta-pageBreakSource-valid.opf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <metadata>
+        <dc:title>Title</dc:title>
+        <dc:language>en</dc:language>
+        <dc:identifier id="uid">NOID</dc:identifier>
+        <meta property="dcterms:modified">2019-01-01T12:00:00Z</meta>
+        <meta property="pageBreakSource">example</meta>
+    </metadata>
+    <manifest>
+        <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>
+    </manifest>
+    <spine>
+        <itemref idref="t001"/>
+    </spine>
+</package>

--- a/src/test/resources/epub3/D-vocabularies/meta-properties.feature
+++ b/src/test/resources/epub3/D-vocabularies/meta-properties.feature
@@ -250,3 +250,12 @@ Feature: EPUB 3 — Vocabularies — Meta properties vocabulary
     Then error RSC-005 is reported
     And the message contains '"title-type" cannot be declared more than once'
     And no other errors or warnings are reported
+
+
+  ## Incubation
+
+  @spec @xref:sec-title-type
+  Scenario: 'pageBreakSource' metadata is allowed 
+    When checking file 'metadata-meta-pageBreakSource-valid.opf'
+    Then no errors or warnings are reported
+


### PR DESCRIPTION
The ["pageBreakSource"](https://www.w3.org/publishing/a11y/page-source-id/#pageBreakSource) package metadata property is planned to be added to EPUB, after 3.3.

This commit allows this property to start incubating its use.

Fix #1491