### PR TITLE
fix: from X as Y casing in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build the epubcheck.jar file
-FROM maven:slim as builder
+FROM maven:slim AS builder
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
Currently, building the epubcheck Docker (Docker server version: 27.0.3, API version: 1.46) image produces a [warning](https://docs.docker.com/reference/build-checks/from-as-casing/):

> WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)