### PR TITLE
feat: update Jackson from 1.9.12 to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,14 +136,14 @@
             <version>3.9.4</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-            <version>1.9.12</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.17.0</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.12</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.0</version>
         </dependency>
         <!-- ================= -->
         <!-- Test Dependencies -->

--- a/src/main/java/com/adobe/epubcheck/api/EPUBLocation.java
+++ b/src/main/java/com/adobe/epubcheck/api/EPUBLocation.java
@@ -2,13 +2,12 @@ package com.adobe.epubcheck.api;
 
 import java.io.File;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-
 import com.adobe.epubcheck.ocf.OCFContainer;
 import com.adobe.epubcheck.opf.ValidationContext;
 import com.adobe.epubcheck.util.JsonWriter;
 import com.adobe.epubcheck.util.PathUtil;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 

--- a/src/main/java/com/adobe/epubcheck/api/MasterReport.java
+++ b/src/main/java/com/adobe/epubcheck/api/MasterReport.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import com.adobe.epubcheck.messages.Message;
 import com.adobe.epubcheck.messages.LocaleHolder;
 import com.adobe.epubcheck.messages.LocalizedMessageDictionary;
@@ -15,6 +13,8 @@ import com.adobe.epubcheck.messages.OverriddenMessageDictionary;
 import com.adobe.epubcheck.messages.Severity;
 import com.adobe.epubcheck.util.Messages;
 import com.adobe.epubcheck.util.ReportingLevel;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Locale;
 
 /**

--- a/src/main/java/com/adobe/epubcheck/reporting/CheckMessage.java
+++ b/src/main/java/com/adobe/epubcheck/reporting/CheckMessage.java
@@ -4,11 +4,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import com.adobe.epubcheck.api.EPUBLocation;
 import com.adobe.epubcheck.messages.Message;
 import com.adobe.epubcheck.messages.Severity;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @SuppressWarnings("FieldCanBeLocal")
 public class CheckMessage implements Comparable<CheckMessage>

--- a/src/main/java/com/adobe/epubcheck/reporting/CheckerMetadata.java
+++ b/src/main/java/com/adobe/epubcheck/reporting/CheckerMetadata.java
@@ -2,7 +2,7 @@ package com.adobe.epubcheck.reporting;
 
 import com.adobe.epubcheck.util.PathUtil;
 import com.adobe.epubcheck.util.outWriter;
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.File;
 import java.text.SimpleDateFormat;

--- a/src/main/java/com/adobe/epubcheck/reporting/CheckingReport.java
+++ b/src/main/java/com/adobe/epubcheck/reporting/CheckingReport.java
@@ -9,8 +9,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import com.adobe.epubcheck.api.EPUBLocation;
 import com.adobe.epubcheck.api.EpubCheck;
 import com.adobe.epubcheck.api.MasterReport;
@@ -19,6 +17,7 @@ import com.adobe.epubcheck.util.FeatureEnum;
 import com.adobe.epubcheck.util.JsonWriter;
 import com.adobe.epubcheck.util.PathUtil;
 import com.adobe.epubcheck.util.outWriter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class CheckingReport extends MasterReport
 {

--- a/src/main/java/com/adobe/epubcheck/reporting/ItemMetadata.java
+++ b/src/main/java/com/adobe/epubcheck/reporting/ItemMetadata.java
@@ -4,9 +4,8 @@ import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
 import com.adobe.epubcheck.util.FeatureEnum;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ItemMetadata implements Comparable<ItemMetadata>
 {

--- a/src/main/java/com/adobe/epubcheck/reporting/PublicationMetadata.java
+++ b/src/main/java/com/adobe/epubcheck/reporting/PublicationMetadata.java
@@ -1,7 +1,7 @@
 package com.adobe.epubcheck.reporting;
 
 import com.adobe.epubcheck.util.FeatureEnum;
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;

--- a/src/main/java/com/adobe/epubcheck/util/JsonWriter.java
+++ b/src/main/java/com/adobe/epubcheck/util/JsonWriter.java
@@ -3,64 +3,50 @@ package com.adobe.epubcheck.util;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.JsonSerializer;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
-import org.codehaus.jackson.map.SerializerProvider;
-
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.google.common.base.Optional;
 
 /**
  * This is used to create json output
  */
-public class JsonWriter
-{
-  public static class OptionalJsonSerializer extends JsonSerializer<Optional<? extends String>>  {
+public class JsonWriter{
 
+    public static class OptionalJsonSerializer extends JsonSerializer<Optional<String>> {
     @Override
-    public void serialize(Optional<? extends String> value, JsonGenerator jgen, SerializerProvider provider)
-      throws IOException,
-      JsonProcessingException
-    {
-//      jgen.writeStartObject();
+    public void serialize(Optional<String> value, JsonGenerator jgen, SerializerProvider provider)
+            throws IOException {
       jgen.writeString(value.orNull());
-//      jgen.writeEndObject();
-      
     }
-
-    
   }
-  
-  private ObjectMapper objectMapper;
 
-  private JsonWriter(ObjectMapper objectMapper)
-  {
-    if (objectMapper == null)
-    {
+  private final ObjectMapper objectMapper;
+
+  private JsonWriter(ObjectMapper objectMapper) {
+    if (objectMapper == null) {
       throw new IllegalArgumentException("objectMapper argument is required.");
     }
     this.objectMapper = objectMapper;
   }
 
-  public static JsonWriter createJsonWriter(boolean pretty)
-  {
+  public static JsonWriter createJsonWriter(boolean pretty) {
     JsonFactory jf = new JsonFactory();
     ObjectMapper om = new ObjectMapper(jf);
     om.configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
-    om.configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, true);
-    om.configure(SerializationConfig.Feature.INDENT_OUTPUT, pretty);
-    om.configure(SerializationConfig.Feature.AUTO_DETECT_GETTERS, false);
-    om.configure(SerializationConfig.Feature.FAIL_ON_EMPTY_BEANS, false);
+    om.configure(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature(), true);
+    om.configure(SerializationFeature.INDENT_OUTPUT, pretty);
+    om.configure(MapperFeature.AUTO_DETECT_GETTERS, false);
+    om.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
     return new JsonWriter(om);
   }
 
-  public void writeJson(Object content, PrintWriter pw)
-      throws
-      IOException
-  {
+  public void writeJson(Object content, PrintWriter pw) throws IOException {
     this.objectMapper.writeValue(pw, content);
   }
 }


### PR DESCRIPTION
- This fixes a high severity vulnerability in `org.codehaus.jackson:jackson-mapper-asl:1.9.12` (CVE-2019-10172).
- It also fixes a high severity vulnerability in `org.codehaus.jackson:jackson-core-asl:1.9.12` (CVE-2019-10202).