### PR TITLE
fix: recognize `--failonwarnings+` and `--failonwarnings-`

### DIFF
--- a/src/main/java/com/adobe/epubcheck/tool/EpubChecker.java
+++ b/src/main/java/com/adobe/epubcheck/tool/EpubChecker.java
@@ -663,6 +663,8 @@ public class EpubChecker
               outWriter.setQuiet(true);
             break;
           case "failonwarnings":
+          case "failonwarnings+":
+          case "failonwarnings-":
               String fw = args[i].substring("--failonwarnings".length());
               failOnWarnings = (fw.compareTo("-") != 0);
             break;


### PR DESCRIPTION
Fixes #1575

Although I don't understand the purpose of the extra `+` or `-` - i.e. does it not simply repeat what specifying `--failonwarnings` and omitting `--failonwarnings` would achieve?