### PR TITLE
fix: rare decoding error on UTF-8 documents

### DIFF
--- a/src/main/java/com/adobe/epubcheck/xml/XMLEncodingSniffer.java
+++ b/src/main/java/com/adobe/epubcheck/xml/XMLEncodingSniffer.java
@@ -108,8 +108,28 @@ public final class XMLEncodingSniffer
     return encoding.toUpperCase(Locale.ROOT);
   }
 
+  /**
+   * Checks if the parameter input stream has a UTF-8 byte order mark.
+   *
+   * @param in
+   *        an input stream
+   * @return <code>true</code> if and only if the input stream starts with a
+   *           UTF-8 BOM
+   * @throws IOException
+   */
+  public static boolean hasUTF8BOM(InputStream in)
+    throws IOException
+  {
+    byte[] buffer = new byte[3];
+    in.mark(buffer.length);
+    int len = in.read(buffer);
+    in.reset();
+    return (len == 3 && matchesMagic(UTF8_MAGIC, buffer));
+  }
+
   private XMLEncodingSniffer()
   {
     // Not instanciable.
   }
+
 }


### PR DESCRIPTION
On rare occasions, decoding UTF-8 documents caused a fatal error RSC-016 (`Invalid byte 2 of 4-byte UTF-8 sequence.`).

This was likely due to a bug in the Xerces XML parser decoding component, see https://issues.apache.org/jira/browse/XERCESJ-1668

As a workaround, we now read documents using the Java built-in UTF-8 decoder instead of Xerces's own decoder, by creating the SAX parsers' InputSource from an InputStreamReader instead of the raw InputStream.

Fixes #1548