### PR TITLE
fix: allow flow content for XHTML 1.1 edit elements (EPUB 2.0.1)

### DIFF
--- a/src/main/resources/com/adobe/epubcheck/schema/20/rng/xhtml/edit.rng
+++ b/src/main/resources/com/adobe/epubcheck/schema/20/rng/xhtml/edit.rng
@@ -5,7 +5,7 @@
 <define name="del">
   <element name="del">
     <ref name="del.attlist"/>
-    <ref name="Inline.model"/>
+    <ref name="Flow.model"/>
   </element>
 </define>
 
@@ -18,7 +18,7 @@
   <element name="ins">
     <ref name="Common.attrib"/>
     <ref name="ins.attlist"/>
-    <ref name="Inline.model"/>
+    <ref name="Flow.model"/>
   </element>
 </define>
 

--- a/src/test/resources/epub2/files/ops-document-xhtml/edit-block-content-valid.xhtml
+++ b/src/test/resources/epub2/files/ops-document-xhtml/edit-block-content-valid.xhtml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<title>Minimal EPUB</title>
+	</head>
+	<body>
+		<del datetime="2011-09-02">
+			<h1>Title Old</h1>
+		</del>
+		<ins datetime="2011-09-02">
+			<h1>Title New</h1>
+		</ins>
+		<p>Call me Ishmael.</p>
+	</body>
+</html>

--- a/src/test/resources/epub2/ops-content-document-xhtml.feature
+++ b/src/test/resources/epub2/ops-content-document-xhtml.feature
@@ -76,6 +76,11 @@ Feature: EPUB 2 ▸ Open Publication Structure ▸ XHTML Document Checks
   Scenario: Verify attributes allowed on `ins` and `del` are not restricted (issue 293)
     When checking document 'edit-attributes-valid.xhtml'
     Then no errors or warnings are reported
+  
+  Scenario: Verify `ins` and `del` elements can contain block content
+    See https://github.com/w3c/epubcheck/issues/1522
+    When checking document 'edit-block-content-valid.xhtml'
+    Then no errors or warnings are reported
 
   ### Identifiers
   


### PR DESCRIPTION
See https://www.w3.org/TR/xhtml-modularization/abstract_modules.html#s_editmodule

Fix #1522