### PR TITLE
fix for jpms by remove use of ResourceBundle.Control

### DIFF
--- a/src/main/java/com/adobe/epubcheck/messages/LocalizedMessages.java
+++ b/src/main/java/com/adobe/epubcheck/messages/LocalizedMessages.java
@@ -66,6 +66,7 @@ public class LocalizedMessages
       {
         if (instance == null)
         {
+          // ???
           instance = new LocalizedMessages(locale);
           localizedMessages.put(localeKey, instance);
         }
@@ -110,8 +111,12 @@ public class LocalizedMessages
   public LocalizedMessages(Locale locale)
   {
     this.locale = (locale != null) ? locale : Locale.getDefault();
-    bundle = ResourceBundle.getBundle(
-      "com.adobe.epubcheck.messages.MessageBundle", this.locale, new LocalizedMessages.UTF8Control());
+    try {
+      this.bundle = ResourceResolver.toResourceBundle(ResourceResolver.getInstance()
+              .resource2Url("com.adobe.epubcheck.messages.MessageBundle", locale));
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
   }
 
   private String getStringFromBundle(String id)
@@ -170,54 +175,4 @@ public class LocalizedMessages
             : getSuggestion(id));
   }
 
-  public static class UTF8Control extends ResourceBundle.Control
-  {
-
-    @Override
-    public ResourceBundle newBundle(
-            String baseName,
-            Locale locale,
-            String format,
-            ClassLoader loader,
-            boolean reload) throws IllegalAccessException,
-            InstantiationException,
-            IOException
-    {
-      // The below is a copy of the default implementation.
-      String bundleName = toBundleName(baseName, locale);
-      String resourceName = toResourceName(bundleName, "properties"); //$NON-NLS-1$
-      ResourceBundle bundle = null;
-      InputStream stream = null;
-      if (reload)
-      {
-        URL url = loader.getResource(resourceName);
-        if (url != null)
-        {
-          URLConnection connection = url.openConnection();
-          if (connection != null)
-          {
-            connection.setUseCaches(false);
-            stream = connection.getInputStream();
-          }
-        }
-      } else
-      {
-        stream = loader.getResourceAsStream(resourceName);
-      }
-      if (stream != null)
-      {
-        try
-        {
-          // Only this line is changed to make it to read properties files as
-          // UTF-8.
-          bundle = new PropertyResourceBundle(
-                  new BufferedReader(new InputStreamReader(stream, Charsets.UTF_8)));
-        } finally
-        {
-          stream.close();
-        }
-      }
-      return bundle;
-    }
-  }
 }

--- a/src/main/java/com/adobe/epubcheck/messages/LocalizedMessages.java
+++ b/src/main/java/com/adobe/epubcheck/messages/LocalizedMessages.java
@@ -66,7 +66,6 @@ public class LocalizedMessages
       {
         if (instance == null)
         {
-          // ???
           instance = new LocalizedMessages(locale);
           localizedMessages.put(localeKey, instance);
         }

--- a/src/main/java/com/adobe/epubcheck/messages/ResourceResolver.java
+++ b/src/main/java/com/adobe/epubcheck/messages/ResourceResolver.java
@@ -1,0 +1,110 @@
+package com.adobe.epubcheck.messages;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.Lists;
+
+import java.io.*;
+import java.net.URL;
+import java.util.*;
+
+public class ResourceResolver {
+
+    private static class MyPropertyResourceBundle extends PropertyResourceBundle {
+
+        MyPropertyResourceBundle(Reader reader) throws IOException {
+            super(reader);
+        }
+
+        MyPropertyResourceBundle(URL url) throws IOException {
+            this(new BufferedReader(
+                    new InputStreamReader(url.openStream(), Charsets.UTF_8)));
+        }
+
+        void setMyParent(MyPropertyResourceBundle resourceBundle){
+            setParent(resourceBundle);
+        }
+
+    }
+
+    private static final ResourceResolver INSTANCE = new ResourceResolver();
+
+    public static ResourceResolver getInstance() {
+        return INSTANCE;
+    }
+
+    private ResourceResolver() {
+    }
+
+    public List<URL> resource2Url(String resource, Locale locale) {
+        String path = resource.replaceAll("\\.", "/");
+        List<URL> result = flatResource2Url(path, locale);
+        if (result.isEmpty()) {
+            result = flatResource2Url("/" + path, locale);
+        }
+        if (result.isEmpty()) {
+            result = flatResource2Url(resource, locale);
+        }
+        if (result.isEmpty()) {
+            throw new IllegalStateException("Can't find resource for " + resource + " and " + locale);
+        }
+        return result;
+    }
+
+    private List<URL> flatResource2Url(String resource, Locale locale) {
+        final List<URL> result = new ArrayList<>();
+        if (locale != null) {
+            if (!"".equals(locale.getCountry())) {
+                addTo(result, from(resource + "_" + locale.toString() + ".properties"));
+            }
+            final String lang = locale.getLanguage();
+            if (!"".equals(lang)) {
+                addTo(result, from(resource + "_" + locale.getLanguage() + ".properties"));
+            }
+        }
+        // fallback to default locale (only if locale not found)
+        Locale dft = Locale.getDefault();
+        if (result.isEmpty()) {
+            if (!"".equals(locale.getCountry())) {
+                addTo(result, from(resource + "_" + dft.toString() + ".properties"));
+            }
+            final String lang2 = dft.getLanguage();
+            if (!"".equals(lang2)) {
+                addTo(result, from(resource + "_" + lang2 + ".properties"));
+            }
+        }
+        // fallback to default bundle (unconditionally)
+        addTo(result, from(resource + ".properties"));
+        return result;
+    }
+
+    private static void addTo(List<URL> list, URL toAdd) {
+        if (toAdd != null) {
+            if (!list.contains(toAdd)) {
+                list.add(toAdd);
+            }
+        }
+    }
+
+    private URL from(String resourceName) {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        if (cl == null) {
+            cl = ResourceResolver.class.getClassLoader();
+        }
+        if (cl == null) {
+            cl = ClassLoader.getSystemClassLoader();
+        }
+        return cl.getResource(resourceName);
+    }
+
+    public static PropertyResourceBundle toResourceBundle(List<URL> list) throws IOException {
+        MyPropertyResourceBundle result = null;
+        for (URL url : Lists.reverse(list)) {
+            final MyPropertyResourceBundle last = result;
+            result = new MyPropertyResourceBundle(url);
+            if (last != null) {
+                result.setMyParent(last);
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/thaiopensource/util/Localizer.java
+++ b/src/main/java/com/thaiopensource/util/Localizer.java
@@ -1,5 +1,6 @@
 package com.thaiopensource.util;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -7,6 +8,7 @@ import java.util.ResourceBundle;
 
 import com.adobe.epubcheck.messages.LocaleHolder;
 import com.adobe.epubcheck.messages.LocalizedMessages;
+import com.adobe.epubcheck.messages.ResourceResolver;
 
 import java.text.MessageFormat;
 
@@ -56,11 +58,20 @@ public class Localizer
     {
       String s = cls.getName();
       int i = s.lastIndexOf('.');
-      if (i > 0) s = s.substring(0, i + 1);
+      if (i > 0) {
+        s = s.substring(0, i + 1);
+      }
       else
-	s = "";
-      bundles.put(locale, ResourceBundle.getBundle(s + "resources.Messages", LocaleHolder.get(),
-          new LocalizedMessages.UTF8Control()));
+      {
+        s = "";
+      }
+      try {
+        bundles.put(locale,
+                ResourceResolver.toResourceBundle(ResourceResolver.getInstance()
+                        .resource2Url(s + "resources.Messages", LocaleHolder.get())));
+      } catch (IOException e) {
+        throw new IllegalStateException(e);
+      }
     }
     return bundles.get(locale);
   }


### PR DESCRIPTION
I observed the following

1. The use of `ResourceBundle.Control` with the Java Platform Module System (jpms) is not possible. In Java >=9 the following method is present in `ResourceBundle`:
   ```java
    private static void checkNamedModule(Class<?> caller) {
        if (caller.getModule().isNamed()) {
            throw new UnsupportedOperationException("ResourceBundle.Control not supported in named modules");
        }
    }
   ```
2. ResourceBundle *.properties files in epubcheck are UTF-8 encoded.

Hence this pull request will (a) eliminate the use of `ResourceBundle.Control` and unify the loading of `*.properties` files to enhance the compatibility of epubcheck with jpms.

Review und comments are appreciated.

Kind regards,

aanno