### PR TITLE
fix: support UNC paths (fix URL/File conversions)

### DIFF
--- a/src/main/java/com/adobe/epubcheck/ocf/OCFZipResources.java
+++ b/src/main/java/com/adobe/epubcheck/ocf/OCFZipResources.java
@@ -3,7 +3,6 @@ package com.adobe.epubcheck.ocf;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Enumeration;
@@ -12,6 +11,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+
+import org.w3c.epubcheck.util.url.URLUtils;
 
 import com.adobe.epubcheck.util.FeatureEnum;
 import com.google.common.base.Preconditions;
@@ -25,14 +26,7 @@ public class OCFZipResources implements Iterable<OCFResource>
 
   public OCFZipResources(URL url) throws IOException
   {
-    File file = null;
-    try
-    {
-      file = new File(url.toJavaURI());
-    } catch (URISyntaxException e)
-    {
-      new IllegalArgumentException("Not a file URL: " + url);
-    }
+    File file = URLUtils.toFile(url);
     this.zip = new ZipFile(file, StandardCharsets.UTF_8);
   }
 

--- a/src/main/java/com/adobe/epubcheck/opf/ValidationContext.java
+++ b/src/main/java/com/adobe/epubcheck/opf/ValidationContext.java
@@ -1,7 +1,5 @@
 package com.adobe.epubcheck.opf;
 
-import java.io.File;
-import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Locale;
@@ -163,13 +161,7 @@ public final class ValidationContext
     }
     else if ("file".equals(url.scheme()))
     {
-      try
-      {
-        return new File(url.toJavaURI()).getAbsolutePath();
-      } catch (URISyntaxException e)
-      {
-        return url.toHumanString();
-      }
+      return URLUtils.toFilePath(url);
     }
     else
     {

--- a/src/main/java/org/w3c/epubcheck/util/url/URLUtils.java
+++ b/src/main/java/org/w3c/epubcheck/util/url/URLUtils.java
@@ -6,6 +6,8 @@ import static io.mola.galimatias.URLUtils.percentDecode;
 import static io.mola.galimatias.URLUtils.percentEncode;
 
 import java.io.File;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
 
@@ -23,6 +25,26 @@ public final class URLUtils
   {
     Preconditions.checkArgument(file != null, "file must not be null");
     return URL.fromJavaURI(file.toURI());
+  }
+  
+  public static File toFile(URL url) {
+    Preconditions.checkArgument(url != null, "file must not be null");
+    Preconditions.checkArgument("file".equals(url.scheme()));
+    try {
+      return Paths.get(url.toJavaURI()).toFile();
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+  
+  public static String toFilePath(URL url) {
+    Preconditions.checkArgument(url != null, "file must not be null");
+    Preconditions.checkArgument("file".equals(url.scheme()));
+    try {
+      return Paths.get(url.toJavaURI()).toString();
+    } catch (Exception e) {
+      return decode(url.path());
+    }
   }
 
   public static URL docURL(URL url)


### PR DESCRIPTION
EPUBCheck used to work well with UNC paths in 4.x, but this was broken when implementing the new URL and container parsing code.

This commit improves the URL-to-File conversion:
- relies on `java.nio.file.Paths`
- utility methods are introduced in `URLUtils`

This was tested manually on Windows, but not in the test suite since this is largely OS-dependent.

Fix #1485