### PR TITLE
fix: allow remote URLs in HTML "cite" attributes

### DIFF
--- a/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
+++ b/src/main/java/com/adobe/epubcheck/ops/OPSHandler30.java
@@ -448,7 +448,7 @@ public class OPSHandler30 extends OPSHandler
 
   private void checkCiteAttribute()
   {
-    URL url = checkResourceURL(currentElement().getAttribute("cite"));
+    URL url = checkURL(currentElement().getAttribute("cite"));
     registerReference(url, Type.CITE);
   }
 

--- a/src/main/java/org/w3c/epubcheck/core/references/ResourceReferencesChecker.java
+++ b/src/main/java/org/w3c/epubcheck/core/references/ResourceReferencesChecker.java
@@ -177,7 +177,7 @@ public class ResourceReferencesChecker
           report.message(MessageId.RSC_012, reference.location.context(reference.url.toString()));
           throw new CheckAbortException();
         }
-        
+
         switch (reference.type)
         {
         case SVG_PAINT:
@@ -189,6 +189,7 @@ public class ResourceReferencesChecker
           }
           break;
         case SVG_SYMBOL:
+        case CITE:
         case HYPERLINK:
         case OVERLAY_TEXT_LINK:
           if (targetIDType != reference.type && targetIDType != Reference.Type.GENERIC)
@@ -334,7 +335,8 @@ public class ResourceReferencesChecker
         // links and remote hyperlinks are not Publication Resources
         && !(reference.type == Reference.Type.LINK
             || container.isRemote(reference.targetResource)
-                && reference.type == Reference.Type.HYPERLINK))
+                && (reference.type == Reference.Type.HYPERLINK
+                    || reference.type == Reference.Type.CITE)))
     {
       undeclared.add(reference.targetResource);
       report.message(MessageId.RSC_008, reference.location,
@@ -351,7 +353,8 @@ public class ResourceReferencesChecker
 
     // Check if the remote reference is allowed
     if (// remote links and hyperlinks are not Publication Resources
-    !EnumSet.of(Reference.Type.LINK, Reference.Type.HYPERLINK).contains(reference.type)
+    !EnumSet.of(Reference.Type.CITE, Reference.Type.LINK, Reference.Type.HYPERLINK)
+        .contains(reference.type)
         // spine items are checked in OPFChecker30
         && !(version == EPUBVersion.VERSION_3 && targetResource.isPresent()
             && targetResource.get().isInSpine())

--- a/src/test/resources/epub3/04-ocf/files/url-xhtml-cite-absolute-valid/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/04-ocf/files/url-xhtml-cite-absolute-valid/EPUB/content_001.xhtml
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns:epub="http://www.idpf.org/2007/ops" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal EPUB</title>
+	</head>
+	<body>
+		<h1>Loomings</h1>
+		<p>Call me Ishmael.</p>
+		<q cite="https://example.org/cite.html">text</q>
+	</body>
+</html>

--- a/src/test/resources/epub3/04-ocf/files/url-xhtml-cite-absolute-valid/EPUB/nav.xhtml
+++ b/src/test/resources/epub3/04-ocf/files/url-xhtml-cite-absolute-valid/EPUB/nav.xhtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/epub3/04-ocf/files/url-xhtml-cite-absolute-valid/EPUB/package.opf
+++ b/src/test/resources/epub3/04-ocf/files/url-xhtml-cite-absolute-valid/EPUB/package.opf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="q">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+</metadata>
+<manifest>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml"/>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/src/test/resources/epub3/04-ocf/files/url-xhtml-cite-absolute-valid/META-INF/container.xml
+++ b/src/test/resources/epub3/04-ocf/files/url-xhtml-cite-absolute-valid/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+	<rootfiles>
+		<rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/epub3/04-ocf/files/url-xhtml-cite-absolute-valid/mimetype
+++ b/src/test/resources/epub3/04-ocf/files/url-xhtml-cite-absolute-valid/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/src/test/resources/epub3/04-ocf/ocf.feature
+++ b/src/test/resources/epub3/04-ocf/ocf.feature
@@ -156,8 +156,12 @@ Feature: EPUB 3 — Open Container Format
 
   #### resource existence checks:
 
+  Scenario: Allow an absolute `cite` URL
+    When checking EPUB 'url-xhtml-cite-absolute-valid'
+    Then no errors or warnings are reported
+
   @spec @xref:sec-container-iri
-  Scenario: Report a reference from an XHTML `cite` attribute not declared in the manifest
+  Scenario: Report a relative `cite` URL when the resource is not found in the manifest
     When checking EPUB 'url-xhtml-cite-missing-resource-error'
     Then error RSC-007 is reported 4 times
     And no other errors or warnings are reported
@@ -168,7 +172,7 @@ Feature: EPUB 3 — Open Container Format
     Then error RSC-007 is reported
     And no other errors or warnings are reported
 
-  @spec @xref:sec-exempt-resources
+  @spec @xref:sec-container-iri
   Scenario: Report a reference from an XHTML `track` not declared in the manifest
     When checking EPUB 'url-xhtml-track-missing-resource-error'
     Then error RSC-007 is reported


### PR DESCRIPTION
The resources referenced in `cite` attribute URLs are not publication resources.

This commit disables the publication-resource-specific URL checks for the `cite` attribute. For instance, the referenced document is not subject to resource location restrictions.

The URL is still registered in the reference registry, so that the existence of the underlying container resource is checked (for relative URLs).

Fix #1495