### PR TITLE
feat: allow `its-*` attributes (ITS) in HTML

### DIFF
--- a/src/main/java/com/adobe/epubcheck/xml/HTMLUtils.java
+++ b/src/main/java/com/adobe/epubcheck/xml/HTMLUtils.java
@@ -59,6 +59,11 @@ public final class HTMLUtils
     return namespace.isEmpty() && name.startsWith("data-");
   }
 
+  public static boolean isITSAttribute(String namespace, String name)
+  {
+    return namespace.isEmpty() && name.startsWith("its-");
+  }
+
   /**
    * Tells if a string is a valid <a href=
    * "https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute">

--- a/src/main/java/com/adobe/epubcheck/xml/handlers/PreprocessingDefaultHandler.java
+++ b/src/main/java/com/adobe/epubcheck/xml/handlers/PreprocessingDefaultHandler.java
@@ -93,6 +93,11 @@ public final class PreprocessingDefaultHandler extends WrappingDefaultHandler
             }
             attributes.removeAttribute(i);
           }
+          // Filter its-* attributes
+          else if (HTMLUtils.isITSAttribute(namespace, name))
+          {
+            attributes.removeAttribute(i);
+          }
           // Remove custom namespace attributes in XHTML
           else if ("application/xhtml+xml".equals(context.mimeType)
               && HTMLUtils.isCustomNamespace(namespace))

--- a/src/test/resources/epub3/06-content-document/content-document-xhtml.feature
+++ b/src/test/resources/epub3/06-content-document/content-document-xhtml.feature
@@ -814,6 +814,13 @@ Feature: EPUB 3 — Content Documents — XHTML
     Then warning HTM-007 is reported 2 times
     And no other errors or warnings are reported
 
+  #### 6.1.3.X Internationalization tag set (ITS)
+
+  @spec @xref:sec-xhtml-its
+  Scenario: Verify ITS attributes are allowed
+    When checking document 'attrs-its-valid.xhtml'
+    Then no errors or warnings are reported
+
   ###  6.1.4 HTML deviations and constraints
 
   #### 6.1.4.1 Embedded MathML

--- a/src/test/resources/epub3/06-content-document/files/attrs-its-valid.xhtml
+++ b/src/test/resources/epub3/06-content-document/files/attrs-its-valid.xhtml
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Test</title>
+	</head>
+	<body custom:attribute="allowed" xmlns:custom="http://example.org">
+		<h1>Test</h1>
+		<p its-locale-filter-list="*-EN">This is a <span its-term="yes">content document</span></p>
+	</body>
+</html>


### PR DESCRIPTION
This change proactively allows ITS attributes in XHMTL content document, which is a new HTML extension planned in EPUB 3.4. See w3c/epub-specs#2732

The implementation naïvely removes the attributes when pre-processing the content sent to the validators. It does not check that the attributes are defined and conform to the requirements in ITS 2.0.

This is a first step in resolving #1616, to prevent EPUBCheck from totally rejecting ITS attributes.