### PR TITLE
fix: `mailto` URLs were reported as missing resources

### DIFF
--- a/src/main/java/com/adobe/epubcheck/ocf/OCFContainer.java
+++ b/src/main/java/com/adobe/epubcheck/ocf/OCFContainer.java
@@ -131,7 +131,7 @@ public final class OCFContainer implements GenericResourceProvider
   public boolean isRemote(URL url)
   {
     Preconditions.checkArgument(url != null, "URL is null");
-    if (!url.isHierarchical() || contains(url))
+    if ("data".equals(url.scheme()) || contains(url))
     {
       return false;
     }

--- a/src/test/resources/epub3/03-resources/files/mailto-url-valid/EPUB/content_001.xhtml
+++ b/src/test/resources/epub3/03-resources/files/mailto-url-valid/EPUB/content_001.xhtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns:epub="http://www.idpf.org/2007/ops" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal EPUB</title>
+	</head>
+	<body>
+		<h1>Loomings</h1>
+		<p>Call me <a href="mailto:ishmael@example.org">Ishmael</a>.</p>
+	</body>
+</html>

--- a/src/test/resources/epub3/03-resources/files/mailto-url-valid/EPUB/nav.xhtml
+++ b/src/test/resources/epub3/03-resources/files/mailto-url-valid/EPUB/nav.xhtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8"/>
+		<title>Minimal Nav</title>
+	</head>
+	<body>
+		<nav epub:type="toc">
+			<ol>
+				<li><a href="content_001.xhtml">content 001</a></li>
+			</ol>
+		</nav>
+	</body>
+</html>

--- a/src/test/resources/epub3/03-resources/files/mailto-url-valid/EPUB/package.opf
+++ b/src/test/resources/epub3/03-resources/files/mailto-url-valid/EPUB/package.opf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="en" unique-identifier="q">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <dc:title id="title">Minimal EPUB 3.0</dc:title>
+  <dc:language>en</dc:language>
+  <dc:identifier id="q">NOID</dc:identifier>
+  <meta property="dcterms:modified">2017-06-14T00:00:01Z</meta>
+</metadata>
+<manifest>
+  <item id="content_001"  href="content_001.xhtml" media-type="application/xhtml+xml"/>
+  <item id="nav"  href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+</manifest>
+<spine>
+  <itemref idref="content_001" />
+</spine>
+</package>

--- a/src/test/resources/epub3/03-resources/files/mailto-url-valid/META-INF/container.xml
+++ b/src/test/resources/epub3/03-resources/files/mailto-url-valid/META-INF/container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+	<rootfiles>
+		<rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/>
+	</rootfiles>
+</container>

--- a/src/test/resources/epub3/03-resources/files/mailto-url-valid/mimetype
+++ b/src/test/resources/epub3/03-resources/files/mailto-url-valid/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip

--- a/src/test/resources/epub3/03-resources/resources.feature
+++ b/src/test/resources/epub3/03-resources/resources.feature
@@ -490,6 +490,10 @@
     Then warning RSC-031 is reported 3 times
     And no other errors or warnings are reported
 
+  Scenario: Allow `mailto` URLs, do not process them as resources
+    When checking document 'mailto-url-valid'
+    Then no errors or warnings are reported
+
   ## 3.7 Data URLs
 
   @spec @xref:sec-data-urls


### PR DESCRIPTION
Fix a regression bug introduced in PR #1582, in the implementatiom of `OCFContainer#isRemote(URL)`.
The buggy implementation considered `mailto` URLs as local URLs. As a result, it reported an error as no matching local resource could be found in the container.

The new implementation says a URL is remote when it is not a `data` URL and is not the URL of a resource in the container.

Fix #1595