### PR TITLE
fix: incorrect ID refs in toc nav caused a NullPointerException

### DIFF
--- a/src/main/java/org/w3c/epubcheck/core/references/ResourceReferencesChecker.java
+++ b/src/main/java/org/w3c/epubcheck/core/references/ResourceReferencesChecker.java
@@ -456,25 +456,27 @@ public class ResourceReferencesChecker
         // check that the fragment is in document order
         URLFragment fragment = URLFragment.parse(ref.url, res.getMimeType());
         int targetAnchorPosition = resourceRegistry.getIDPosition(fragment.getId(), res);
-        if (targetAnchorPosition < lastAnchorPosition)
-        {
-          String orderContext = LocalizedMessages.getInstance(locale).getSuggestion(
-              MessageId.NAV_011,
-              "document");
-          if (ref.type == Reference.Type.OVERLAY_TEXT_LINK)
+        if (targetAnchorPosition > -1) {
+          if (targetAnchorPosition < lastAnchorPosition)
           {
-            report.message(MessageId.MED_015, ref.location, container.relativize(ref.url),
-                orderContext);
+            String orderContext = LocalizedMessages.getInstance(locale).getSuggestion(
+                MessageId.NAV_011,
+                "document");
+            if (ref.type == Reference.Type.OVERLAY_TEXT_LINK)
+            {
+              report.message(MessageId.MED_015, ref.location, container.relativize(ref.url),
+                  orderContext);
+            }
+            else
+            {
+              report.message(MessageId.NAV_011, ref.location,
+                  (ref.type == Reference.Type.NAV_TOC_LINK) ? "toc" : "page-list",
+                      container.relativize(ref.url),
+                      orderContext);
+            }
           }
-          else
-          {
-            report.message(MessageId.NAV_011, ref.location,
-                (ref.type == Reference.Type.NAV_TOC_LINK) ? "toc" : "page-list",
-                container.relativize(ref.url),
-                orderContext);
-          }
+          lastAnchorPosition = targetAnchorPosition;
         }
-        lastAnchorPosition = targetAnchorPosition;
       }
     }
 

--- a/src/main/java/org/w3c/epubcheck/core/references/ResourceRegistry.java
+++ b/src/main/java/org/w3c/epubcheck/core/references/ResourceRegistry.java
@@ -11,6 +11,7 @@ import org.w3c.epubcheck.core.references.Reference.Type;
 import com.adobe.epubcheck.opf.OPFItem;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Table;
 
 import io.mola.galimatias.URL;
@@ -54,7 +55,8 @@ public final class ResourceRegistry
   {
     Preconditions.checkArgument(resource != null);
     if (id == null || id.trim().isEmpty()) return 0;
-    int position = ids.get(resource.getURL()).indexOf(id);
+    int position = Optional.ofNullable(ids.get(resource.getURL())).orElse(ImmutableList.of())
+        .indexOf(id);
     return (position == -1) ? -1 : position + 1;
   }
 

--- a/src/test/resources/epub3/06-content-document/content-document-xhtml.feature
+++ b/src/test/resources/epub3/06-content-document/content-document-xhtml.feature
@@ -263,6 +263,11 @@ Feature: EPUB 3 — Content Documents — XHTML
     Then error RSC-012 is reported
     And no errors or warnings are reported
 
+  Scenario: Report a hyperlink to a missing identifier in the Nav Doc
+    When checking EPUB 'content-xhtml-link-to-missing-id-in-nav-doc-error'
+    Then error RSC-012 is reported
+    And no errors or warnings are reported
+
   Scenario: Report a hyperlink to a mising identifier in another document
     When checking EPUB 'content-xhtml-link-to-missing-id-xref-error'
     Then error RSC-012 is reported

--- a/src/test/resources/epub3/06-content-document/files/content-xhtml-link-to-missing-id-in-nav-doc-error/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/06-content-document/files/content-xhtml-link-to-missing-id-in-nav-doc-error/EPUB/content_001.xhtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns:epub="http://www.idpf.org/2007/ops" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal EPUB</title>
+	</head>
+	<body>
+		<h1>Loomings</h1>
+		<p>Call me Ishmael.</p>
+	</body>
+</html>

--- a/src/test/resources/epub3/06-content-document/files/content-xhtml-link-to-missing-id-in-nav-doc-error/EPUB/nav.xhtml
+++ b/src/test/resources/epub3/06-content-document/files/content-xhtml-link-to-missing-id-in-nav-doc-error/EPUB/nav.xhtml
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+				<li><a href="content_001.xhtml#missing">content 002</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/epub3/06-content-document/files/content-xhtml-link-to-missing-id-in-nav-doc-error/EPUB/package.opf
+++ b/src/test/resources/epub3/06-content-document/files/content-xhtml-link-to-missing-id-in-nav-doc-error/EPUB/package.opf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="q">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+</metadata>
+<manifest>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml"/>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/src/test/resources/epub3/06-content-document/files/content-xhtml-link-to-missing-id-in-nav-doc-error/META-INF/container.xml
+++ b/src/test/resources/epub3/06-content-document/files/content-xhtml-link-to-missing-id-in-nav-doc-error/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+	<rootfiles>
+		<rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/epub3/06-content-document/files/content-xhtml-link-to-missing-id-in-nav-doc-error/mimetype
+++ b/src/test/resources/epub3/06-content-document/files/content-xhtml-link-to-missing-id-in-nav-doc-error/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip


### PR DESCRIPTION
When the `toc` nav of the navigation document contained links pointing to non-existing IDs, checking that links are in reading order caused a NullPointerException.

This commit fixes that by using a more defensive programming logic.

Fix #1516