### PR TITLE
chore: bump GitHub Action versions

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout sources"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: "Set up Java"
       uses: actions/setup-java@v4
       with:
@@ -24,7 +24,7 @@ jobs:
         distribution: "temurin"
         cache: 'maven'
     - name: "Get Maven dependencies from cache"
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout sources"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: "Setup Java"
       uses: actions/setup-java@v4
       with:
@@ -49,7 +49,7 @@ jobs:
         server-username: OSSRH_USERNAME
         server-password: OSSRH_PASSWORD
     - name: "Get Maven dependencies from cache"
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
`actions/checkout@v2` and `actions/cache@v2` currently issue deprecation warnings during execution about deprecated Node.js version. 

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/cache@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

> The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@v2, actions/cache@v2. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/