### PR TITLE
Zip file is not closed properly

### DIFF
--- a/src/main/java/com/adobe/epubcheck/ocf/OCFChecker.java
+++ b/src/main/java/com/adobe/epubcheck/ocf/OCFChecker.java
@@ -233,6 +233,18 @@ public final class OCFChecker extends AbstractChecker
     //
     checkFileExtension(state);
 
+    // Close zip file to free resource
+    if (state.getZipResources() != null)
+    {
+      try
+      {
+        state.getZipResources().close();
+      }
+      catch (Exception e)
+      {
+        // FIXME 2023 - Inability to close zip file should be handled
+      }
+    }
   }
 
   private boolean checkContainerFile(OCFCheckerState state)
@@ -275,7 +287,9 @@ public final class OCFChecker extends AbstractChecker
     {
       // FIXME 2022 build resourcesProvider depending on MIME type
       // Get a container
-      Iterable<OCFResource> resourcesProvider = new OCFZipResources(context.url);
+      OCFZipResources resourcesProvider = new OCFZipResources(context.url);
+      // Store the OCFZipResources object so it can be closed later
+      state.setZipResources(resourcesProvider);
       // Set to store the normalized paths for duplicate checks
       final Set<String> normalizedPaths = new HashSet<>();
       // Lists to store the container entries for later empty directory check

--- a/src/main/java/com/adobe/epubcheck/ocf/OCFCheckerState.java
+++ b/src/main/java/com/adobe/epubcheck/ocf/OCFCheckerState.java
@@ -41,6 +41,8 @@ class OCFCheckerState
   private final ImmutableList.Builder<URL> packageDocuments = ImmutableList.builder();
   private URL mappingDocument;
 
+  private OCFZipResources zipResources = null;
+
   private final Map<URL, EPUBLocation> obfuscated = new HashMap<>();
   private final Map<URL, Set<PublicationType>> publicationTypes = new LinkedHashMap<>();
   private final Map<URL, String> publicationIDs = new LinkedHashMap<>();
@@ -82,6 +84,16 @@ class OCFCheckerState
   {
     containerBuilder.addResource(resource);
     containerNeedsRebuild = true;
+  }
+
+  public OCFZipResources getZipResources()
+  {
+    return zipResources;
+  }
+
+  public void setZipResources(OCFZipResources zipResources)
+  {
+    this.zipResources = zipResources;
   }
 
   public void addRootfile(String mediaType, URL resource)

--- a/src/main/java/com/adobe/epubcheck/ocf/OCFZipResources.java
+++ b/src/main/java/com/adobe/epubcheck/ocf/OCFZipResources.java
@@ -98,6 +98,11 @@ public class OCFZipResources implements Iterable<OCFResource>
     };
   }
 
+  public void close() throws IOException
+  {
+    zip.close();
+  }
+
   private static String getSHAHash(ZipEntry entry, ZipFile zip)
   {
     try (InputStream inputStream = zip.getInputStream(entry))


### PR DESCRIPTION
For checking the contents of an EPUB, a `java.util.zip.ZipFile`-object is created. This opens the file for introspection. The file can be closed in two different ways: By explicitly being closed once epubcheck is done with it (calling the `.close()` method), which is *not* done in this case; or by waiting for the garbage collection to clean up the object which results in a close as well. The latter is what happens in epubcheck. However there is no guarantee when Java runs the garbage collection, it could after hours. If epubcheck is integrated into another long running process, this can block EPUB file for quite a long time – during which it can not be deleted or overwritten.

I have implemented a fix for this, storing the ZipFile in the state object and closing it once all checks have been performed. The ZipFile object is still required to be open for checking all the resources during the process so it cannot just be closed at the end of the `checkContainerStructure(···)` method.

A merge would be greatly appreciated.