### PR TITLE
fix: do not pollute stdout JSON with messages

### DIFF
--- a/src/main/java/com/adobe/epubcheck/tool/EpubChecker.java
+++ b/src/main/java/com/adobe/epubcheck/tool/EpubChecker.java
@@ -253,7 +253,9 @@ public class EpubChecker
       int validationResult = ((EpubCheck) checker).doValidate();
       if (validationResult == 0)
       {
-        outWriter.println(messages.get("no_errors__or_warnings"));
+        if (!((jsonOutput||xmlOutput||xmpOutput) && fileOut==null)) {
+          outWriter.println(messages.get("no_errors__or_warnings"));
+        }
         return 0;
       }
       else if (validationResult == 1)
@@ -269,7 +271,9 @@ public class EpubChecker
       checker.check();
       if (report.getWarningCount() == 0 && report.getFatalErrorCount() == 0 && report.getErrorCount() == 0)
       {
-        outWriter.println(messages.get("no_errors__or_warnings"));
+        if (!((jsonOutput||xmlOutput||xmpOutput) && fileOut==null)) {
+          outWriter.println(messages.get("no_errors__or_warnings"));
+        }
         return 0;
       }
       else if (report.getWarningCount() > 0 && report.getFatalErrorCount() == 0 && report.getErrorCount() == 0)

--- a/src/test/resources/cli/cli.feature
+++ b/src/test/resources/cli/cli.feature
@@ -280,6 +280,13 @@ Feature: EPUBCheck Command Line
 			Then the return code is 0
 			And file 'report.json' was created
 
+		Example: output a JSON report to the standard output
+			Given file 'report.json' does not exist
+			When running `epubcheck {{valid.epub}} -j -`
+			Then the return code is 0
+			And stdout contains '"title" : "Minimal EPUB 3.0"'
+			But stdout does not contain 'No errors or warnings detected'
+
 		Example: conflicting report formats are rejected
 			When running `epubcheck {{valid.epub}} -o {{report.xml}} -j {{report.json}}`
 			Then the return code is 1


### PR DESCRIPTION
The message "No errors or warnings detected." was printed to `stdout` even when EPUBCheck was configured to print a JSON report to `stdout``, why caused the JSON output to be invalid. This commit fixes that by checking that JSON (or XML/XMP) is not being printed to `stdout` before writing this message.

Fixes #1603