### PR TITLE
fix: allow CSS `has:(<selector>)` syntax

### DIFF
--- a/src/main/java/org/idpf/epubcheck/util/css/CssGrammar.java
+++ b/src/main/java/org/idpf/epubcheck/util/css/CssGrammar.java
@@ -897,9 +897,11 @@ public class CssGrammar
             selector.components.add(comb);
             start = iter.next();
           }
-          else if (iter.list.get(idx - 1).type == CssToken.Type.S)
+          else if (iter.list.get(idx - 1).type == CssToken.Type.S
+                  || iter.list.get(idx - 1).type == CssToken.Type.FUNCTION)
           {
             selector.components.add(new CssSelectorCombinator(' ', start.location));
+            relative = false;
           }
           else
           {
@@ -1117,7 +1119,7 @@ public class CssGrammar
 
       String name = start.getChars().substring(0, start.getChars().length() - 1);
 
-      CssFunction negation = new CssFunction(name, start.location);
+      CssFunction function = new CssFunction(name, start.location);
 
       CssToken tk = iter.next();
       List<CssSelector> selectors = createSelectorList(tk, iter, err, forgiving, relative,
@@ -1130,10 +1132,10 @@ public class CssGrammar
       {
         for (CssSelector selector : selectors)
         {
-          negation.components.add(selector);
+          function.components.add(selector);
         }
       }
-      return negation;
+      return function;
     }
 
     CssAttributeSelector createAttributeSelector(final CssToken start,

--- a/src/test/java/org/idpf/epubcheck/util/css/CssParserTest.java
+++ b/src/test/java/org/idpf/epubcheck/util/css/CssParserTest.java
@@ -372,9 +372,18 @@ public class CssParserTest {
 			+":nth-child( 3n + 1 ) {}"
 			+":nth-child( +3n - 2 ) {}"
 			+":nth-child( -n+ 6) {}"
-			+":nth-child( +6 ) {}";			
-		checkBasics(exec(s));		
+			+":nth-child( +6 ) {}";
+		checkBasics(exec(s));
 	}
+  
+  @Test
+  public void testParserSelectorsFunctionalPseudoValid002() throws Exception {
+    String s = 
+        ":has(>img) {}"
+       +":has( img) {}"
+       +":has(img) {}";
+    checkBasics(exec(s));
+  }
 	
 	@Test
 	public void testParserSelectorsFunctionalPseudoInvalid001() throws Exception {

--- a/src/test/resources/epub3/06-content-document/files/content-css-selectors-valid/EPUB/style.css
+++ b/src/test/resources/epub3/06-content-document/files/content-css-selectors-valid/EPUB/style.css
@@ -49,3 +49,8 @@ div[epub|type = "chapter"] {
 :has(>img) {
   font-size: 1em;
 }
+
+:has(img)
+{
+  font-size: 1em;
+}


### PR DESCRIPTION
The CSS parser was raising an error when the selector list used by the `:has()` pseudo-class was not starting with an explicit relative combinator. This is now fixed and allowed.

Fix #1605, fix #1618