### PR TITLE
fix: recognize the `a11y:exemption` property

### DIFF
--- a/src/main/java/com/adobe/epubcheck/vocab/AccessibilityVocab.java
+++ b/src/main/java/com/adobe/epubcheck/vocab/AccessibilityVocab.java
@@ -15,6 +15,7 @@ public final class AccessibilityVocab
   {
     CERTIFIED_BY,
     CERTIFIER_CREDENTIAL,
+    EXEMPTION
   }
 
   public static enum LINKREL_PROPERTIES

--- a/src/test/resources/epub-accessibility/accessibility.feature
+++ b/src/test/resources/epub-accessibility/accessibility.feature
@@ -23,3 +23,7 @@ Feature: EPUB 3 — Accessibility
   Scenario: Verify an 'a11y:certifierCredential' property can be defined as a link
     When checking file 'link-rel-a11y-certifierCredential-valid.opf'
     Then no errors or warnings are reported
+
+  Scenario: Allow using the 'a11y:exemption' property in package metadata
+    When checking file 'metadata-a11y-exemption-valid.opf'
+    Then no errors or warnings are reported

--- a/src/test/resources/epub-accessibility/files/metadata-a11y-exemption-valid.opf
+++ b/src/test/resources/epub-accessibility/files/metadata-a11y-exemption-valid.opf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <metadata>
+        <dc:title>Title</dc:title>
+        <dc:language>en</dc:language>
+        <dc:identifier id="uid">NOID</dc:identifier>
+        <meta property="dcterms:modified">2019-01-01T12:00:00Z</meta>
+        <!-- using the a11y:exemption property -->
+        <meta property="dcterms:conformsTo">none</meta>
+        <meta property="a11y:exemption">eaa-microenterprise</meta>
+    </metadata>
+    <manifest>
+        <item id="t001" href="contents.xhtml" properties="nav" media-type="application/xhtml+xml"/>
+    </manifest>
+    <spine>
+        <itemref idref="t001"/>
+    </spine>
+</package>


### PR DESCRIPTION
Fix #1566