### PR TITLE
chore(deps): bump commons-compress from v1.21 to v1.28.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.21</version>
+            <version>1.28.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.tukaani</groupId>

--- a/src/main/java/com/adobe/epubcheck/util/Archive.java
+++ b/src/main/java/com/adobe/epubcheck/util/Archive.java
@@ -2,6 +2,8 @@ package com.adobe.epubcheck.util;
 
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream.UnicodeExtraFieldPolicy;
+import org.apache.commons.compress.archivers.zip.ZipExtraField;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -92,6 +94,7 @@ public class Archive
 
       out = new ZipArchiveOutputStream(epubFile);
       out.setEncoding("UTF-8");
+      out.setCreateUnicodeExtraFields(UnicodeExtraFieldPolicy.NEVER);
 
       for (int i = 0; i < paths.size(); i++)
       {
@@ -101,6 +104,7 @@ public class Archive
           entry.setMethod(ZipArchiveEntry.STORED);
           entry.setSize(getSize(paths.get(i)));
           entry.setCrc(getCRC(paths.get(i)));
+          entry.setExtraFields(new ZipExtraField[] {});
         }
         else
         {
@@ -210,7 +214,7 @@ public class Archive
         cis.close();
       }
     }
-    return cis.getChecksum().getValue();
+    return (cis!=null)?cis.getChecksum().getValue():0L;
   }
 
   // public void createArchiveOld() {


### PR DESCRIPTION
We now explicit set empty extra fields on the `mimetype` ZIP entry when creating a ZIP from an expanded directory.

Close #1557