### PR TITLE
fix: allow CSS custom properties with no value

### DIFF
--- a/src/main/java/org/idpf/epubcheck/util/css/CssParser.java
+++ b/src/main/java/org/idpf/epubcheck/util/css/CssParser.java
@@ -373,7 +373,7 @@ public final class CssParser
         CssToken value = iter.next();
         if (MATCH_SEMI_CLOSEBRACE.apply(value))
         {
-          if (declaration.components.size() < 1)
+          if (declaration.components.size() < 1 && !declaration.name.or("").startsWith("--"))
           {
             err.error(new CssGrammarException(GRAMMAR_EXPECTING_TOKEN, iter.last.location,
                 messages.getLocale(), value.getChar(), messages.get("a_property_value")));

--- a/src/test/java/org/idpf/epubcheck/util/css/CssParserTest.java
+++ b/src/test/java/org/idpf/epubcheck/util/css/CssParserTest.java
@@ -178,6 +178,13 @@ public class CssParserTest {
     HandlerImpl handler = checkBasics(exec(s));
     assertEquals(0, handler.errors.size());
   }
+
+  @Test
+  public void testParser016() throws Exception {
+    String s = "E { --my-property: ; } ";
+    HandlerImpl handler = checkBasics(exec(s));
+    assertEquals(0, handler.errors.size());
+  }
 			
 	@Test
 	public void testParserAtRule001() throws Exception {

--- a/src/test/resources/css/custom-properties.css
+++ b/src/test/resources/css/custom-properties.css
@@ -4,6 +4,7 @@
 
 :root {
   --main-bg-color: brown;
+  --empty:;
 }
 
 .one {


### PR DESCRIPTION
Fix the built-in CSS parser to allow custom properties with empty values, as this is valid CSS.
See https://www.w3.org/TR/css-variables/#guaranteed-invalid

Fixes #1538